### PR TITLE
Use strongly-typed .NET classes to generate the protocol classes

### DIFF
--- a/source/ChromeDevTools/Protocol/Accessibility/AXWidgetAttributes.cs
+++ b/source/ChromeDevTools/Protocol/Accessibility/AXWidgetAttributes.cs
@@ -2,7 +2,7 @@ using MasterDevs.ChromeDevTools;
 
 namespace MasterDevs.ChromeDevTools.Protocol.Accessibility{
 	/// <summary>
-	/// 
+	/// Attributes which apply to widgets.
 	/// </summary>
 	public enum AXWidgetAttributes
 	{

--- a/source/ProtocolGenerator/Command.cs
+++ b/source/ProtocolGenerator/Command.cs
@@ -4,6 +4,13 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
 {
     class Command : ProtocolItem
     {
+        public Command()
+        {
+            this.Returns = new Collection<Property>();
+            this.Handlers = new Collection<string>();
+            this.Parameters = new Collection<Property>();
+        }
+
         public Collection<Property> Returns
         {
             get;

--- a/source/ProtocolGenerator/Command.cs
+++ b/source/ProtocolGenerator/Command.cs
@@ -1,0 +1,43 @@
+﻿using System.Collections.ObjectModel;
+
+namespace MasterDevs.ChromeDevTools.ProtocolGenerator
+{
+    class Command : ProtocolItem
+    {
+        public Collection<Property> Returns
+        {
+            get;
+            set;
+        }
+
+        public Property Error
+        {
+            get;
+            set;
+        }
+
+        public Collection<string> Handlers
+        {
+            get;
+            set;
+        }
+
+        public Collection<Property> Parameters
+        {
+            get;
+            set;
+        }
+
+        public bool async
+        {
+            get;
+            set;
+        }
+
+        public string Redirect
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/source/ProtocolGenerator/Domain.cs
+++ b/source/ProtocolGenerator/Domain.cs
@@ -1,0 +1,45 @@
+﻿using Newtonsoft.Json;
+using System.Collections.ObjectModel;
+
+namespace MasterDevs.ChromeDevTools.ProtocolGenerator
+{
+    class Domain : ProtocolItem
+    {
+        [JsonProperty(PropertyName = "domain")]
+        public override string Name
+        {
+            get;
+            set;
+        }
+
+        public Collection<Type> Types
+        {
+            get;
+            set;
+        }
+
+        public Collection<Command> Commands
+        {
+            get;
+            set;
+        }
+
+        public Collection<Event> Events
+        {
+            get;
+            set;
+        }
+
+        public string Availability
+        {
+            get;
+            set;
+        }
+
+        public string FeatureGuard
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/source/ProtocolGenerator/Domain.cs
+++ b/source/ProtocolGenerator/Domain.cs
@@ -5,6 +5,13 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
 {
     class Domain : ProtocolItem
     {
+        public Domain()
+        {
+            this.Types = new Collection<Type>();
+            this.Events = new Collection<Event>();
+            this.Commands = new Collection<Command>();
+        }
+
         [JsonProperty(PropertyName = "domain")]
         public override string Name
         {

--- a/source/ProtocolGenerator/Event.cs
+++ b/source/ProtocolGenerator/Event.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.ObjectModel;
+
+namespace MasterDevs.ChromeDevTools.ProtocolGenerator
+{
+    class Event : ProtocolItem
+    {
+        public Collection<Property> Parameters
+        {
+            get;
+            set;
+        }
+
+        public Collection<string> Handlers
+        {
+            get;
+            set;
+        }
+
+        public bool Deprecated
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/source/ProtocolGenerator/Event.cs
+++ b/source/ProtocolGenerator/Event.cs
@@ -4,6 +4,12 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
 {
     class Event : ProtocolItem
     {
+        public Event()
+        {
+            this.Parameters = new Collection<Property>();
+            this.Handlers = new Collection<string>();
+        }
+
         public Collection<Property> Parameters
         {
             get;

--- a/source/ProtocolGenerator/Inspector-0.1.json
+++ b/source/ProtocolGenerator/Inspector-0.1.json
@@ -1,0 +1,2024 @@
+{
+    "compatible": [],
+    "domains" : [{
+        "domain": "Inspector",
+        "hidden": true,
+        "types": [],
+        "commands": [
+        ],
+        "events": [
+            {
+                "name": "frontendReused"
+            },
+            {
+                "name": "bringToFront"
+            },
+            {
+                "name": "disconnectFromBackend"
+            },
+            {
+                "name": "reset"
+            },
+            {
+                "name": "showPanel",
+                "parameters": [
+                    { "name": "panel", "type": "string" }
+                ]
+            },
+            {
+                "name": "startUserInitiatedDebugging"
+            },
+            {
+                "name": "evaluateForTestInFrontend",
+                "parameters": [
+                    { "name": "testCallId", "type": "integer" },
+                    { "name": "script", "type": "string" }
+                ]
+            },
+            {
+                "name": "inspect",
+                "parameters": [
+                    { "name": "object", "$ref": "Runtime.RemoteObject" },
+                    { "name": "hints", "type": "object" }
+                ]
+            },
+            {
+                "name": "didCreateWorker",
+                "parameters": [
+                    { "name": "id", "type": "integer" },
+                    { "name": "url", "type": "string" },
+                    { "name": "isShared", "type": "boolean" }
+                ]
+            },
+            {
+                "name": "didDestroyWorker",
+                "parameters": [
+                    { "name": "id", "type": "integer" }
+                ]
+            }
+        ]
+    },
+    {
+        "domain": "Page",
+        "description": "Actions and events related to the inspected page belong to the page domain.",
+        "types": [
+            {
+                "id": "ResourceType",
+                "type": "string",
+                "enum": ["Document", "Stylesheet", "Image", "Font", "Script", "XHR", "WebSocket", "Other"],
+                "description": "Resource type as it was perceived by the rendering engine."
+            },
+            {
+                "id": "Frame",
+                "type": "object",
+                "description": "Information about the Frame on the page.",
+                "properties": [
+                    { "name": "id", "type": "string", "description": "Frame unique identifier." },
+                    { "name": "parentId", "type": "string", "optional": true, "description": "Parent frame identifier." },
+                    { "name": "loaderId", "$ref": "Network.LoaderId", "description": "Identifier of the loader associated with this frame." },
+                    { "name": "name", "type": "string", "optional": true, "description": "Frame's name as specified in the tag." },
+                    { "name": "url", "type": "string", "description": "Frame document's URL." },
+                    { "name": "mimeType", "type": "string", "description": "Frame document's mimeType as determined by the browser." }
+                ],
+                "hidden": true
+            },
+            {
+                "id": "FrameResourceTree",
+                "type": "object",
+                "description": "Information about the Frame hierarchy along with their cached resources.",
+                "properties": [
+                    { "name": "frame", "$ref": "Frame", "description": "Frame information for this tree item." },
+                    { "name": "childFrames", "type": "array", "optional": true, "items": { "$ref": "FrameResourceTree" }, "description": "Child frames." },
+                    { "name": "resources", "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": [
+                                { "name": "url", "type": "string", "description": "Resource URL." },
+                                { "name": "type", "$ref": "ResourceType", "description": "Type of this resource." },
+                                { "name": "mimeType", "type": "string", "description": "Resource mimeType as determined by the browser." }
+                            ]
+                        },
+                        "description": "Information about frame resources."
+                    }
+                ],
+                "hidden": true
+            },
+            {
+                "id": "SearchResult",
+                "type": "object",
+                "description": "Search result for resource.",
+                "properties": [
+	                { "name": "url", "type": "string", "description": "Resource URL." },
+                    { "name": "frameId", "type": "string", "description": "Resource frame id." },
+                    { "name": "matchesCount", "type": "number", "description": "Number of matches in the resource content." }
+                ],
+                "hidden": true
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables page domain notifications."
+            },
+            {
+                "name": "disable",
+                "description": "Disables page domain notifications."
+            },
+            {
+                "name": "addScriptToEvaluateOnLoad",
+                "parameters": [
+                    { "name": "scriptSource", "type": "string" }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "removeAllScriptsToEvaluateOnLoad",
+                "hidden": true
+            },
+            {
+                "name": "reload",
+                "parameters": [
+                    { "name": "ignoreCache", "type": "boolean", "optional": true, "description": "If true, browser cache is ignored (as if the user pressed Shift+refresh)." }
+                ],
+                "description": "Reloads given page optionally ignoring the cache."
+            },
+            {
+                "name": "open",
+                "parameters": [
+                    { "name": "url", "type": "string", "description": "URL to open." },
+                    { "name": "newWindow", "optional": true, "type": "boolean", "description": "If true, opens given URL in a new window or tab." }
+                ],
+                "description": "Opens given URL either in the inspected page or in a new tab / window.",
+                "hidden": true
+            },
+            {
+                "name": "getCookies",
+                "returns": [
+                    { "name": "cookies", "type": "array", "items": { "$ref": "Cookie"}, "description": "Array of cookie objects." },
+                    { "name": "cookiesString", "type": "string", "description": "document.cookie string representation of the cookies." }
+                ],
+                "description": "Returns all browser cookies. Depending on the backend support, will either return detailed cookie information in the <code>cookie</code> field or string cookie representation using <code>cookieString</code>.",
+                "hidden": true
+            },
+            {
+                "name": "deleteCookie",
+                "parameters": [
+                    { "name": "cookieName", "type": "string", "description": "Name of the cookie to remove." },
+                    { "name": "domain", "type": "string", "description": "Domain of the cookie to remove." }
+                ],
+                "description": "Deletes browser cookie with given name for the given domain.",
+                "hidden": true
+            },
+            {
+                "name": "getResourceTree",
+                "description": "Returns present frame / resource tree structure.",
+                "returns": [
+                    { "name": "frameTree", "$ref": "FrameResourceTree", "description": "Present frame / resource tree structure." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "getResourceContent",
+                "description": "Returns content of the given resource.",
+                "parameters": [
+                    { "name": "frameId", "type": "string", "description": "Frame id to get resource for." },
+                    { "name": "url", "type": "string", "description": "URL of the resource to get content for." }
+                ],
+                "returns": [
+                    { "name": "content", "type": "string", "description": "Resource content." },
+                    { "name": "base64Encoded", "type": "boolean", "description": "True, if content was served as base64." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "searchInResources",
+                "description": "Searches for given string in frame / resource tree structure.",
+                "parameters": [
+                    { "name": "text", "type": "string", "description": "String to search for."  },
+                    { "name": "caseSensitive", "type": "boolean", "optional": true, "description": "If true, search is case sensitive." },
+                    { "name": "isRegex", "type": "boolean", "optional": true, "description": "If true, treats string parameter as regex." }
+                ],
+                "returns": [
+                    { "name": "result", "type": "array", "items": { "$ref": "SearchResult" }, "description": "List of search results." }
+                ],
+                "hidden": true
+            }
+        ],
+        "events": [
+            {
+                "name": "domContentEventFired",
+                "parameters": [
+                    { "name": "timestamp", "type": "number" }
+                ]
+            },
+            {
+                "name": "loadEventFired",
+                "parameters": [
+                    { "name": "timestamp", "type": "number" }
+                ]
+            },
+            {
+                "name": "frameNavigated",
+                "description": "Fired once navigation of the frame has completed. Frame is now associated with the new loader.",
+                "parameters": [
+                    { "name": "frame", "$ref": "Frame", "description": "Frame object." },
+                    { "name": "loaderId", "$ref": "Network.LoaderId", "description": "Loader identifier." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "frameDetached",
+                "description": "Fired when frame has been detached from its parent.",
+                "parameters": [
+                    { "name": "frameId", "type": "string", "description": "Id of the frame that has been detached." }
+                ],
+                "hidden": true
+            }
+        ]
+    },
+    {
+        "domain": "Runtime",
+        "description": "Runtime domain exposes JavaScript runtime by means of remote evaluation and mirror objects. Evaluation results are returned as mirror object that expose object type, string representation and unique identifier that can be used for further object reference. Original objects are maintained in memory unless they are either explicitly released or are released along with the other objects in their object group.",
+        "types": [
+            {
+                "id": "RemoteObjectId",
+                "type": "string",
+                "description": "Unique object identifier."
+            },
+            {
+                "id": "RemoteObject",
+                "type": "object",
+                "description": "Mirror object referencing original JavaScript object.",
+                "properties": [
+                    { "name": "type", "type": "string", "enum": ["object", "function", "undefined", "string", "number", "boolean"], "description": "Object type." },
+                    { "name": "subtype", "type": "string", "optional": true, "enum": ["array", "null", "node", "regexp", "date"], "description": "Object subtype hint. Specified for <code>object</code> type values only." },
+                    { "name": "className", "type": "string", "optional": true, "description": "Object class (constructor) name. Specified for <code>object</code> type values only." },
+                    { "name": "value", "type": "any", "optional": true, "description": "Remote object value (in case of primitive values or JSON values if it was requested)." },
+                    { "name": "description", "type": "string", "optional": true, "description": "String representation of the object." },
+                    { "name": "objectId", "$ref": "RemoteObjectId", "optional": true, "description": "Unique object identifier (for non-primitive values)." }
+                ]
+            },
+            {
+                "id": "PropertyDescriptor",
+                "type": "object",
+                "description": "Object property descriptor.",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "Property name." },
+                    { "name": "value", "$ref": "RemoteObject", "optional": true, "description": "The value associated with the property." },
+                    { "name": "writable", "type": "boolean", "optional": true, "description": "True if the value associated with the property may be changed (data descriptors only)." },
+                    { "name": "get", "$ref": "RemoteObject", "optional": true, "description": "A function which serves as a getter for the property, or <code>undefined</code> if there is no getter (accessor descriptors only)." },
+                    { "name": "set", "$ref": "RemoteObject", "optional": true, "description": "A function which serves as a setter for the property, or <code>undefined</code> if there is no setter (accessor descriptors only)." },
+                    { "name": "configurable", "type": "boolean", "description": "True if the type of this property descriptor may be changed and if the property may be deleted from the corresponding object." },
+                    { "name": "enumerable", "type": "boolean", "description": "True if this property shows up during enumeration of the properties on the corresponding object." },
+                    { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." }
+                ]
+            },
+            {
+                "id": "CallArgument",
+                "type": "object",
+                "description": "Represents function call argument. Either remote object id <code>objectId</code> or primitive <code>value</code> or neither of (for undefined) them should be specified.",
+                "properties": [
+                    { "name": "value", "type": "any", "optional": true, "description": "Primitive value." },
+                    { "name": "objectId", "$ref": "RemoteObjectId", "optional": true, "description": "Remote object handle." }
+                ]
+            }
+        ],
+        "commands": [
+            {
+                "name": "evaluate",
+                "parameters": [
+                    { "name": "expression", "type": "string", "description": "Expression to evaluate." },
+                    { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." },
+                    { "name": "includeCommandLineAPI", "type": "boolean", "optional": true, "description": "Determines whether Command Line API should be available during the evaluation.", "hidden": true },
+                    { "name": "doNotPauseOnExceptions", "type": "boolean", "optional": true, "description": "Specifies whether evaluation should stop on exceptions. Overrides setPauseOnException state.", "hidden": true },
+                    { "name": "frameId", "type": "string", "optional": true, "description": "Specifies in which frame to perform evaluation.", "hidden": true },
+                    { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object that should be sent by value." }
+                ],
+                "returns": [
+                    { "name": "result", "$ref": "RemoteObject", "description": "Evaluation result." },
+                    { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." }
+                ],
+                "description": "Evaluates expression on global object."
+            },
+            {
+                "name": "callFunctionOn",
+                "parameters": [
+                    { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to call function on." },
+                    { "name": "functionDeclaration", "type": "string", "description": "Declaration of the function to call." },
+                    { "name": "arguments", "type": "array", "items": { "$ref": "CallArgument", "description": "Call argument." }, "optional": true, "description": "Call arguments. All call arguments must belong to the same JavaScript world as the target object." },
+                    { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object which should be sent by value." }
+                ],
+                "returns": [
+                    { "name": "result", "$ref": "RemoteObject", "description": "Call result." },
+                    { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." }
+                ],
+                "description": "Calls function with given declaration on the given object. Object group of the result is inherited from the target object."
+            },
+            {
+                "name": "getProperties",
+                "parameters": [
+                    { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to return properties for." },
+                    { "name": "ownProperties", "optional": true, "type": "boolean", "description": "If true, returns properties belonging only to the element itself, not to its prototype chain." }
+                ],
+                "returns": [
+                    { "name": "result", "type": "array", "items": { "$ref": "PropertyDescriptor"}, "description": "Object properties." }
+                ],
+                "description": "Returns properties of a given object. Object group of the result is inherited from the target object."
+            },
+            {
+                "name": "releaseObject",
+                "parameters": [
+                    { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to release." }
+                ],
+                "description": "Releases remote object with given id."
+            },
+            {
+                "name": "releaseObjectGroup",
+                "parameters": [
+                    { "name": "objectGroup", "type": "string", "description": "Symbolic object group name." }
+                ],
+                "description": "Releases all remote objects that belong to a given group."
+            }
+        ]
+    },
+    {
+        "domain": "Console",
+        "description": "Console domain defines methods and events for interaction with the JavaScript console. Console collects messages created by means of the <a href='http://getfirebug.com/wiki/index.php/Console_API'>JavaScript Console API</a>. One needs to enable this domain using <code>enable</code> command in order to start receiving the console messages. Browser collects messages issued while console domain is not enabled as well and reports them using <code>messageAdded</code> notification upon enabling.",
+        "types": [
+            {
+                "id": "ConsoleMessage",
+                "type": "object",
+                "description": "Console message.",
+                "properties": [
+                    { "name": "source", "type": "string", "enum": ["html", "wml", "xml", "javascript", "network", "console-api", "other"], "description": "Message source." },
+                    { "name": "level", "type": "string", "enum": ["tip", "log", "warning", "error", "debug"], "description": "Message severity." },
+                    { "name": "text", "type": "string", "description": "Message text." },
+                    { "name": "type", "type": "string", "optional": true, "enum": ["log", "dir", "dirxml", "trace", "startGroup", "startGroupCollapsed", "endGroup", "assert"], "description": "Console message type." },
+                    { "name": "url", "type": "string", "optional": true, "description": "URL of the message origin." },
+                    { "name": "line", "type": "integer", "optional": true, "description": "Line number in the resource that generated this message." },
+                    { "name": "repeatCount", "type": "integer", "optional": true, "description": "Repeat count for repeated messages." },
+                    { "name": "networkRequestId", "$ref": "Network.RequestId", "optional": true, "description": "Identifier of the network request associated with this message." },
+                    { "name": "parameters", "type": "array", "items": { "$ref": "Runtime.RemoteObject" }, "optional": true, "description": "Message parameters in case of the formatted message." },
+                    { "name": "stackTrace", "$ref": "StackTrace", "optional": true, "description": "JavaScript stack trace for assertions and error messages." }
+                ]
+            },
+            {
+                "id": "CallFrame",
+                "type": "object",
+                "description": "Stack entry for console errors and assertions.",
+                "properties": [
+                    { "name": "functionName", "type": "string", "description": "JavaScript function name." },
+                    { "name": "url", "type": "string", "description": "JavaScript script name or url." },
+                    { "name": "lineNumber", "type": "integer", "description": "JavaScript script line number." },
+                    { "name": "columnNumber", "type": "integer", "description": "JavaScript script column number." }
+                ]
+            },
+            {
+                "id": "StackTrace",
+                "type": "array",
+                "items": { "$ref": "CallFrame" },
+                "description": "Call frames for assertions or error messages."
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "returns": [
+                    { "name": "expiredMessagesCount", "type": "integer",  "optional": true, "description": "Number of messages dropped due to message threashold overflow." }
+                ],
+                "description": "Enables console domain, sends the messages collected so far to the client by means of the <code>messageAdded</code> notification." 
+            },
+            {
+                "name": "disable",
+                "description": "Disables console domain, prevents further console messages from being reported to the client." 
+            },
+            {
+                "name": "clearMessages",
+                "description": "Clears console messages collected in the browser." 
+            },
+            {
+                "name": "setMonitoringXHREnabled",
+                "parameters": [
+                    { "name": "enabled", "type": "boolean", "description": "Monitoring enabled state." }
+                ],
+                "description": "Toggles monitoring of XMLHttpRequest. If <code>true</code>, console will receive messages upon each XHR issued.", 
+                "hidden": true
+            },
+            {
+                "name": "addInspectedNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId", "description": "DOM node id to be accessible by means of $x command line API." }
+                ],
+                "description": "Enables console to refer to the node with given id via $x (see Command Line API for more details $x functions).",
+                "hidden": true
+            }
+        ],
+        "events": [
+            {
+                "name": "messageAdded",
+                "parameters": [
+                    { "name": "message", "$ref": "ConsoleMessage", "description": "Console message that has been added." }
+                ],
+                "description": "Issued when new console message is added."
+            },
+            {
+                "name": "messageRepeatCountUpdated",
+                "parameters": [
+                    { "name": "count", "type": "integer", "description": "New repeat count value." }
+                ],
+                "description": "Issued when subsequent message(s) are equal to the previous one(s)."
+            },
+            {
+                "name": "messagesCleared",
+                "description": "Issued when console is cleared. This happens either upon <code>clearMessages</code> command or after page navigation."
+            }
+        ]
+    },
+    {
+        "domain": "Network",
+        "description": "Network domain allows tracking network activities of the page. It exposes information about http, file, data and other requests and responses, their headers, bodies, timing, etc.",
+        "types": [
+            {
+                "id": "LoaderId",
+                "type": "string",
+                "description": "Unique loader identifier."
+            },
+            {
+                "id": "RequestId",
+                "type": "string",
+                "description": "Unique request identifier."
+            },
+            {
+                "id": "Timestamp",
+                "type": "number",
+                "description": "Number of seconds since epoch."
+            },
+            {
+                "id": "Headers",
+                "type": "object",
+                "description": "Request / response headers as keys / values of JSON object."
+            },
+            {
+                "id": "ResourceTiming",
+                "type": "object",
+                "description": "Timing information for the request.",
+                "properties": [
+                    { "name": "requestTime", "type": "number", "description": "Timing's requestTime is a baseline in seconds, while the other numbers are ticks in milliseconds relatively to this requestTime." },
+                    { "name": "proxyStart", "type": "number", "description": "Started resolving proxy." },
+                    { "name": "proxyEnd", "type": "number", "description": "Finished resolving proxy." },
+                    { "name": "dnsStart", "type": "number", "description": "Started DNS address resolve." },
+                    { "name": "dnsEnd", "type": "number", "description": "Finished DNS address resolve." },
+                    { "name": "connectStart", "type": "number", "description": "Started connecting to the remote host." },
+                    { "name": "connectEnd", "type": "number", "description": "Connected to the remote host." },
+                    { "name": "sslStart", "type": "number", "description": "Started SSL handshake." },
+                    { "name": "sslEnd", "type": "number", "description": "Finished SSL handshake." },
+                    { "name": "sendStart", "type": "number", "description": "Started sending request." },
+                    { "name": "sendEnd", "type": "number", "description": "Finished sending request." },
+                    { "name": "receiveHeadersEnd", "type": "number", "description": "Finished receiving response headers." }
+                ]
+            },
+            {
+                "id": "Request",
+                "type": "object",
+                "description": "HTTP request data.",
+                "properties": [
+                    { "name": "url", "type": "string", "description": "Request URL." },
+                    { "name": "method", "type": "string", "description": "HTTP request method." },
+                    { "name": "headers", "$ref": "Headers", "description": "HTTP request headers." },
+                    { "name": "postData", "type": "string", "optional": true, "description": "HTTP POST request data." }
+                ]
+            },
+            {
+                "id": "Response",
+                "type": "object",
+                "description": "HTTP response data.",
+                "properties": [
+                    { "name": "url", "type": "string", "description": "Response URL." },
+                    { "name": "status", "type": "number", "description": "HTTP response status code." },
+                    { "name": "statusText", "type": "string", "description": "HTTP response status text." },
+                    { "name": "headers", "$ref": "Headers", "description": "HTTP response headers." },
+                    { "name": "headersText", "type": "string", "optional": true, "description": "HTTP response headers text." },
+                    { "name": "mimeType", "type": "string", "description": "Resource mimeType as determined by the browser." },
+                    { "name": "requestHeaders", "$ref": "Headers", "optional": true, "description": "Refined HTTP request headers that were actually transmitted over the network." },
+                    { "name": "requestHeadersText", "type": "string", "optional": true, "description": "HTTP request headers text." },
+                    { "name": "connectionReused", "type": "boolean", "description": "Specifies whether physical connection was actually reused for this request." },
+                    { "name": "connectionId", "type": "number", "description": "Physical connection id that was actually used for this request." },
+                    { "name": "fromDiskCache", "type": "boolean", "optional": true, "description": "Specifies that the request was served from the disk cache." },
+                    { "name": "timing", "$ref": "ResourceTiming", "optional": true, "description": "Timing information for the given request." }
+                ]
+            },
+            {
+                "id": "CachedResource",
+                "type": "object",
+                "description": "Information about the cached resource.",
+                "properties": [
+                    { "name": "url", "type": "string", "description": "Resource URL." },
+                    { "name": "type", "$ref": "Page.ResourceType", "description": "Type of this resource." },
+                    { "name": "response", "$ref": "Response", "optional": true, "description": "Cached response data." },
+                    { "name": "bodySize", "type": "number", "description": "Cached response body size." }
+                ]
+            },
+            {
+                "id": "Initiator",
+                "type": "object",
+                "description": "Information about the request initiator.",
+                "properties": [
+                    { "name": "type", "type": "string", "enum": ["parser", "script", "other"], "description": "Type of this initiator." },
+                    { "name": "stackTrace", "$ref": "Console.StackTrace", "optional": true, "description": "Initiator JavaScript stack trace, set for Script only." },
+                    { "name": "url", "type": "string", "optional": true, "description": "Initiator URL, set for Parser type only." },
+                    { "name": "lineNumber", "type": "number", "optional": true, "description": "Initiator line number, set for Parser type only." }
+                ]
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables network tracking, network events will now be delivered to the client."
+            },
+            {
+                "name": "disable",
+                "description": "Disables network tracking, prevents network events from being sent to the client."
+            },
+            {
+                "name": "setUserAgentOverride",
+                "description": "Allows overriding user agent with the given string.",
+                "parameters": [
+                    { "name": "userAgent", "type": "string", "description": "User agent to use." }
+                ]
+            },
+            {
+                "name": "setExtraHTTPHeaders",
+                "description": "Specifies whether to always send extra HTTP headers with the requests from this page.",
+                "parameters": [
+                    { "name": "headers", "$ref": "Headers", "description": "Map with extra HTTP headers." }
+                ]
+            },
+            {
+                "name": "getResponseBody",
+                "description": "Returns content served for the given request.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Identifier of the network request to get content for." }
+                ],
+                "returns": [
+                    { "name": "body", "type": "string", "description": "Response body." },
+                    { "name": "base64Encoded", "type": "boolean", "description": "True, if content was sent as base64." }
+                ]
+            },
+            {
+                "name": "clearBrowserCache",
+                "description": "Clears browser cache."
+            },
+            {
+                "name": "clearBrowserCookies",
+                "description": "Clears browser cookies."
+            },
+            {
+                "name": "setCacheDisabled",
+                "parameters": [
+                    { "name": "cacheDisabled", "type": "boolean", "description": "Cache disabled state." }
+                ],
+                "description": "Toggles ignoring cache for each request. If <code>true</code>, cache will not be used." 
+            }
+        ],
+        "events": [
+            {
+                "name": "requestWillBeSent",
+                "description": "Fired when page is about to send HTTP request.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "frameId", "type": "string", "description": "Frame identifier.", "hidden": true },
+                    { "name": "loaderId", "$ref": "LoaderId", "description": "Loader identifier." },
+                    { "name": "documentURL", "type": "string", "description": "URL of the document this request is loaded for." },
+                    { "name": "request", "$ref": "Request", "description": "Request data." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "initiator", "$ref": "Initiator", "description": "Request initiator." },
+                    { "name": "stackTrace", "$ref": "Console.StackTrace", "optional": true, "description": "JavaScript stack trace upon issuing this request." },
+                    { "name": "redirectResponse", "optional": true, "$ref": "Response", "description": "Redirect response data." }
+                ]
+            },
+            {
+                "name": "requestServedFromCache",
+                "description": "Fired if request ended up loading from cache.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." }
+                ]
+            },
+            {
+                "name": "responseReceived",
+                "description": "Fired when HTTP response is available.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "type", "$ref": "Page.ResourceType", "description": "Resource type." },
+                    { "name": "response", "$ref": "Response", "description": "Response data." }
+                ]
+            },
+            {
+                "name": "dataReceived",
+                "description": "Fired when data chunk was received over the network.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "dataLength", "type": "integer", "description": "Data chunk length." },
+                    { "name": "encodedDataLength", "type": "integer", "description": "Actual bytes received (might be less than dataLength for compressed encodings)." }
+                ]
+            },
+            {
+                "name": "loadingFinished",
+                "description": "Fired when HTTP request has finished loading.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." }
+                ]
+            },
+            {
+                "name": "loadingFailed",
+                "description": "Fired when HTTP request has failed to load.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "errorText", "type": "string", "description": "User friendly error message." },
+                    { "name": "canceled", "type": "boolean", "optional": true, "description": "True if loading was canceled." }
+                ]
+            },
+            {
+                "name": "requestServedFromMemoryCache",
+                "description": "Fired when HTTP request has been served from memory cache.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "frameId", "type": "string", "description": "Frame identifier.", "hidden": true },
+                    { "name": "loaderId", "$ref": "LoaderId", "description": "Loader identifier." },
+                    { "name": "documentURL", "type": "string", "description": "URL of the document this request is loaded for." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "initiator", "$ref": "Initiator", "description": "Request initiator." },
+                    { "name": "resource", "$ref": "CachedResource", "description": "Cached resource data." }
+                ]
+            },
+            {
+                "name": "webSocketWillSendHandshakeRequest",
+                "description": "Fired when WebSocket is about to initiate handshake.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "request", "type": "object", "description": "WebSocket request data." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "webSocketHandshakeResponseReceived",
+                "description": "Fired when WebSocket handshake response becomes available.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "response", "type": "object", "description": "WebSocket response data." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "webSocketCreated",
+                "description": "Fired upon WebSocket creation.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "url", "type": "string", "description": "WebSocket request URL." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "webSocketClosed",
+                "description": "Fired when WebSocket is closed.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." }
+                ],
+                "hidden": true
+            }
+        ]
+    },
+    {
+        "domain": "Database",
+        "hidden": true,
+        "types": [
+            {
+                "id": "Database",
+                "type": "object",
+                "description": "Database object."
+            },
+            {
+                "id": "Error",
+                "type": "object",
+                "description": "Database error."
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables database tracking, database events will now be delivered to the client."
+            },
+            {
+                "name": "disable",
+                "description": "Disables database tracking, prevents database events from being sent to the client."
+            },
+            {
+                "name": "getDatabaseTableNames",
+                "parameters": [
+                    { "name": "databaseId", "type": "integer" }
+                ],
+                "returns": [
+                    { "name": "tableNames", "type": "array", "items": { "type": "string" } }
+                ]
+            },
+            {
+                "name": "executeSQL",
+                "parameters": [
+                    { "name": "databaseId", "type": "integer" },
+                    { "name": "query", "type": "string" }
+                ],
+                "returns": [
+                    { "name": "success", "type": "boolean" },
+                    { "name": "transactionId", "type": "integer" }
+                ]
+            }
+        ],
+        "events": [
+            {
+                "name": "addDatabase",
+                "parameters": [
+                    { "name": "database", "$ref": "Database" }
+                ]
+            },
+            {
+                "name": "sqlTransactionSucceeded",
+                "parameters": [
+                    { "name": "transactionId", "type": "integer" },
+                    { "name": "columnNames", "type": "array", "items": { "type": "string" } },
+                    { "name": "values", "type": "array", "items": { "type": "string or number" }}
+                ]
+            },
+            {
+                "name": "sqlTransactionFailed",
+                "parameters": [
+                    { "name": "transactionId", "type": "integer" },
+                    { "name": "sqlError", "$ref": "Error" }
+                ]
+            }
+        ]
+    },
+    {
+        "domain": "DOMStorage",
+        "hidden": true,
+        "types": [],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables storage tracking, storage events will now be delivered to the client."
+            },
+            {
+                "name": "disable",
+                "description": "Disables storage tracking, prevents storage events from being sent to the client."
+            },
+            {
+                "name": "getDOMStorageEntries",
+                "parameters": [
+                    { "name": "storageId", "type": "integer" }
+                ],
+                "returns": [
+                    { "name": "entries", "type": "array", "items": { "$ref": "DOMStorageEntry"} }
+                ]
+            },
+            {
+                "name": "setDOMStorageItem",
+                "parameters": [
+                    { "name": "storageId", "type": "integer" },
+                    { "name": "key", "type": "string" },
+                    { "name": "value", "type": "string" }
+                ],
+                "returns": [
+                    { "name": "success", "type": "boolean" }
+                ]
+            },
+            {
+                "name": "removeDOMStorageItem",
+                "parameters": [
+                    { "name": "storageId", "type": "integer" },
+                    { "name": "key", "type": "string" }
+                ],
+                "returns": [
+                    { "name": "success", "type": "boolean" }
+                ]
+            }
+        ],
+        "events": [
+            {
+                "name": "addDOMStorage",
+                "parameters": [
+                    { "name": "storage", "type": "object" }
+                ]
+            },
+            {
+                "name": "updateDOMStorage",
+                "parameters": [
+                    { "name": "storageId", "type": "integer" }
+                ]
+            }
+        ]
+    },
+    {
+        "domain": "ApplicationCache",
+        "hidden": true,
+        "types": [
+            {
+                "id": "AppCache",
+                "type": "object",
+                "description": "AppCache."
+            }
+        ],
+        "commands": [
+            {
+                "name": "getApplicationCaches",
+                "returns": [
+                    { "name": "applicationCaches", "$ref": "AppCache" }
+                ]
+            }
+        ],
+        "events": [
+            {
+                "name": "updateApplicationCacheStatus",
+                "parameters": [
+                    { "name": "status", "type": "integer" }
+                ]
+            },
+            {
+                "name": "updateNetworkState",
+                "parameters": [
+                    { "name": "isNowOnline", "type": "boolean" }
+                ]
+            }
+        ]
+    },
+    {
+        "domain": "DOM",
+        "description": "This domain exposes DOM read/write operations. Each DOM Node is represented with its mirror object that has an <code>id</code>. This <code>id</code> can be used to get additional information on the Node, resolve it into the JavaScript object wrapper, etc. It is important that client receives DOM events only for the nodes that are known to the client. Backend keeps track of the nodes that were sent to the client and never sends the same node twice. It is client's responsibility to collect information about the nodes that were sent to the client.<p>Note that <code>iframe</code> owner elements will return corresponding document elements as their child nodes.</p>",
+        "types": [
+            {
+                "id": "NodeId",
+                "type": "integer",
+                "description": "Unique DOM node identifier."
+            },
+            {
+                "id": "Node",
+                "type": "object",
+                "properties": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Node identifier that is passed into the rest of the DOM messages as the <code>nodeId</code>. Backend will only push node with given <code>id</code> once. It is aware of all requested nodes and will only fire DOM events for nodes known to the client." },
+                    { "name": "nodeType", "type": "integer", "description": "<code>Node</code>'s nodeType." },
+                    { "name": "nodeName", "type": "string", "description": "<code>Node</code>'s nodeName." },
+                    { "name": "localName", "type": "string", "description": "<code>Node</code>'s localName." },
+                    { "name": "nodeValue", "type": "string", "description": "<code>Node</code>'s nodeValue." },
+                    { "name": "childNodeCount", "type": "integer", "optional": true, "description": "Child count for <code>Container</code> nodes." },
+                    { "name": "children", "type": "array", "optional": true, "items": { "$ref": "Node" }, "description": "Child nodes of this node when requested with children." },
+                    { "name": "attributes", "type": "array", "optional": true, "items": { "type": "string" }, "description": "Attributes of the <code>Element</code> node in the form of flat array <code>[name1, value1, name2, value2]</code>." },
+                    { "name": "documentURL", "type": "string", "optional": true, "description": "Document URL that <code>Document</code> or <code>FrameOwner</code> node points to." },
+                    { "name": "publicId", "type": "string", "optional": true, "description": "<code>DocumentType</code>'s publicId." },
+                    { "name": "systemId", "type": "string", "optional": true, "description": "<code>DocumentType</code>'s systemId." },
+                    { "name": "internalSubset", "type": "string", "optional": true, "description": "<code>DocumentType</code>'s internalSubset." },
+                    { "name": "name", "type": "string", "optional": true, "description": "<code>Attr</code>'s name." },
+                    { "name": "value", "type": "string", "optional": true, "description": "<code>Attr</code>'s value." }
+                ],
+                "description": "DOM interaction is implemented in terms of mirror objects that represent the actual DOM nodes. DOMNode is a base node mirror type."
+            },
+            {
+                "id": "EventListener",
+                "type": "object",
+                "hidden": true,
+                "properties": [
+                    { "name": "type", "type": "string", "description": "<code>EventListener</code>'s type." },
+                    { "name": "useCapture", "type": "boolean", "description": "<code>EventListener</code>'s useCapture." },
+                    { "name": "isAttribute", "type": "boolean", "description": "<code>EventListener</code>'s isAttribute." },
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Target <code>DOMNode</code> id." },
+                    { "name": "handlerBody", "type": "string", "description": "Event handler function body." },
+                    { "name": "location", "$ref": "Debugger.Location", "optional": true, "description": "Handler code location." }
+                ],
+                "description": "DOM interaction is implemented in terms of mirror objects that represent the actual DOM nodes. DOMNode is a base node mirror type."
+            },
+            {
+                "id": "RGBA",
+                "type": "object",
+                "properties": [
+                    { "name": "r", "type": "integer", "description": "The red component, in the [0-255] range." },
+                    { "name": "g", "type": "integer", "description": "The green component, in the [0-255] range." },
+                    { "name": "b", "type": "integer", "description": "The blue component, in the [0-255] range." },
+                    { "name": "a", "type": "number", "optional": true, "description": "The alpha component, in the [0-1] range (default: 1)." }
+                ],
+                "description": "A structure holding an RGBA color."
+            },
+            {
+                "id": "HighlightConfig",
+                "type": "object",
+                "properties": [
+                    { "name": "showInfo", "type": "boolean", "optional": true, "description": "Whether the node info tooltip should be shown (default: false)." },
+                    { "name": "contentColor", "$ref": "RGBA", "optional": true, "description": "The content box highlight fill color (default: transparent)." },
+                    { "name": "paddingColor", "$ref": "RGBA", "optional": true, "description": "The padding highlight fill color (default: transparent)." },
+                    { "name": "borderColor", "$ref": "RGBA", "optional": true, "description": "The border highlight fill color (default: transparent)." },
+                    { "name": "marginColor", "$ref": "RGBA", "optional": true, "description": "The margin highlight fill color (default: transparent)." }
+                ],
+                "description": "Configuration data for the highlighting of page elements."
+            }
+        ],
+        "commands": [
+            {
+                "name": "getDocument",
+                "returns": [
+                    { "name": "root", "$ref": "Node", "description": "Resulting node." }
+                ],
+                "description": "Returns the root DOM node to the caller."
+            },
+            {
+                "name": "requestChildNodes",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to get children for." }
+                ],
+                "description": "Requests that children of the node with given id are returned to the caller in form of <code>setChildNodes</code> events."
+            },
+            {
+                "name": "querySelector",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to query upon." },
+                    { "name": "selector", "type": "string", "description": "Selector string." }
+                ],
+                "returns": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Query selector result." }
+                ],
+                "description": "Executes <code>querySelector</code> on a given node."
+            },
+            {
+                "name": "querySelectorAll",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to query upon." },
+                    { "name": "selector", "type": "string", "description": "Selector string." }
+                ],
+                "returns": [
+                    { "name": "nodeIds", "type": "array", "items": { "$ref": "NodeId" }, "description": "Query selector result." }
+                ],
+                "description": "Executes <code>querySelectorAll</code> on a given node."
+            },
+            {
+                "name": "setNodeName",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to set name for." },
+                    { "name": "name", "type": "string", "description": "New node's name." }
+                ],
+                "returns": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "New node's id." }
+                ],
+                "description": "Sets node name for a node with given id."
+            },
+            {
+                "name": "setNodeValue",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to set value for." },
+                    { "name": "value", "type": "string", "description": "New node's value." }
+                ],
+                "description": "Sets node value for a node with given id."
+            },
+            {
+                "name": "removeNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to remove." }
+                ],
+                "description": "Removes node with given id."
+            },
+            {
+                "name": "setAttributeValue",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the element to set attribute for." },
+                    { "name": "name", "type": "string", "description": "Attribute name." },
+                    { "name": "value", "type": "string", "description": "Attribute value." }
+                ],
+                "description": "Sets attribute for an element with given id."
+            },
+            {
+                "name": "setAttributesAsText",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the element to set attributes for." },
+                    { "name": "text", "type": "string", "description": "Text with a number of attributes. Will parse this text using HTML parser." },
+                    { "name": "name", "type": "string", "optional": true, "description": "Attribute name to replace with new attributes derived from text in case text parsed successfully." }
+                ],
+                "description": "Sets attributes on element with given id. This method is useful when user edits some existing attribute value and types in several attribute name/value pairs."
+            },
+            {
+                "name": "removeAttribute",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the element to remove attribute from." },
+                    { "name": "name", "type": "string", "description": "Name of the attribute to remove." }
+                ],
+                "description": "Removes attribute with given name from an element with given id."
+            },
+            {
+                "name": "getEventListenersForNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to get listeners for." }
+                ],
+                "returns": [
+                    { "name": "listeners", "type": "array", "items": { "$ref": "EventListener"}, "description": "Array of relevant listeners." }
+                ],
+                "description": "Returns event listeners relevant to the node.",
+                "hidden": true
+            },
+            {
+                "name": "copyNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to copy." }
+                ],
+                "description": "Copies node's HTML markup into the clipboard.",
+                "hidden": true
+            },
+            {
+                "name": "getOuterHTML",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to get markup for." }
+                ],
+                "returns": [
+                    { "name": "outerHTML", "type": "string", "description": "Outer HTML markup." }
+                ],
+                "description": "Returns node's HTML markup."
+            },
+            {
+                "name": "setOuterHTML",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to set markup for." },
+                    { "name": "outerHTML", "type": "string", "description": "Outer HTML markup to set." }
+                ],
+                "description": "Sets node HTML markup, returns new node id."
+            },
+            {
+                "name": "performSearch",
+                "parameters": [
+                    { "name": "query", "type": "string", "description": "Plain text or query selector or XPath search query." },
+                    { "name": "runSynchronously", "type": "boolean", "optional": true, "description": "When set to true, performing search synchronously (can block user interaction)." }
+                ],
+                "description": "Starts asynchronous search for a given string in the DOM tree. Use <code>cancelSearch</code> to stop given asynchronous search task.",
+                "hidden": true
+            },
+            {
+                "name": "cancelSearch",
+                "description": "Cancels asynchronous search started with <code>performSearch</code>.",
+                "hidden": true
+            },
+            {
+                "name": "requestNode",
+                "parameters": [
+                    { "name": "objectId", "$ref": "Runtime.RemoteObjectId", "description": "JavaScript object id to convert into node." }
+                ],
+                "returns": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Node id for given object." }
+                ],
+                "description": "Requests that the node is sent to the caller given the JavaScript node object reference. All nodes that form the path from the node to the root are also sent to the client as a series of <code>setChildNodes</code> notifications."
+            },
+            {
+                "name": "setInspectModeEnabled",
+                "hidden": true,
+                "parameters": [
+                    { "name": "enabled", "type": "boolean", "description": "True to enable inspection mode, false to disable it." },
+                    { "name": "highlightConfig", "$ref": "HighlightConfig", "optional": true, "description": "A descriptor for the highlight appearance of hovered-over nodes. May be omitted if <code>enabled == false</code>." }
+                ],
+                "description": "Enters the 'inspect' mode. In this mode, elements that user is hovering over are highlighted. Backend then generates 'inspect' command upon element selection."
+            },
+            {
+                "name": "highlightRect",
+                "parameters": [
+                    { "name": "x", "type": "integer", "description": "X coordinate" },
+                    { "name": "y", "type": "integer", "description": "Y coordinate" },
+                    { "name": "width", "type": "integer", "description": "Rectangle width" },
+                    { "name": "height", "type": "integer", "description": "Rectangle height" },
+                    { "name": "color", "$ref": "RGBA", "optional": true, "description": "The highlight fill color (default: transparent)." },
+                    { "name": "outlineColor", "$ref": "RGBA", "optional": true, "description": "The highlight outline color (default: transparent)." }
+                ],
+                "description": "Highlights given rectangle. Coordinates are absolute with respect to the main frame viewport."
+            },
+            {
+                "name": "highlightNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Identifier of the node to highlight." },
+                    { "name": "highlightConfig", "$ref": "HighlightConfig", "description": "A descriptor for the highlight appearance." }
+                ],
+                "description": "Highlights DOM node with given id."
+            },
+            {
+                "name": "hideHighlight",
+                "description": "Hides DOM node highlight."
+            },
+            {
+                "name": "highlightFrame",
+                "parameters": [
+                    { "name": "frameId", "type": "string", "description": "Identifier of the frame to highlight." },
+                    { "name": "contentColor", "$ref": "RGBA", "optional": true, "description": "The content box highlight fill color (default: transparent)." },
+                    { "name": "contentOutlineColor", "$ref": "RGBA", "optional": true, "description": "The content box highlight outline color (default: transparent)." }
+                ],
+                "description": "Highlights owner element of the frame with given id.",
+                "hidden": true
+            },
+            {
+                "name": "pushNodeByPathToFrontend",
+                "parameters": [
+                    { "name": "path", "type": "string", "description": "Path to node in the proprietary format." }
+                ],
+                "returns": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node for given path." }
+                ],
+                "description": "Requests that the node is sent to the caller given its path. // FIXME, use XPath",
+                "hidden": true
+            },
+            {
+                "name": "resolveNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to resolve." },
+                    { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." }
+                ],
+                "returns": [
+                    { "name": "object", "$ref": "Runtime.RemoteObject", "description": "JavaScript object wrapper for given node." }
+                ],
+                "description": "Resolves JavaScript node object for given node id."
+            },
+            {
+                "name": "getAttributes",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to retrieve attibutes for." }
+                ],
+                "returns": [
+                    { "name": "attributes", "type": "array", "items": { "type": "string" }, "description": "An interleaved array of node attribute names and values." }
+                ],
+                "description": "Returns attributes for the specified node."
+            },
+            {
+                "name": "moveTo",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to drop." },
+                    { "name": "targetNodeId", "$ref": "NodeId", "description": "Id of the element to drop into." },
+                    { "name": "insertBeforeNodeId", "$ref": "NodeId", "optional": true, "description": "Drop node before given one." }
+                ],
+                "returns": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "New id of the moved node." }
+                ],
+                "description": "Moves node into the new container, places it before the given anchor."
+            }
+        ],
+        "events": [
+            {
+                "name": "documentUpdated",
+                "description": "Fired when <code>Document</code> has been totally updated. Node ids are no longer valid."
+            },
+            {
+                "name": "setChildNodes",
+                "parameters": [
+                    { "name": "parentId", "$ref": "NodeId", "description": "Parent node id to populate with children." },
+                    { "name": "nodes", "type": "array", "items": { "$ref": "Node"}, "description": "Child nodes array." }
+                ],
+                "description": "Fired when backend wants to provide client with the missing DOM structure. This happens upon most of the calls requesting node ids."
+            },
+            {
+                "name": "attributeModified",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                    { "name": "name", "type": "string", "description": "Attribute name." },
+                    { "name": "value", "type": "string", "description": "Attribute value." }
+                ],
+                "description": "Fired when <code>Element</code>'s attribute is modified."
+            },
+            {
+                "name": "attributeRemoved",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                    { "name": "name", "type": "string", "description": "Local attribute name." }
+                ],
+                "description": "Fired when <code>Element</code>'s attribute is removed."
+            },
+            {
+                "name": "inlineStyleInvalidated",
+                "parameters": [
+                    { "name": "nodeIds", "type": "array", "items": { "$ref": "NodeId" }, "description": "Ids of the nodes for which the inline styles have been invalidated." }
+                ],
+                "description": "Fired when <code>Element</code>'s inline style is modified via a CSS property modification.",
+                "hidden": true
+            },
+            {
+                "name": "characterDataModified",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                    { "name": "characterData", "type": "string", "description": "New text value." }
+                ],
+                "description": "Mirrors <code>DOMCharacterDataModified</code> event."
+            },
+            {
+                "name": "childNodeCountUpdated",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                    { "name": "childNodeCount", "type": "integer", "description": "New node count." }
+                ],
+                "description": "Fired when <code>Container</code>'s child node count has changed."
+            },
+            {
+                "name": "childNodeInserted",
+                "parameters": [
+                    { "name": "parentNodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                    { "name": "previousNodeId", "$ref": "NodeId", "description": "If of the previous siblint." },
+                    { "name": "node", "$ref": "Node", "description": "Inserted node data." }
+                ],
+                "description": "Mirrors <code>DOMNodeInserted</code> event."
+            },
+            {
+                "name": "childNodeRemoved",
+                "parameters": [
+                    { "name": "parentNodeId", "$ref": "NodeId", "description": "Parent id." },
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has been removed." }
+                ],
+                "description": "Mirrors <code>DOMNodeRemoved</code> event."
+            },
+            {
+                "name": "searchResults",
+                "parameters": [
+                    { "name": "nodeIds", "type": "array", "items": { "$ref": "NodeId" }, "description": "Ids of the search result nodes." }
+                ],
+                "description": "Pushes search results initiated using <code>performSearch</code> to the client.",
+                "hidden": true
+            }
+        ]
+    },
+    {
+        "domain": "CSS",
+        "hidden": true,
+        "description": "This domain exposes CSS read/write operations. All CSS objects, like stylesheets, rules, and styles, have an associated <code>id</code> used in subsequent operations on the related object. Each object type has a specific <code>id</code> structure, and those are not interchangeable between objects of different kinds. CSS objects can be loaded using the <code>get*ForNode()</code> calls (which accept a DOM node id). Alternatively, a client can discover all the existing stylesheets with the <code>getAllStyleSheets()</code> method and subsequently load the required stylesheet contents using the <code>getStyleSheet[Text]()</code> methods.",
+        "types": [
+            {
+                "id": "CSSStyleId",
+                "type": "object",
+                "properties": [
+                    { "name": "styleSheetId", "type": "string", "description": "Enclosing stylesheet identifier." },
+                    { "name": "ordinal", "type": "integer", "description": "The style ordinal within the stylesheet." }
+                ],
+                "description": "This object identifies a CSS style in a unique way."
+            },
+            {
+                "id": "CSSRuleId",
+                "type": "object",
+                "properties": [
+                    { "name": "styleSheetId", "type": "string", "description": "Enclosing stylesheet identifier." },
+                    { "name": "ordinal", "type": "integer", "description": "The rule ordinal within the stylesheet." }
+                ],
+                "description": "This object identifies a CSS rule in a unique way."
+            },
+            {
+                "id": "CSSNodeStyles",
+                "type": "object",
+                "properties": [
+                    { "name": "inlineStyle", "$ref": "CSSStyle", "optional": true, "description": "The node's inline style, if any." },
+                    { "name": "computedStyle", "$ref": "CSSComputedStyle", "description": "The node's computed style." },
+                    { "name": "matchedCSSRules", "type": "array", "items": { "$ref": "CSSRule" }, "description": "CSS rules matching this node, from all applicable stylesheets." },
+                    { "name": "styleAttributes", "type": "array", "items": { "$ref": "CSSStyleAttribute" }, "description": "Entries for style-related element attributes (e.g. width=20)."},
+                    { "name": "pseudoElements", "type": "array", "items": { "$ref": "PseudoIdRules" }, "description": "Pseudo style rules for this node." },
+                    { "name": "inherited", "type": "array", "items": { "$ref": "InheritedStyleEntry" }, "description": "A chain of inherited styles (from the immediate node parent up to the DOM tree root)." }
+                ],
+                "description": "A holder for all CSS styles applicable to a particular DOM node."
+            },
+            {
+                "id": "PseudoIdRules",
+                "type": "object",
+                "properties": [
+                    { "name": "pseudoId", "type": "integer", "description": "Pseudo style identifier (see <code>enum PseudoId</code> in <code>RenderStyleConstants.h</code>)."},
+                    { "name": "rules", "type": "array", "items": { "$ref": "CSSRule" }, "description": "CSS rules applicable to the pseudo style."}
+                ],
+                "description": "CSS rule collection for a single pseudo style."
+            },
+            {
+                "id": "InheritedStyleEntry",
+                "type": "object",
+                "properties": [
+                    { "name": "inlineStyle", "$ref": "CSSStyle", "optional": true, "description": "The ancestor node's inline style, if any, in the style inheritance chain." },
+                    { "name": "matchedCSSRules", "type": "array", "items": { "$ref": "CSSRule" }, "description": "CSS rules matching the ancestor node in the style inheritance chain." }
+                ],
+                "description": "CSS rule collection for a single pseudo style."
+            },
+            {
+                "id": "CSSStyleAttribute",
+                "type": "object",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "DOM attribute name (e.g. \"width\")."},
+                    { "name": "style", "$ref": "CSSStyle", "description": "CSS style generated by the respective DOM attribute."}
+                ],
+                "description": "CSS style information for a DOM style attribute."
+            },
+            {
+                "id": "CSSStyleSheetHeader",
+                "type": "object",
+                "properties": [
+                    { "name": "styleSheetId", "type": "string", "description": "The stylesheet identifier."},
+                    { "name": "sourceURL", "type": "string", "description": "Stylesheet resource URL."},
+                    { "name": "title", "type": "string", "description": "Stylesheet title."},
+                    { "name": "disabled", "type": "boolean", "description": "Denotes whether the stylesheet is disabled."}
+                ],
+                "description": "CSS stylesheet metainformation."
+            },
+            {
+                "id": "CSSStyleSheetBody",
+                "type": "object",
+                "properties": [
+                    { "name": "styleSheetId", "type": "string", "description": "The stylesheet identifier."},
+                    { "name": "rules", "type": "array", "items": { "$ref": "CSSRule" }, "description": "Stylesheet resource URL."},
+                    { "name": "text", "type": "string", "optional": true, "description": "Stylesheet resource contents (if available)."}
+                ],
+                "description": "CSS stylesheet contents."
+            },
+            {
+                "id": "CSSRule",
+                "type": "object",
+                "properties": [
+                    { "name": "ruleId", "$ref": "CSSRuleId", "description": "The CSS rule identifier."},
+                    { "name": "selectorText", "type": "string", "description": "Rule selector."},
+                    { "name": "sourceURL", "type": "string", "optional": true, "description": "Parent stylesheet resource URL (for regular rules)."},
+                    { "name": "sourceLine", "type": "integer", "description": "Line ordinal of the rule selector start character in the resource."},
+                    { "name": "origin", "type": "string", "enum": ["user", "user-agent", "inspector", ""], "description": "The parent stylesheet type: \"user\" for user stylesheets, \"user-agent\" for user-agent stylesheets, \"inspector\" for stylesheets created by the inspector (i.e. those holding new rules created with <code>addRule()</code>), \"\" for regular stylesheets."},
+                    { "name": "style", "$ref": "CSSStyle", "description": "Associated style declaration." },
+                    { "name": "selectorRange", "$ref": "SourceRange", "optional": true, "description": "The rule selector range in the underlying resource (if available)." }
+                ],
+                "description": "CSS rule representation."
+            },
+            {
+                "id": "SourceRange",
+                "type": "object",
+                "properties": [
+                    { "name": "start", "type": "integer", "description": "Start of range (inclusive)."},
+                    { "name": "end", "type": "integer", "description": "End of range (exclusive)."}
+                ],
+                "description": "Text range within a resource."
+            },
+            {
+                "id": "ShorthandEntry",
+                "type": "object"
+            },
+            {
+                "id": "CSSComputedStyle",
+                "type": "object"
+            },            
+            {
+                "id": "CSSStyle",
+                "type": "object",
+                "properties": [
+                    { "name": "styleId", "$ref": "CSSStyleId", "description": "The CSS style identifier."},
+                    { "name": "cssProperties", "type": "array", "items": { "$ref": "CSSProperty" }, "description": "CSS properties in the style."},
+                    { "name": "shorthandEntries", "type": "array", "items": { "$ref": "ShorthandEntry" }, "description": "Computed values for all shorthands found in the style." },
+                    { "name": "cssText", "type": "string", "optional": true, "description": "Style declaration text (if available)."},
+                    { "name": "range", "$ref": "SourceRange", "optional": true, "description": "Style declaration range in the enclosing stylesheet (if available)." },
+                    { "name": "width", "type": "integer", "description": "The effective \"width\" property value from this style." },
+                    { "name": "height", "type": "integer", "description": "The effective \"height\" property value from this style." }
+                ],
+                "description": "CSS style representation."
+            },
+            {
+                "id": "CSSProperty",
+                "type": "object",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "The property name." },
+                    { "name": "value", "type": "string", "description": "The property value." },
+                    { "name": "priority", "type": "string", "optional": true, "description": "The property priority (implies \"\" if absent)." },
+                    { "name": "implicit", "type": "boolean", "optional": true, "description": "Whether the property is implicit (implies <code>false</code> if absent)." },
+                    { "name": "parsedOk", "type": "boolean", "optional": true, "description": "Whether the property is understood by the browser (implies <code>true</code> if absent)." },
+                    { "name": "status", "type": "string", "enum": ["active", "inactive", "disabled", "style"], "optional": true, "description": "The property status: \"active\" (implied if absent) if the property is effective in the style, \"inactive\" if the property is overridden by a same-named property in this style later on, \"disabled\" if the property is disabled by the user, \"style\" if the property is reported by the browser rather than by the CSS source parser." },
+                    { "name": "shorthandName", "type": "string", "description": "The related shorthand property name (absent if this property is not a longhand)." },
+                    { "name": "range", "$ref": "SourceRange", "optional": true, "description": "The entire property range in the enclosing style declaration (if available)." }
+                ],
+                "description": "CSS style effective visual dimensions and source offsets."
+            }
+        ],
+        "commands": [
+            {
+                "name": "getStylesForNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId" },
+                    { "name": "forcedPseudoClasses", "type": "array", "items": { "type": "string", "enum": ["active", "focus", "hover", "visited"] }, "optional": true, "description": "Element pseudo classes to force when computing applicable style rules." }
+                ],
+                "returns": [
+                    { "name": "styles", "$ref": "CSSNodeStyles", "description": "All styles for the specified DOM node." }
+                ],
+                "description": "Returns all styles for a DOM node identified by <code>nodeId</code>."
+            },
+            {
+                "name": "getComputedStyleForNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId" }
+                ],
+                "returns": [
+                    { "name": "style", "$ref": "CSSStyle", "description": "Computed style for the specified DOM node." }
+                ],
+                "description": "Returns the computed style for a DOM node identified by <code>nodeId</code>."
+            },
+            {
+                "name": "getInlineStyleForNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId" }
+                ],
+                "returns": [
+                    { "name": "style", "$ref": "CSSStyle", "description": "Inline style for the specified DOM node." }
+                ],
+                "description": "Returns the inline style (if present) for a DOM node identified by <code>nodeId</code>."
+            },
+            {
+                "name": "getAllStyleSheets",
+                "returns": [
+                    { "name": "headers", "type": "array", "items": { "$ref": "CSSStyleSheetHeader" }, "description": "Descriptor entries for all available stylesheets." }
+                ],
+                "description": "Returns metainfo entries for all known stylesheets."
+            },
+            {
+                "name": "getStyleSheet",
+                "parameters": [
+                    { "name": "styleSheetId", "type": "string" }
+                ],
+                "returns": [
+                    { "name": "styleSheet", "$ref": "CSSStyleSheetBody", "description": "Stylesheet contents for the specified <code>styleSheetId</code>." }
+                ],
+                "description": "Returns stylesheet data for the specified <code>styleSheetId</code>."
+            },
+            {
+                "name": "getStyleSheetText",
+                "parameters": [
+                    { "name": "styleSheetId", "type": "string" }
+                ],
+                "returns": [
+                    { "name": "text", "type": "string", "description": "The stylesheet text." }
+                ],
+                "description": "Returns the current textual content and the URL for a stylesheet."
+            },
+            {
+                "name": "setStyleSheetText",
+                "parameters": [
+                    { "name": "styleSheetId", "type": "string" },
+                    { "name": "text", "type": "string" }
+                ],
+                "description": "Sets the new stylesheet text, thereby invalidating all existing <code>CSSStyleId</code>'s and <code>CSSRuleId</code>'s contained by this stylesheet."
+            },
+            {
+                "name": "setPropertyText",
+                "parameters": [
+                    { "name": "styleId", "$ref": "CSSStyleId" },
+                    { "name": "propertyIndex", "type": "integer" },
+                    { "name": "text", "type": "string" },
+                    { "name": "overwrite", "type": "boolean" }
+                ],
+                "returns": [
+                    { "name": "style", "$ref": "CSSStyle", "description": "The resulting style after the property text modification." }
+                ],
+                "description": "Sets the new <code>text</code> for a property in the respective style, at offset <code>propertyIndex</code>. If <code>overwrite</code> is <code>true</code>, a property at the given offset is overwritten, otherwise inserted. <code>text</code> entirely replaces the property <code>name: value</code>."
+            },
+            {
+                "name": "toggleProperty",
+                "parameters": [
+                    { "name": "styleId", "$ref": "CSSStyleId" },
+                    { "name": "propertyIndex", "type": "integer" },
+                    { "name": "disable", "type": "boolean" }
+                ],
+                "returns": [
+                    { "name": "style", "$ref": "CSSStyle", "description": "The resulting style after the property toggling." }
+                ],
+                "description": "Toggles the property in the respective style, at offset <code>propertyIndex</code>. The <code>disable</code> parameter denotes whether the property should be disabled (i.e. removed from the style declaration). If <code>disable == false</code>, the property gets put back into its original place in the style declaration."
+            },
+            {
+                "name": "setRuleSelector",
+                "parameters": [
+                    { "name": "ruleId", "$ref": "CSSRuleId" },
+                    { "name": "selector", "type": "string" }
+                ],
+                "returns": [
+                    { "name": "rule", "$ref": "CSSRule", "description": "The resulting rule after the selector modification." }
+                ],
+                "description": "Modifies the rule selector."
+            },
+            {
+                "name": "addRule",
+                "parameters": [
+                    { "name": "contextNodeId", "$ref": "DOM.NodeId" },
+                    { "name": "selector", "type": "string" }
+                ],
+                "returns": [
+                    { "name": "rule", "$ref": "CSSRule", "description": "The newly created rule." }
+                ],
+                "description": "Creates a new empty rule with the given <code>selector</code> in a special \"inspector\" stylesheet in the owner document of the context node."
+            },
+            {
+                "name": "getSupportedCSSProperties",
+                "returns": [
+                    { "name": "cssProperties", "type": "array", "items": { "type": "string" }, "description": "Supported property names." }
+                ],
+                "description": "Returns all supported CSS property names."
+            }
+        ]
+    },
+    {
+        "domain": "Timeline",
+        "description": "Timeline provides its clients with instrumentation records that are generated during the page runtime. Timeline instrumentation can be started and stopped using corresponding commands. While timeline is started, it is generating timeline event records.",
+        "types": [
+            {
+                "id": "TimelineEvent",
+                "type": "object",
+                "properties": [
+                    { "name": "type", "type": "string", "description": "Event type." },
+                    { "name": "data", "type": "object", "description": "Event data." },
+                    { "name": "children", "type": "array", "optional": true, "items": { "$ref": "TimelineEvent" }, "description": "Nested records." }
+                ],
+                "description": "Timeline record contains information about the recorded activity."
+            }
+        ],
+        "commands": [
+            {
+                "name": "start",
+                "parameters": [
+                    { "name": "maxCallStackDepth", "optional": true, "type": "integer", "description": "Samples JavaScript stack traces up to <code>maxCallStackDepth</code>, defaults to 5." }
+                ],
+                "description": "Starts capturing instrumentation events."
+            },
+            {
+                "name": "stop",
+                "description": "Stops capturing instrumentation events."
+            }
+        ],
+        "events": [
+            {
+                "name": "started",
+                "description": "Fired when timeline has been started.",
+                "hidden": true
+            },
+            {
+                "name": "stopped",
+                "description": "Fired when timeline has been stopped.",
+                "hidden": true
+            },
+            {
+                "name": "eventRecorded",
+                "parameters": [
+                    { "name": "record", "$ref": "TimelineEvent", "description": "Timeline event record data." }
+                ],
+                "description": "Fired for every instrumentation event while timeline is started."
+            }
+        ]
+    },
+    {
+        "domain": "Debugger",
+        "description": "Debugger domain exposes JavaScript debugging capabilities. It allows setting and removing breakpoints, stepping through execution, exploring stack traces, etc.",
+        "types": [
+            {
+                "id": "BreakpointId",
+                "type": "string",
+                "description": "Breakpoint identifier."
+            },
+            {
+                "id": "ScriptId",
+                "type": "string",
+                "description": "Unique script identifier."
+            },
+            {
+                "id": "CallFrameId",
+                "type": "string",
+                "description": "Call frame identifier."
+            },
+            {
+                "id": "Location",
+                "type": "object",
+                "properties": [
+                    { "name": "scriptId", "$ref": "ScriptId", "description": "Script identifier as reported in the <code>Debugger.scriptParsed</code>." },
+                    { "name": "lineNumber", "type": "integer", "description": "Line number in the script." },
+                    { "name": "columnNumber", "type": "integer", "optional": true, "description": "Column number in the script." }
+                ],
+                "description": "Location in the source code."
+            },
+            {
+                "id": "CallFrame",
+                "type": "object",
+                "properties": [
+                    { "name": "callFrameId", "$ref": "CallFrameId", "description": "Call frame identifier. This identifier is only valid while the virtual machine is paused." },
+                    { "name": "functionName", "type": "string", "description": "Name of the JavaScript function called on this call frame." },
+                    { "name": "location", "$ref": "Location", "description": "Location in the source code." },
+                    { "name": "scopeChain", "type": "array", "items": { "$ref": "Scope" }, "description": "Scope chain for this call frame." },
+                    { "name": "this", "$ref": "Runtime.RemoteObject", "description": "<code>this</code> object for this call frame." }
+                ],
+                "description": "JavaScript call frame. Array of call frames form the call stack."
+            },
+            {
+                "id": "Scope",
+                "type": "object",
+                "properties": [
+                    { "name": "type", "type": "string", "enum": ["global", "local", "with", "closure", "catch"], "description": "Scope type." },
+                    { "name": "object", "$ref": "Runtime.RemoteObject", "description": "Object representing the scope. For <code>global</code> and <code>with</code> scopes it represents the actual object; for the rest of the scopes, it is artificial transient object enumerating scope variables as its properties." }
+                ],
+                "description": "Scope description."
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables debugger for given page."
+            },
+            {
+                "name": "disable",
+                "description": "Disables debugger for given page."
+            },
+            {
+                "name": "setBreakpointsActive",
+                "parameters": [
+                    { "name": "active", "type": "boolean", "description": "New value for breakpoints active state." }
+                ],
+                "description": "Activates / deactivates all breakpoints on the page."
+            },
+            {
+                "name": "setBreakpointByUrl",
+                "parameters": [
+                    { "name": "lineNumber", "type": "integer", "description": "Line number to set breakpoint at." },
+                    { "name": "url", "type": "string", "optional": true, "description": "URL of the resources to set breakpoint on." },
+                    { "name": "urlRegex", "type": "string", "optional": true, "description": "Regex pattern for the URLs of the resources to set breakpoints on. Either <code>url</code> or <code>urlRegex</code> must be specified." },
+                    { "name": "columnNumber", "type": "integer", "optional": true, "description": "Offset in the line to set breakpoint at." },
+                    { "name": "condition", "type": "string", "optional": true, "description": "Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true." }
+                ],
+                "returns": [
+                    { "name": "breakpointId", "$ref": "BreakpointId", "description": "Id of the created breakpoint for further reference." },
+                    { "name": "locations", "optional": true, "type": "array", "items": { "$ref": "Location"}, "description": "List of the locations this breakpoint resolved into upon addition." }
+                ],
+                "description": "Sets JavaScript breakpoint at given location specified either by URL or URL regex. Once this command is issued, all existing parsed scripts will have breakpoints resolved and returned in <code>locations</code> property. Further matching script parsing will result in subsequent <code>breakpointResolved</code> events issued. This logical breakpoint will survive page reloads."
+            },
+            {
+                "name": "setBreakpoint",
+                "parameters": [
+                    { "name": "location", "$ref": "Location", "description": "Location to set breakpoint in." },
+                    { "name": "condition", "type": "string", "optional": true, "description": "Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true." }
+                ],
+                "returns": [
+                    { "name": "breakpointId", "$ref": "BreakpointId", "description": "Id of the created breakpoint for further reference." },
+                    { "name": "actualLocation", "$ref": "Location", "description": "Location this breakpoint resolved into." }
+                ],
+                "description": "Sets JavaScript breakpoint at a given location."
+            },
+            {
+                "name": "removeBreakpoint",
+                "parameters": [
+                    { "name": "breakpointId", "$ref": "BreakpointId" }
+                ],
+                "description": "Removes JavaScript breakpoint."
+            },
+            {
+                "name": "continueToLocation",
+                "parameters": [
+                    { "name": "location", "$ref": "Location", "description": "Location to continue to." }
+                ],
+                "description": "Continues execution until specific location is reached."
+            },
+            {
+                "name": "stepOver",
+                "description": "Steps over the statement."
+            },
+            {
+                "name": "stepInto",
+                "description": "Steps into the function call."
+            },
+            {
+                "name": "stepOut",
+                "description": "Steps out of the function call."
+            },
+            {
+                "name": "pause",
+                "description": "Stops on the next JavaScript statement."
+            },
+            {
+                "name": "resume",
+                "description": "Resumes JavaScript execution."
+            },
+            {
+                "name": "setScriptSource",
+                "parameters": [
+                    { "name": "scriptId", "$ref": "ScriptId", "description": "Id of the script to edit." },
+                    { "name": "scriptSource", "type": "string", "description": "New content of the script." },
+                    { "name": "preview", "type": "boolean", "optional": true, "description": " If true the change will not actually be applied. Preview mode may be used to get result description without actually modifying the code.", "hidden": true }
+                ],
+                "returns": [
+                    { "name": "callFrames", "type": "array", "optional": true, "items": { "$ref": "CallFrame"}, "description": "New stack trace in case editing has happened while VM was stopped." },
+                    { "name": "result", "type": "object", "optional": true, "description": "VM-specific description of the changes applied.", "hidden": true }
+                ],
+                "description": "Edits JavaScript source live."
+            },
+            {
+                "name": "getScriptSource",
+                "parameters": [
+                    { "name": "scriptId", "$ref": "ScriptId", "description": "Id of the script to get source for." }
+                ],
+                "returns": [
+                    { "name": "scriptSource", "type": "string", "description": "Script source." }
+                ],
+                "description": "Returns source for the script with given id."
+            },
+            {
+                "name": "setPauseOnExceptions",
+                "parameters": [
+                    { "name": "state", "type": "string", "enum": ["none", "uncaught", "all"], "description": "Pause on exceptions mode." }
+                ],
+                "description": "Defines pause on exceptions state. Can be set to stop on all exceptions, uncaught exceptions or no exceptions. Initial pause on exceptions state is <code>none</code>."
+            },
+            {
+                "name": "evaluateOnCallFrame",
+                "parameters": [
+                    { "name": "callFrameId", "$ref": "CallFrameId", "description": "Call frame identifier to evaluate on." },
+                    { "name": "expression", "type": "string", "description": "Expression to evaluate." },
+                    { "name": "objectGroup", "type": "string", "optional": true, "description": "String object group name to put result into (allows rapid releasing resulting object handles using <code>releaseObjectGroup</code>)." },
+                    { "name": "includeCommandLineAPI", "type": "boolean", "optional": true, "description": "Specifies whether command line API should be available to the evaluated expression, defaults to false.", "hidden": true },
+                    { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object that should be sent by value." }
+                ],
+                "returns": [
+                    { "name": "result", "$ref": "Runtime.RemoteObject", "description": "Object wrapper for the evaluation result." },
+                    { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." }
+                ],
+                "description": "Evaluates expression on a given call frame."
+            }
+        ],
+        "events": [
+            {
+                "name": "debuggerWasEnabled",
+                "description": "Fired when debugger gets enabled (deprecated).",
+                "hidden": true
+            },
+            {
+                "name": "debuggerWasDisabled",
+                "description": "Fired when debugger gets disabled (deprecated).",
+                "hidden": true
+            },
+            {
+                "name": "scriptParsed",
+                "parameters": [
+                    { "name": "scriptId", "$ref": "ScriptId", "description": "Identifier of the script parsed." },
+                    { "name": "url", "type": "string", "description": "URL or name of the script parsed (if any)." },
+                    { "name": "startLine", "type": "integer", "description": "Line offset of the script within the resource with given URL (for script tags)." },
+                    { "name": "startColumn", "type": "integer", "description": "Column offset of the script within the resource with given URL." },
+                    { "name": "endLine", "type": "integer", "description": "Last line of the script." },
+                    { "name": "endColumn", "type": "integer", "description": "Length of the last line of the script." },
+                    { "name": "isContentScript", "type": "boolean", "optional": true, "description": "Determines whether this script is a user extension script." }
+                ],
+                "description": "Fired when virtual machine parses script. This event is also fired for all known and uncollected scripts upon enabling debugger."
+            },
+            {
+                "name": "scriptFailedToParse",
+                "parameters": [
+                    { "name": "url", "type": "string", "description": "URL of the script that failed to parse." },
+                    { "name": "scriptSource", "type": "string", "description": "Source text of the script that failed to parse." },
+                    { "name": "startLine", "type": "integer", "description": "Line offset of the script within the resource." },
+                    { "name": "errorLine", "type": "integer", "description": "Line with error." },
+                    { "name": "errorMessage", "type": "string", "description": "Parse error message." }
+                ],
+                "description": "Fired when virtual machine fails to parse the script."
+            },
+            {
+                "name": "breakpointResolved",
+                "parameters": [
+                    { "name": "breakpointId", "$ref": "BreakpointId", "description": "Breakpoint unique identifier." },
+                    { "name": "location", "$ref": "Location", "description": "Actual breakpoint location." }
+                ],
+                "description": "Fired when breakpoint is resolved to an actual script and location."
+            },
+            {
+                "name": "paused",
+                "parameters": [
+                    { "name": "callFrames", "type": "array", "items": { "$ref": "CallFrame" }, "description": "Call stack the virtual machine stopped on." },
+                    { "name": "reason", "type": "string", "enum": [ "XHR", "DOM", "EventListener", "exception", "other" ], "description": "Pause reason." },
+                    { "name": "data", "type": "object", "optional": true, "description": "Object containing break-specific auxiliary properties." }
+                ],
+                "description": "Fired when the virtual machine stopped on breakpoint or exception or any other stop criteria."
+            },
+            {
+                "name": "resumed",
+                "description": "Fired when the virtual machine resumed execution."
+            }
+        ]
+    },
+    {
+        "domain": "DOMDebugger",
+        "description": "DOM debugging allows setting breakpoints on particular DOM operations and events. JavaScript execution will stop on these operations as if there was a regular breakpoint set.",
+        "types": [
+            {
+                "id": "DOMBreakpointType",
+                "type": "string",
+                "enum": ["subtree-modified", "attribute-modified", "node-removed"],
+                "description": "DOM breakpoint type."
+            }
+        ],
+        "commands": [
+            {
+                "name": "setDOMBreakpoint",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId", "description": "Identifier of the node to set breakpoint on." },
+                    { "name": "type", "$ref": "DOMBreakpointType", "description": "Type of the operation to stop upon." }
+                ],
+                "description": "Sets breakpoint on particular operation with DOM."
+            },
+            {
+                "name": "removeDOMBreakpoint",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId", "description": "Identifier of the node to remove breakpoint from." },
+                    { "name": "type", "$ref": "DOMBreakpointType", "description": "Type of the breakpoint to remove." }
+                ],
+                "description": "Removes DOM breakpoint that was set using <code>setDOMBreakpoint</code>."
+            },
+            {
+                "name": "setEventListenerBreakpoint",
+                "parameters": [
+                    { "name": "eventName", "type": "string", "description": "Event name to stop on (any DOM event will do)." }
+                ],
+                "description": "Sets breakpoint on particular DOM event."
+            },
+            {
+                "name": "removeEventListenerBreakpoint",
+                "parameters": [
+                    { "name": "eventName", "type": "string", "description": "Event name." }
+                ],
+                "description": "Removes breakpoint on particular DOM event."
+            },
+            {
+                "name": "setXHRBreakpoint",
+                "parameters": [
+                    { "name": "url", "type": "string", "description": "Resource URL substring. All XHRs having this substring in the URL will get stopped upon." }
+                ],
+                "description": "Sets breakpoint on XMLHttpRequest."
+            },
+            {
+                "name": "removeXHRBreakpoint",
+                "parameters": [
+                    { "name": "url", "type": "string", "description": "Resource URL substring." }
+                ],
+                "description": "Removes breakpoint from XMLHttpRequest."
+            }
+        ]
+    },
+    {
+        "domain": "Profiler",
+        "hidden": true,
+        "types": [
+            {
+                "id": "Profile",
+                "type": "object",
+                "description": "Profile."
+            },
+            {
+                "id": "ProfileHeader",
+                "type": "object",
+                "description": "Profile header."
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable"
+            },
+            {
+                "name": "disable"
+            },
+            {
+                "name": "isEnabled",
+                "returns": [
+                    { "name": "state", "type": "boolean" }
+                ]
+            },
+            {
+                "name": "start"
+            },
+            {
+                "name": "stop"
+            },
+            {
+                "name": "getProfileHeaders",
+                "returns": [
+                    { "name": "headers", "type": "array", "items": { "$ref": "ProfileHeader"} }
+                ]
+            },
+            {
+                "name": "getProfile",
+                "parameters": [
+                    { "name": "type", "type": "string" },
+                    { "name": "uid", "type": "integer" }
+                ],
+                "returns": [
+                    { "name": "profile", "$ref": "Profile" }
+                ]
+            },
+            {
+                "name": "removeProfile",
+                "parameters": [
+                    { "name": "type", "type": "string" },
+                    { "name": "uid", "type": "integer" }
+                ]
+            },
+            {
+                "name": "clearProfiles"
+            },
+            {
+                "name": "takeHeapSnapshot"
+            },
+            {
+                "name": "collectGarbage"
+            }
+        ],
+        "events": [
+            {
+                "name": "profilerWasEnabled"
+            },
+            {
+                "name": "profilerWasDisabled"
+            },
+            {
+                "name": "addProfileHeader",
+                "parameters": [
+                    { "name": "header", "$ref": "ProfileHeader" }
+                ]
+            },
+            {
+                "name": "addHeapSnapshotChunk",
+                "parameters": [
+                    { "name": "uid", "type": "integer" },
+                    { "name": "chunk", "type": "string" }
+                ]
+            },
+            {
+                "name": "finishHeapSnapshot",
+                "parameters": [
+                    { "name": "uid", "type": "integer" }
+                ]
+            },
+            {
+                "name": "setRecordingProfile",
+                "parameters": [
+                    { "name": "isProfiling", "type": "boolean" }
+                ]
+            },
+            {
+                "name": "resetProfiles"
+            },
+            {
+                "name": "reportHeapSnapshotProgress",
+                "parameters": [
+                    { "name": "done", "type": "integer" },
+                    { "name": "total", "type": "integer" }
+                ]
+            }
+        ]
+    },
+    {
+        "domain": "Worker",
+        "hidden": true,
+        "types": [],
+        "commands": [
+            {
+                "name": "setWorkerInspectionEnabled",
+                "parameters": [
+                    { "name": "value", "type": "boolean" }
+                ]
+            },
+            {
+                "name": "sendMessageToWorker",
+                "parameters": [
+                    { "name": "workerId", "type": "integer" },
+                    { "name": "message", "type": "object" }
+                ]
+            },
+            {
+                "name": "connectToWorker",
+                "parameters": [
+                    { "name": "workerId", "type": "integer" }
+                ]
+            },
+            {
+                "name": "disconnectFromWorker",
+                "parameters": [
+                    { "name": "workerId", "type": "integer" }
+                ]
+            },
+            {
+                "name": "setAutoconnectToWorkers",
+                "parameters": [
+                    { "name": "value", "type": "boolean" }
+                ]
+            }
+
+        ],
+        "events": [
+            {
+                "name": "workerCreated",
+                "parameters": [
+                    { "name": "workerId", "type": "integer" },
+                    { "name": "url", "type": "string" },
+                    { "name": "inspectorConnected", "type": "boolean" }
+                ]
+            },
+            {
+                "name": "workerTerminated",
+                "parameters": [
+                    { "name": "workerId", "type": "integer" }
+                ]
+            },
+            {
+                "name": "dispatchMessageFromWorker",
+                "parameters": [
+                    { "name": "workerId", "type": "integer" },
+                    { "name": "message", "type": "object" }
+                ]
+            }
+        ]
+    }]
+}

--- a/source/ProtocolGenerator/Inspector-1.0.json
+++ b/source/ProtocolGenerator/Inspector-1.0.json
@@ -1,0 +1,2490 @@
+{
+    "domains": [{
+        "domain": "Inspector",
+        "hidden": true,
+        "types": [],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables inspector domain notifications."
+            },
+            {
+                "name": "disable",
+                "description": "Disables inspector domain notifications."
+            }
+        ],
+        "events": [
+            {
+                "name": "evaluateForTestInFrontend",
+                "parameters": [
+                    { "name": "testCallId", "type": "integer" },
+                    { "name": "script", "type": "string" }
+                ]
+            },
+            {
+                "name": "inspect",
+                "parameters": [
+                    { "name": "object", "$ref": "Runtime.RemoteObject" },
+                    { "name": "hints", "type": "object" }
+                ]
+            },
+            {
+                "name": "didCreateWorker",
+                "parameters": [
+                    { "name": "id", "type": "integer" },
+                    { "name": "url", "type": "string" },
+                    { "name": "isShared", "type": "boolean" }
+                ]
+            },
+            {
+                "name": "didDestroyWorker",
+                "parameters": [
+                    { "name": "id", "type": "integer" }
+                ]
+            }
+        ]
+    },
+    {
+        "domain": "Memory",
+        "hidden": true,
+        "types": [
+            {
+                "id": "NodeCount",
+                "type": "object",
+                "properties": [
+                    { "name": "nodeName", "type": "string" },
+                    { "name": "count", "type": "integer" }
+                ],
+                "description": "Number of nodes with given name."
+            },
+            {
+                "id": "ListenerCount",
+                "type": "object",
+                "properties": [
+                    { "name": "type", "type": "string" },
+                    { "name": "count", "type": "integer" }
+                ],
+                "description": "Number of JS event listeners by event type."
+            },
+            {
+                "id": "StringStatistics",
+                "type": "object",
+                "properties": [
+                    { "name": "dom", "type": "integer" },
+                    { "name": "js", "type": "integer" },
+                    { "name": "shared", "type": "integer" }
+                ],
+                "description": "Character data statistics for the page."
+            },
+            {
+                "id": "DOMGroup",
+                "type": "object",
+                "properties": [
+                    { "name": "size", "type": "integer" },
+                    { "name": "title", "type": "string" },
+                    { "name": "documentURI", "type": "string", "optional": true },
+                    { "name": "nodeCount", "type": "array", "items": { "$ref": "NodeCount" }},
+                    { "name": "listenerCount", "type": "array", "items": { "$ref": "ListenerCount" }}
+                ]
+            }
+        ],
+        "commands": [
+            {
+                "name": "getDOMNodeCount",
+                "returns": [
+                    { "name": "domGroups", "type": "array", "items": { "$ref": "DOMGroup" }},
+                    { "name": "strings", "$ref": "StringStatistics" }
+                ]
+            }
+        ]
+    },
+    {
+        "domain": "Page",
+        "description": "Actions and events related to the inspected page belong to the page domain.",
+        "types": [
+            {
+                "id": "ResourceType",
+                "type": "string",
+                "enum": ["Document", "Stylesheet", "Image", "Font", "Script", "XHR", "WebSocket", "Other"],
+                "description": "Resource type as it was perceived by the rendering engine."
+            },
+            {
+                "id": "Frame",
+                "type": "object",
+                "description": "Information about the Frame on the page.",
+                "properties": [
+                    { "name": "id", "type": "string", "description": "Frame unique identifier." },
+                    { "name": "parentId", "type": "string", "optional": true, "description": "Parent frame identifier." },
+                    { "name": "loaderId", "$ref": "Network.LoaderId", "description": "Identifier of the loader associated with this frame." },
+                    { "name": "name", "type": "string", "optional": true, "description": "Frame's name as specified in the tag." },
+                    { "name": "url", "type": "string", "description": "Frame document's URL." },
+                    { "name": "securityOrigin", "type": "string", "optional": true, "description": "Frame document's security origin." },
+                    { "name": "mimeType", "type": "string", "description": "Frame document's mimeType as determined by the browser." }
+                ],
+                "hidden": true
+            },
+            {
+                "id": "FrameResourceTree",
+                "type": "object",
+                "description": "Information about the Frame hierarchy along with their cached resources.",
+                "properties": [
+                    { "name": "frame", "$ref": "Frame", "description": "Frame information for this tree item." },
+                    { "name": "childFrames", "type": "array", "optional": true, "items": { "$ref": "FrameResourceTree" }, "description": "Child frames." },
+                    { "name": "resources", "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": [
+                                { "name": "url", "type": "string", "description": "Resource URL." },
+                                { "name": "type", "$ref": "ResourceType", "description": "Type of this resource." },
+                                { "name": "mimeType", "type": "string", "description": "Resource mimeType as determined by the browser." }
+                            ]
+                        },
+                        "description": "Information about frame resources."
+                    }
+                ],
+                "hidden": true
+            },
+            {
+                "id": "SearchMatch",
+                "type": "object",
+                "description": "Search match for resource.",
+                "properties": [
+                    { "name": "lineNumber", "type": "number", "description": "Line number in resource content." },
+                    { "name": "lineContent", "type": "string", "description": "Line with match content." }
+                ],
+                "hidden": true
+            },
+            {
+                "id": "SearchResult",
+                "type": "object",
+                "description": "Search result for resource.",
+                "properties": [
+                    { "name": "url", "type": "string", "description": "Resource URL." },
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Resource frame id." },
+                    { "name": "matchesCount", "type": "number", "description": "Number of matches in the resource content." }
+                ],
+                "hidden": true
+            },
+            {
+                "id": "Cookie",
+                "type": "object",
+                "description": "Cookie object",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "Cookie name." },
+                    { "name": "value", "type": "string", "description": "Cookie value." },
+                    { "name": "domain", "type": "string", "description": "Cookie domain." },
+                    { "name": "path", "type": "string", "description": "Cookie path." },
+                    { "name": "expires", "type": "integer", "description": "Cookie expires." },
+                    { "name": "size", "type": "integer", "description": "Cookie size." },
+                    { "name": "httpOnly", "type": "boolean", "description": "True if cookie is http-only." },
+                    { "name": "secure", "type": "boolean", "description": "True if cookie is secure." },
+                    { "name": "session", "type": "boolean", "description": "True in case of session cookie." }
+                ],
+                "hidden": true
+            },
+            {
+                "id": "ScriptIdentifier",
+                "type": "string",
+                "description": "Unique script identifier.",
+                "hidden": true
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables page domain notifications."
+            },
+            {
+                "name": "disable",
+                "description": "Disables page domain notifications."
+            },
+            {
+                "name": "addScriptToEvaluateOnLoad",
+                "parameters": [
+                    { "name": "scriptSource", "type": "string" }
+                ],
+                "returns": [
+                    { "name": "identifier", "$ref": "ScriptIdentifier", "description": "Identifier of the added script." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "removeScriptToEvaluateOnLoad",
+                "parameters": [
+                    { "name": "identifier", "$ref": "ScriptIdentifier" }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "reload",
+                "parameters": [
+                    { "name": "ignoreCache", "type": "boolean", "optional": true, "description": "If true, browser cache is ignored (as if the user pressed Shift+refresh)." },
+                    { "name": "scriptToEvaluateOnLoad", "type": "string", "optional": true, "description": "If set, the script will be injected into all frames of the inspected page after reload." }
+                ],
+                "description": "Reloads given page optionally ignoring the cache."
+            },
+            {
+                "name": "navigate",
+                "parameters": [
+                    { "name": "url", "type": "string", "description": "URL to navigate the page to." }
+                ],
+                "description": "Navigates current page to the given URL."
+            },
+            {
+                "name": "getCookies",
+                "returns": [
+                    { "name": "cookies", "type": "array", "items": { "$ref": "Cookie"}, "description": "Array of cookie objects." },
+                    { "name": "cookiesString", "type": "string", "description": "document.cookie string representation of the cookies." }
+                ],
+                "description": "Returns all browser cookies. Depending on the backend support, will either return detailed cookie information in the <code>cookie</code> field or string cookie representation using <code>cookieString</code>.",
+                "hidden": true
+            },
+            {
+                "name": "deleteCookie",
+                "parameters": [
+                    { "name": "cookieName", "type": "string", "description": "Name of the cookie to remove." },
+                    { "name": "domain", "type": "string", "description": "Domain of the cookie to remove." }
+                ],
+                "description": "Deletes browser cookie with given name for the given domain.",
+                "hidden": true
+            },
+            {
+                "name": "getResourceTree",
+                "description": "Returns present frame / resource tree structure.",
+                "returns": [
+                    { "name": "frameTree", "$ref": "FrameResourceTree", "description": "Present frame / resource tree structure." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "getResourceContent",
+                "description": "Returns content of the given resource.",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Frame id to get resource for." },
+                    { "name": "url", "type": "string", "description": "URL of the resource to get content for." }
+                ],
+                "returns": [
+                    { "name": "content", "type": "string", "description": "Resource content." },
+                    { "name": "base64Encoded", "type": "boolean", "description": "True, if content was served as base64." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "searchInResource",
+                "description": "Searches for given string in resource content.",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Frame id for resource to search in." },
+                    { "name": "url", "type": "string", "description": "URL of the resource to search in." },
+                    { "name": "query", "type": "string", "description": "String to search for."  },
+                    { "name": "caseSensitive", "type": "boolean", "optional": true, "description": "If true, search is case sensitive." },
+                    { "name": "isRegex", "type": "boolean", "optional": true, "description": "If true, treats string parameter as regex." }
+                ],
+                "returns": [
+                    { "name": "result", "type": "array", "items": { "$ref": "SearchMatch" }, "description": "List of search matches." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "searchInResources",
+                "description": "Searches for given string in frame / resource tree structure.",
+                "parameters": [
+                    { "name": "text", "type": "string", "description": "String to search for."  },
+                    { "name": "caseSensitive", "type": "boolean", "optional": true, "description": "If true, search is case sensitive." },
+                    { "name": "isRegex", "type": "boolean", "optional": true, "description": "If true, treats string parameter as regex." }
+                ],
+                "returns": [
+                    { "name": "result", "type": "array", "items": { "$ref": "SearchResult" }, "description": "List of search results." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "setDocumentContent",
+                "description": "Sets given markup as the document's HTML.",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Frame id to set HTML for." },
+                    { "name": "html", "type": "string", "description": "HTML content to set."  }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "setScreenSizeOverride",
+                "description": "Overrides the values of window.screen.width, window.screen.height, window.innerWidth, window.innerHeight, and \"device-width\"/\"device-height\"-related CSS media query results",
+                "parameters": [
+                    { "name": "width", "type": "integer", "description": "Overriding width value in pixels (minimum 0, maximum 10000000). 0 disables the override." },
+                    { "name": "height", "type": "integer", "description": "Overriding height value in pixels (minimum 0, maximum 10000000). 0 disables the override." }
+                ],
+                "hidden": true
+            }
+        ],
+        "events": [
+            {
+                "name": "domContentEventFired",
+                "parameters": [
+                    { "name": "timestamp", "type": "number" }
+                ]
+            },
+            {
+                "name": "loadEventFired",
+                "parameters": [
+                    { "name": "timestamp", "type": "number" }
+                ]
+            },
+            {
+                "name": "frameNavigated",
+                "description": "Fired once navigation of the frame has completed. Frame is now associated with the new loader.",
+                "parameters": [
+                    { "name": "frame", "$ref": "Frame", "description": "Frame object." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "frameDetached",
+                "description": "Fired when frame has been detached from its parent.",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Id of the frame that has been detached." }
+                ],
+                "hidden": true
+            }
+        ]
+    },
+    {
+        "domain": "Runtime",
+        "description": "Runtime domain exposes JavaScript runtime by means of remote evaluation and mirror objects. Evaluation results are returned as mirror object that expose object type, string representation and unique identifier that can be used for further object reference. Original objects are maintained in memory unless they are either explicitly released or are released along with the other objects in their object group.",
+        "types": [
+            {
+                "id": "RemoteObjectId",
+                "type": "string",
+                "description": "Unique object identifier."
+            },
+            {
+                "id": "RemoteObject",
+                "type": "object",
+                "description": "Mirror object referencing original JavaScript object.",
+                "properties": [
+                    { "name": "type", "type": "string", "enum": ["object", "function", "undefined", "string", "number", "boolean"], "description": "Object type." },
+                    { "name": "subtype", "type": "string", "optional": true, "enum": ["array", "null", "node", "regexp", "date"], "description": "Object subtype hint. Specified for <code>object</code> type values only." },
+                    { "name": "className", "type": "string", "optional": true, "description": "Object class (constructor) name. Specified for <code>object</code> type values only." },
+                    { "name": "value", "type": "any", "optional": true, "description": "Remote object value (in case of primitive values or JSON values if it was requested)." },
+                    { "name": "description", "type": "string", "optional": true, "description": "String representation of the object." },
+                    { "name": "objectId", "$ref": "RemoteObjectId", "optional": true, "description": "Unique object identifier (for non-primitive values)." }
+                ]
+            },
+            {
+                "id": "PropertyDescriptor",
+                "type": "object",
+                "description": "Object property descriptor.",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "Property name." },
+                    { "name": "value", "$ref": "RemoteObject", "optional": true, "description": "The value associated with the property." },
+                    { "name": "writable", "type": "boolean", "optional": true, "description": "True if the value associated with the property may be changed (data descriptors only)." },
+                    { "name": "get", "$ref": "RemoteObject", "optional": true, "description": "A function which serves as a getter for the property, or <code>undefined</code> if there is no getter (accessor descriptors only)." },
+                    { "name": "set", "$ref": "RemoteObject", "optional": true, "description": "A function which serves as a setter for the property, or <code>undefined</code> if there is no setter (accessor descriptors only)." },
+                    { "name": "configurable", "type": "boolean", "description": "True if the type of this property descriptor may be changed and if the property may be deleted from the corresponding object." },
+                    { "name": "enumerable", "type": "boolean", "description": "True if this property shows up during enumeration of the properties on the corresponding object." },
+                    { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." }
+                ]
+            },
+            {
+                "id": "CallArgument",
+                "type": "object",
+                "description": "Represents function call argument. Either remote object id <code>objectId</code> or primitive <code>value</code> or neither of (for undefined) them should be specified.",
+                "properties": [
+                    { "name": "value", "type": "any", "optional": true, "description": "Primitive value." },
+                    { "name": "objectId", "$ref": "RemoteObjectId", "optional": true, "description": "Remote object handle." }
+                ]
+            }
+        ],
+        "commands": [
+            {
+                "name": "evaluate",
+                "parameters": [
+                    { "name": "expression", "type": "string", "description": "Expression to evaluate." },
+                    { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." },
+                    { "name": "includeCommandLineAPI", "type": "boolean", "optional": true, "description": "Determines whether Command Line API should be available during the evaluation.", "hidden": true },
+                    { "name": "doNotPauseOnExceptions", "type": "boolean", "optional": true, "description": "Specifies whether evaluation should stop on exceptions. Overrides setPauseOnException state.", "hidden": true },
+                    { "name": "frameId", "$ref": "Network.FrameId", "optional": true, "description": "Specifies in which frame to perform evaluation.", "hidden": true },
+                    { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object that should be sent by value." }
+                ],
+                "returns": [
+                    { "name": "result", "$ref": "RemoteObject", "description": "Evaluation result." },
+                    { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." }
+                ],
+                "description": "Evaluates expression on global object."
+            },
+            {
+                "name": "callFunctionOn",
+                "parameters": [
+                    { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to call function on." },
+                    { "name": "functionDeclaration", "type": "string", "description": "Declaration of the function to call." },
+                    { "name": "arguments", "type": "array", "items": { "$ref": "CallArgument", "description": "Call argument." }, "optional": true, "description": "Call arguments. All call arguments must belong to the same JavaScript world as the target object." },
+                    { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object which should be sent by value." }
+                ],
+                "returns": [
+                    { "name": "result", "$ref": "RemoteObject", "description": "Call result." },
+                    { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." }
+                ],
+                "description": "Calls function with given declaration on the given object. Object group of the result is inherited from the target object."
+            },
+            {
+                "name": "getProperties",
+                "parameters": [
+                    { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to return properties for." },
+                    { "name": "ownProperties", "optional": true, "type": "boolean", "description": "If true, returns properties belonging only to the element itself, not to its prototype chain." }
+                ],
+                "returns": [
+                    { "name": "result", "type": "array", "items": { "$ref": "PropertyDescriptor"}, "description": "Object properties." }
+                ],
+                "description": "Returns properties of a given object. Object group of the result is inherited from the target object."
+            },
+            {
+                "name": "releaseObject",
+                "parameters": [
+                    { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to release." }
+                ],
+                "description": "Releases remote object with given id."
+            },
+            {
+                "name": "releaseObjectGroup",
+                "parameters": [
+                    { "name": "objectGroup", "type": "string", "description": "Symbolic object group name." }
+                ],
+                "description": "Releases all remote objects that belong to a given group."
+            },
+            {
+                "name": "run",
+                "hidden": true,
+                "description": "Tells inspected instance(worker or page) that it can run in case it was started paused."
+            }
+        ]
+    },
+    {
+        "domain": "Console",
+        "description": "Console domain defines methods and events for interaction with the JavaScript console. Console collects messages created by means of the <a href='http://getfirebug.com/wiki/index.php/Console_API'>JavaScript Console API</a>. One needs to enable this domain using <code>enable</code> command in order to start receiving the console messages. Browser collects messages issued while console domain is not enabled as well and reports them using <code>messageAdded</code> notification upon enabling.",
+        "types": [
+            {
+                "id": "ConsoleMessage",
+                "type": "object",
+                "description": "Console message.",
+                "properties": [
+                    { "name": "source", "type": "string", "enum": ["html", "wml", "xml", "javascript", "network", "console-api", "other"], "description": "Message source." },
+                    { "name": "level", "type": "string", "enum": ["tip", "log", "warning", "error", "debug"], "description": "Message severity." },
+                    { "name": "text", "type": "string", "description": "Message text." },
+                    { "name": "type", "type": "string", "optional": true, "enum": ["log", "dir", "dirxml", "trace", "startGroup", "startGroupCollapsed", "endGroup", "assert"], "description": "Console message type." },
+                    { "name": "url", "type": "string", "optional": true, "description": "URL of the message origin." },
+                    { "name": "line", "type": "integer", "optional": true, "description": "Line number in the resource that generated this message." },
+                    { "name": "repeatCount", "type": "integer", "optional": true, "description": "Repeat count for repeated messages." },
+                    { "name": "parameters", "type": "array", "items": { "$ref": "Runtime.RemoteObject" }, "optional": true, "description": "Message parameters in case of the formatted message." },
+                    { "name": "stackTrace", "$ref": "StackTrace", "optional": true, "description": "JavaScript stack trace for assertions and error messages." },
+                    { "name": "networkRequestId", "$ref": "Network.RequestId", "optional": true, "description": "Identifier of the network request associated with this message." }
+                ]
+            },
+            {
+                "id": "CallFrame",
+                "type": "object",
+                "description": "Stack entry for console errors and assertions.",
+                "properties": [
+                    { "name": "functionName", "type": "string", "description": "JavaScript function name." },
+                    { "name": "url", "type": "string", "description": "JavaScript script name or url." },
+                    { "name": "lineNumber", "type": "integer", "description": "JavaScript script line number." },
+                    { "name": "columnNumber", "type": "integer", "description": "JavaScript script column number." }
+                ]
+            },
+            {
+                "id": "StackTrace",
+                "type": "array",
+                "items": { "$ref": "CallFrame" },
+                "description": "Call frames for assertions or error messages."
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables console domain, sends the messages collected so far to the client by means of the <code>messageAdded</code> notification." 
+            },
+            {
+                "name": "disable",
+                "description": "Disables console domain, prevents further console messages from being reported to the client." 
+            },
+            {
+                "name": "clearMessages",
+                "description": "Clears console messages collected in the browser." 
+            },
+            {
+                "name": "setMonitoringXHREnabled",
+                "parameters": [
+                    { "name": "enabled", "type": "boolean", "description": "Monitoring enabled state." }
+                ],
+                "description": "Toggles monitoring of XMLHttpRequest. If <code>true</code>, console will receive messages upon each XHR issued.", 
+                "hidden": true
+            },
+            {
+                "name": "addInspectedNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId", "description": "DOM node id to be accessible by means of $x command line API." }
+                ],
+                "description": "Enables console to refer to the node with given id via $x (see Command Line API for more details $x functions).",
+                "hidden": true
+            }
+        ],
+        "events": [
+            {
+                "name": "messageAdded",
+                "parameters": [
+                    { "name": "message", "$ref": "ConsoleMessage", "description": "Console message that has been added." }
+                ],
+                "description": "Issued when new console message is added."
+            },
+            {
+                "name": "messageRepeatCountUpdated",
+                "parameters": [
+                    { "name": "count", "type": "integer", "description": "New repeat count value." }
+                ],
+                "description": "Issued when subsequent message(s) are equal to the previous one(s)."
+            },
+            {
+                "name": "messagesCleared",
+                "description": "Issued when console is cleared. This happens either upon <code>clearMessages</code> command or after page navigation."
+            }
+        ]
+    },
+    {
+        "domain": "Network",
+        "description": "Network domain allows tracking network activities of the page. It exposes information about http, file, data and other requests and responses, their headers, bodies, timing, etc.",
+        "types": [
+            {
+                "id": "LoaderId",
+                "type": "string",
+                "description": "Unique loader identifier."
+            },
+            {
+                "id": "FrameId",
+                "type": "string",
+                "description": "Unique frame identifier.",
+                "hidden": true
+            },
+            {
+                "id": "RequestId",
+                "type": "string",
+                "description": "Unique request identifier."
+            },
+            {
+                "id": "Timestamp",
+                "type": "number",
+                "description": "Number of seconds since epoch."
+            },
+            {
+                "id": "Headers",
+                "type": "object",
+                "description": "Request / response headers as keys / values of JSON object."
+            },
+            {
+                "id": "ResourceTiming",
+                "type": "object",
+                "description": "Timing information for the request.",
+                "properties": [
+                    { "name": "requestTime", "type": "number", "description": "Timing's requestTime is a baseline in seconds, while the other numbers are ticks in milliseconds relatively to this requestTime." },
+                    { "name": "proxyStart", "type": "number", "description": "Started resolving proxy." },
+                    { "name": "proxyEnd", "type": "number", "description": "Finished resolving proxy." },
+                    { "name": "dnsStart", "type": "number", "description": "Started DNS address resolve." },
+                    { "name": "dnsEnd", "type": "number", "description": "Finished DNS address resolve." },
+                    { "name": "connectStart", "type": "number", "description": "Started connecting to the remote host." },
+                    { "name": "connectEnd", "type": "number", "description": "Connected to the remote host." },
+                    { "name": "sslStart", "type": "number", "description": "Started SSL handshake." },
+                    { "name": "sslEnd", "type": "number", "description": "Finished SSL handshake." },
+                    { "name": "sendStart", "type": "number", "description": "Started sending request." },
+                    { "name": "sendEnd", "type": "number", "description": "Finished sending request." },
+                    { "name": "receiveHeadersEnd", "type": "number", "description": "Finished receiving response headers." }
+                ]
+            },
+            {
+                "id": "Request",
+                "type": "object",
+                "description": "HTTP request data.",
+                "properties": [
+                    { "name": "url", "type": "string", "description": "Request URL." },
+                    { "name": "method", "type": "string", "description": "HTTP request method." },
+                    { "name": "headers", "$ref": "Headers", "description": "HTTP request headers." },
+                    { "name": "postData", "type": "string", "optional": true, "description": "HTTP POST request data." }
+                ]
+            },
+            {
+                "id": "Response",
+                "type": "object",
+                "description": "HTTP response data.",
+                "properties": [
+                    { "name": "url", "type": "string", "description": "Response URL." },
+                    { "name": "status", "type": "number", "description": "HTTP response status code." },
+                    { "name": "statusText", "type": "string", "description": "HTTP response status text." },
+                    { "name": "headers", "$ref": "Headers", "description": "HTTP response headers." },
+                    { "name": "headersText", "type": "string", "optional": true, "description": "HTTP response headers text." },
+                    { "name": "mimeType", "type": "string", "description": "Resource mimeType as determined by the browser." },
+                    { "name": "requestHeaders", "$ref": "Headers", "optional": true, "description": "Refined HTTP request headers that were actually transmitted over the network." },
+                    { "name": "requestHeadersText", "type": "string", "optional": true, "description": "HTTP request headers text." },
+                    { "name": "connectionReused", "type": "boolean", "description": "Specifies whether physical connection was actually reused for this request." },
+                    { "name": "connectionId", "type": "number", "description": "Physical connection id that was actually used for this request." },
+                    { "name": "fromDiskCache", "type": "boolean", "optional": true, "description": "Specifies that the request was served from the disk cache." },
+                    { "name": "timing", "$ref": "ResourceTiming", "optional": true, "description": "Timing information for the given request." }
+                ]
+            },
+            {
+                "id": "WebSocketRequest",
+                "type": "object",
+                "description": "WebSocket request data.",
+                "hidden": true,
+                "properties": [
+                    { "name": "requestKey3", "type": "string", "description": "HTTP response status text." },
+                    { "name": "headers", "$ref": "Headers", "description": "HTTP response headers." }
+                ]
+            },
+            {
+                "id": "WebSocketResponse",
+                "type": "object",
+                "description": "WebSocket response data.",
+                "hidden": true,
+                "properties": [
+                    { "name": "status", "type": "number", "description": "HTTP response status code." },
+                    { "name": "statusText", "type": "string", "description": "HTTP response status text." },
+                    { "name": "headers", "$ref": "Headers", "description": "HTTP response headers." },
+                    { "name": "challengeResponse", "type": "string", "description": "Challenge response." }
+                ]
+            },
+            {
+                "id": "CachedResource",
+                "type": "object",
+                "description": "Information about the cached resource.",
+                "properties": [
+                    { "name": "url", "type": "string", "description": "Resource URL." },
+                    { "name": "type", "$ref": "Page.ResourceType", "description": "Type of this resource." },
+                    { "name": "response", "$ref": "Response", "optional": true, "description": "Cached response data." },
+                    { "name": "bodySize", "type": "number", "description": "Cached response body size." }
+                ]
+            },
+            {
+                "id": "Initiator",
+                "type": "object",
+                "description": "Information about the request initiator.",
+                "properties": [
+                    { "name": "type", "type": "string", "enum": ["parser", "script", "other"], "description": "Type of this initiator." },
+                    { "name": "stackTrace", "$ref": "Console.StackTrace", "optional": true, "description": "Initiator JavaScript stack trace, set for Script only." },
+                    { "name": "url", "type": "string", "optional": true, "description": "Initiator URL, set for Parser type only." },
+                    { "name": "lineNumber", "type": "number", "optional": true, "description": "Initiator line number, set for Parser type only." }
+                ]
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables network tracking, network events will now be delivered to the client."
+            },
+            {
+                "name": "disable",
+                "description": "Disables network tracking, prevents network events from being sent to the client."
+            },
+            {
+                "name": "setUserAgentOverride",
+                "description": "Allows overriding user agent with the given string.",
+                "parameters": [
+                    { "name": "userAgent", "type": "string", "description": "User agent to use." }
+                ]
+            },
+            {
+                "name": "setExtraHTTPHeaders",
+                "description": "Specifies whether to always send extra HTTP headers with the requests from this page.",
+                "parameters": [
+                    { "name": "headers", "$ref": "Headers", "description": "Map with extra HTTP headers." }
+                ]
+            },
+            {
+                "name": "getResponseBody",
+                "description": "Returns content served for the given request.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Identifier of the network request to get content for." }
+                ],
+                "returns": [
+                    { "name": "body", "type": "string", "description": "Response body." },
+                    { "name": "base64Encoded", "type": "boolean", "description": "True, if content was sent as base64." }
+                ]
+            },
+            {
+                "name": "canClearBrowserCache",
+                "description": "Tells whether clearing browser cache is supported.",
+                "returns": [
+                    { "name": "result", "type": "boolean", "description": "True if browser cache can be cleared." }
+                ]
+            },
+            {
+                "name": "clearBrowserCache",
+                "description": "Clears browser cache."
+            },
+            {
+                "name": "canClearBrowserCookies",
+                "description": "Tells whether clearing browser cookies is supported.",
+                "returns": [
+                    { "name": "result", "type": "boolean", "description": "True if browser cookies can be cleared." }
+                ]
+            },
+            {
+                "name": "clearBrowserCookies",
+                "description": "Clears browser cookies."
+            },
+            {
+                "name": "setCacheDisabled",
+                "parameters": [
+                    { "name": "cacheDisabled", "type": "boolean", "description": "Cache disabled state." }
+                ],
+                "description": "Toggles ignoring cache for each request. If <code>true</code>, cache will not be used." 
+            }
+        ],
+        "events": [
+            {
+                "name": "requestWillBeSent",
+                "description": "Fired when page is about to send HTTP request.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "frameId", "$ref": "FrameId", "description": "Frame identifier.", "hidden": true },
+                    { "name": "loaderId", "$ref": "LoaderId", "description": "Loader identifier." },
+                    { "name": "documentURL", "type": "string", "description": "URL of the document this request is loaded for." },
+                    { "name": "request", "$ref": "Request", "description": "Request data." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "initiator", "$ref": "Initiator", "description": "Request initiator." },
+                    { "name": "stackTrace", "$ref": "Console.StackTrace", "optional": true, "description": "JavaScript stack trace upon issuing this request." },
+                    { "name": "redirectResponse", "optional": true, "$ref": "Response", "description": "Redirect response data." }
+                ]
+            },
+            {
+                "name": "requestServedFromCache",
+                "description": "Fired if request ended up loading from cache.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." }
+                ]
+            },
+            {
+                "name": "responseReceived",
+                "description": "Fired when HTTP response is available.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "frameId", "$ref": "FrameId", "description": "Frame identifier.", "hidden": true },
+                    { "name": "loaderId", "$ref": "LoaderId", "description": "Loader identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "type", "$ref": "Page.ResourceType", "description": "Resource type." },
+                    { "name": "response", "$ref": "Response", "description": "Response data." }
+                ]
+            },
+            {
+                "name": "dataReceived",
+                "description": "Fired when data chunk was received over the network.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "dataLength", "type": "integer", "description": "Data chunk length." },
+                    { "name": "encodedDataLength", "type": "integer", "description": "Actual bytes received (might be less than dataLength for compressed encodings)." }
+                ]
+            },
+            {
+                "name": "loadingFinished",
+                "description": "Fired when HTTP request has finished loading.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." }
+                ]
+            },
+            {
+                "name": "loadingFailed",
+                "description": "Fired when HTTP request has failed to load.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "errorText", "type": "string", "description": "User friendly error message." },
+                    { "name": "canceled", "type": "boolean", "optional": true, "description": "True if loading was canceled." }
+                ]
+            },
+            {
+                "name": "webSocketWillSendHandshakeRequest",
+                "description": "Fired when WebSocket is about to initiate handshake.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "request", "$ref": "WebSocketRequest", "description": "WebSocket request data." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "webSocketHandshakeResponseReceived",
+                "description": "Fired when WebSocket handshake response becomes available.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "response", "$ref": "WebSocketResponse", "description": "WebSocket response data." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "webSocketCreated",
+                "description": "Fired upon WebSocket creation.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "url", "type": "string", "description": "WebSocket request URL." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "webSocketClosed",
+                "description": "Fired when WebSocket is closed.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." }
+                ],
+                "hidden": true
+            }
+        ]
+    },
+    {
+        "domain": "Database",
+        "hidden": true,
+        "types": [
+            {
+                "id": "Database",
+                "type": "object",
+                "description": "Database object.",
+                "hidden": true,
+                "properties": [
+                    { "name": "id", "type": "string", "description": "Database ID." },
+                    { "name": "domain", "type": "string", "description": "Database domain." },
+                    { "name": "name", "type": "string", "description": "Database name." },
+                    { "name": "version", "type": "string", "description": "Database version." }
+                ]
+            },
+            {
+                "id": "Error",
+                "type": "object",
+                "description": "Database error."
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables database tracking, database events will now be delivered to the client."
+            },
+            {
+                "name": "disable",
+                "description": "Disables database tracking, prevents database events from being sent to the client."
+            },
+            {
+                "name": "getDatabaseTableNames",
+                "parameters": [
+                    { "name": "databaseId", "type": "integer" }
+                ],
+                "returns": [
+                    { "name": "tableNames", "type": "array", "items": { "type": "string" } }
+                ]
+            },
+            {
+                "name": "executeSQL",
+                "parameters": [
+                    { "name": "databaseId", "type": "integer" },
+                    { "name": "query", "type": "string" }
+                ],
+                "returns": [
+                    { "name": "success", "type": "boolean" },
+                    { "name": "transactionId", "type": "integer" }
+                ]
+            }
+        ],
+        "events": [
+            {
+                "name": "addDatabase",
+                "parameters": [
+                    { "name": "database", "$ref": "Database" }
+                ]
+            },
+            {
+                "name": "sqlTransactionSucceeded",
+                "parameters": [
+                    { "name": "transactionId", "type": "integer" },
+                    { "name": "columnNames", "type": "array", "items": { "type": "string" } },
+                    { "name": "values", "type": "array", "items": { "type": "any" }}
+                ]
+            },
+            {
+                "name": "sqlTransactionFailed",
+                "parameters": [
+                    { "name": "transactionId", "type": "integer" },
+                    { "name": "sqlError", "$ref": "Error" }
+                ]
+            }
+        ]
+    },
+    {
+        "domain": "IndexedDB",
+        "hidden": true,
+        "types": [
+            {
+                "id": "SecurityOriginWithDatabaseNames",
+                "type": "object",
+                "description": "Security origin with database names.",
+                "properties": [
+                    { "name": "securityOrigin", "type": "string", "description": "Security origin." },
+                    { "name": "databaseNames", "type": "array", "items": { "type": "string" }, "description": "Database names for this origin." }
+                ]
+            },
+            {
+                "id": "DatabaseWithObjectStores",
+                "type": "object",
+                "description": "Database with an array of object stores.",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "Database name." },
+                    { "name": "version", "type": "string", "description": "Database version." },
+                    { "name": "objectStores", "type": "array", "items": { "$ref": "ObjectStore" }, "description": "Object stores in this database." }
+                ]
+            },
+            {
+                "id": "ObjectStore",
+                "type": "object",
+                "description": "Object store.",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "Object store name." },
+                    { "name": "keyPath", "type": "string", "description": "Object store key path." },
+                    { "name": "indexes", "type": "array", "items": { "$ref": "ObjectStoreIndex" }, "description": "Indexes in this object store." }
+                ]
+            },
+            {
+                "id": "ObjectStoreIndex",
+                "type": "object",
+                "description": "Object store index.",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "Index name." },
+                    { "name": "keyPath", "type": "string", "description": "Index key path." },
+                    { "name": "unique", "type": "boolean", "description": "If true, index is unique." },
+                    { "name": "multiEntry", "type": "boolean", "description": "If true, index allows multiple entries for a key." }
+                ]
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables events from backend."
+            },
+            {
+                "name": "disable",
+                "description": "Disables events from backend."
+            },
+            {
+                "name": "requestDatabaseNamesForFrame",
+                "parameters": [
+                    { "name": "requestId", "type": "integer", "description": "Request id." },
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Frame id." }
+                ],
+                "description": "Requests database names for given frame's security origin."
+            },
+            {
+                "name": "requestDatabase",
+                "parameters": [
+                    { "name": "requestId", "type": "integer", "description": "Request id." },
+                    { "name": "frameId", "$ref": "Network.FrameId" },
+                    { "name": "databaseName", "type": "string" }
+                ],
+                "description": "Requests database with given name in given frame."
+            }
+        ],
+        "events": [
+            {
+                "name": "databaseNamesLoaded",
+                "parameters": [
+                    { "name": "requestId", "type": "number", "description": "Request id." },
+                    { "name": "securityOriginWithDatabaseNames", "$ref": "SecurityOriginWithDatabaseNames", "description": "Frame with database names." }
+                ]
+            },
+            {
+                "name": "databaseLoaded",
+                "parameters": [
+                    { "name": "requestId", "type": "integer", "description": "Request id." },
+                    { "name": "databaseWithObjectStores", "$ref": "DatabaseWithObjectStores", "description": "Database with an array of object stores." }
+                ]
+            }
+        ]
+    },
+    {
+        "domain": "DOMStorage",
+        "hidden": true,
+        "types": [
+            {
+                "id": "Entry",
+                "type": "object",
+                "description": "DOM Storage entry.",
+                "hidden": true,
+                "properties": [
+                    { "name": "host", "type": "string", "description": "Domain name." },
+                    { "name": "isLocalStorage", "type": "boolean", "description": "True for local storage." },
+                    { "name": "id", "type": "number", "description": "Entry id for further reference." }
+                ]
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables storage tracking, storage events will now be delivered to the client."
+            },
+            {
+                "name": "disable",
+                "description": "Disables storage tracking, prevents storage events from being sent to the client."
+            },
+            {
+                "name": "getDOMStorageEntries",
+                "parameters": [
+                    { "name": "storageId", "type": "integer" }
+                ],
+                "returns": [
+                    { "name": "entries", "type": "array", "items": { "$ref": "Entry"} }
+                ]
+            },
+            {
+                "name": "setDOMStorageItem",
+                "parameters": [
+                    { "name": "storageId", "type": "integer" },
+                    { "name": "key", "type": "string" },
+                    { "name": "value", "type": "string" }
+                ],
+                "returns": [
+                    { "name": "success", "type": "boolean" }
+                ]
+            },
+            {
+                "name": "removeDOMStorageItem",
+                "parameters": [
+                    { "name": "storageId", "type": "integer" },
+                    { "name": "key", "type": "string" }
+                ],
+                "returns": [
+                    { "name": "success", "type": "boolean" }
+                ]
+            }
+        ],
+        "events": [
+            {
+                "name": "addDOMStorage",
+                "parameters": [
+                    { "name": "storage", "$ref": "Entry" }
+                ]
+            },
+            {
+                "name": "updateDOMStorage",
+                "parameters": [
+                    { "name": "storageId", "type": "integer" }
+                ]
+            }
+        ]
+    },
+    {
+        "domain": "ApplicationCache",
+        "hidden": true,
+        "types": [
+            {
+                "id": "ApplicationCacheResource",
+                "type": "object",
+                "description": "Detailed application cache resource information.",
+                "properties": [
+                    { "name": "url", "type": "string", "description": "Resource url." },
+                    { "name": "size", "type": "integer", "description": "Resource size." },
+                    { "name": "type", "type": "string", "description": "Resource type." }
+                ]
+            },
+            {
+                "id": "ApplicationCache",
+                "type": "object",
+                "description": "Detailed application cache information.",
+                "properties": [
+                    { "name": "manifestURL", "type": "string", "description": "Manifest URL." },
+                    { "name": "size", "type": "number", "description": "Application cache size." },
+                    { "name": "creationTime", "type": "number", "description": "Application cache creation time." },
+                    { "name": "updateTime", "type": "number", "description": "Application cache update time." },
+                    { "name": "resources", "type": "array", "items": { "$ref": "ApplicationCacheResource" }, "description": "Application cache resources." }
+                ]
+            },
+            {
+                "id": "FrameWithManifest",
+                "type": "object",
+                "description": "Frame identifier - manifest URL pair.",
+                "properties": [
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Frame identifier." },
+                    { "name": "manifestURL", "type": "string", "description": "Manifest URL." },
+                    { "name": "status", "type": "integer", "description": "Application cache status." }
+                ]
+            }
+        ],
+        "commands": [
+            {
+                "name": "getFramesWithManifests",
+                "returns": [
+                    { "name": "frameIds", "type": "array", "items": { "$ref": "FrameWithManifest" }, "description": "Array of frame identifiers with manifest urls for each frame containing a document associated with some application cache." }
+                ],
+                "description": "Returns array of frame identifiers with manifest urls for each frame containing a document associated with some application cache."
+            },
+            {
+                "name": "enable",
+                "description": "Enables application cache domain notifications."
+            },
+            {
+                "name": "getManifestForFrame",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Identifier of the frame containing document whose manifest is retrieved." }
+                ],
+                "returns": [
+                    { "name": "manifestURL", "type": "string", "description": "Manifest URL for document in the given frame." }
+                ],
+                "description": "Returns manifest URL for document in the given frame."
+            },
+            {
+                "name": "getApplicationCacheForFrame",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Identifier of the frame containing document whose application cache is retrieved." }
+                ],
+                "returns": [
+                    { "name": "applicationCache", "$ref": "ApplicationCache", "description": "Relevant application cache data for the document in given frame." }
+                ],
+                "description": "Returns relevant application cache data for the document in given frame."
+            }
+        ],
+        "events": [
+            {
+                "name": "applicationCacheStatusUpdated",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Identifier of the frame containing document whose application cache updated status." },
+                    { "name": "manifestURL", "type": "string", "description": "Manifest URL." },
+                    { "name": "status", "type": "integer", "description": "Updated application cache status." }
+                ]
+            },
+            {
+                "name": "networkStateUpdated",
+                "parameters": [
+                    { "name": "isNowOnline", "type": "boolean" }
+                ]
+            }
+        ]
+    },
+    {
+        "domain": "FileSystem",
+        "hidden": true,
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables events from backend."
+            },
+            {
+                "name": "disable",
+                "description": "Disables events from backend.."
+            }
+        ],
+        "events": [
+        ]
+    },
+    {
+        "domain": "DOM",
+        "description": "This domain exposes DOM read/write operations. Each DOM Node is represented with its mirror object that has an <code>id</code>. This <code>id</code> can be used to get additional information on the Node, resolve it into the JavaScript object wrapper, etc. It is important that client receives DOM events only for the nodes that are known to the client. Backend keeps track of the nodes that were sent to the client and never sends the same node twice. It is client's responsibility to collect information about the nodes that were sent to the client.<p>Note that <code>iframe</code> owner elements will return corresponding document elements as their child nodes.</p>",
+        "types": [
+            {
+                "id": "NodeId",
+                "type": "integer",
+                "description": "Unique DOM node identifier."
+            },
+            {
+                "id": "Node",
+                "type": "object",
+                "properties": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Node identifier that is passed into the rest of the DOM messages as the <code>nodeId</code>. Backend will only push node with given <code>id</code> once. It is aware of all requested nodes and will only fire DOM events for nodes known to the client." },
+                    { "name": "nodeType", "type": "integer", "description": "<code>Node</code>'s nodeType." },
+                    { "name": "nodeName", "type": "string", "description": "<code>Node</code>'s nodeName." },
+                    { "name": "localName", "type": "string", "description": "<code>Node</code>'s localName." },
+                    { "name": "nodeValue", "type": "string", "description": "<code>Node</code>'s nodeValue." },
+                    { "name": "childNodeCount", "type": "integer", "optional": true, "description": "Child count for <code>Container</code> nodes." },
+                    { "name": "children", "type": "array", "optional": true, "items": { "$ref": "Node" }, "description": "Child nodes of this node when requested with children." },
+                    { "name": "attributes", "type": "array", "optional": true, "items": { "type": "string" }, "description": "Attributes of the <code>Element</code> node in the form of flat array <code>[name1, value1, name2, value2]</code>." },
+                    { "name": "documentURL", "type": "string", "optional": true, "description": "Document URL that <code>Document</code> or <code>FrameOwner</code> node points to." },
+                    { "name": "publicId", "type": "string", "optional": true, "description": "<code>DocumentType</code>'s publicId." },
+                    { "name": "systemId", "type": "string", "optional": true, "description": "<code>DocumentType</code>'s systemId." },
+                    { "name": "internalSubset", "type": "string", "optional": true, "description": "<code>DocumentType</code>'s internalSubset." },
+                    { "name": "xmlVersion", "type": "string", "optional": true, "description": "<code>Document</code>'s XML version in case of XML documents." },
+                    { "name": "name", "type": "string", "optional": true, "description": "<code>Attr</code>'s name." },
+                    { "name": "value", "type": "string", "optional": true, "description": "<code>Attr</code>'s value." },
+                    { "name": "contentDocument", "$ref": "Node", "optional": true, "description": "Content document for frame owner elements." }
+                ],
+                "description": "DOM interaction is implemented in terms of mirror objects that represent the actual DOM nodes. DOMNode is a base node mirror type."
+            },
+            {
+                "id": "EventListener",
+                "type": "object",
+                "hidden": true,
+                "properties": [
+                    { "name": "type", "type": "string", "description": "<code>EventListener</code>'s type." },
+                    { "name": "useCapture", "type": "boolean", "description": "<code>EventListener</code>'s useCapture." },
+                    { "name": "isAttribute", "type": "boolean", "description": "<code>EventListener</code>'s isAttribute." },
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Target <code>DOMNode</code> id." },
+                    { "name": "handlerBody", "type": "string", "description": "Event handler function body." },
+                    { "name": "location", "$ref": "Debugger.Location", "optional": true, "description": "Handler code location." }
+                ],
+                "description": "DOM interaction is implemented in terms of mirror objects that represent the actual DOM nodes. DOMNode is a base node mirror type."
+            },
+            {
+                "id": "RGBA",
+                "type": "object",
+                "properties": [
+                    { "name": "r", "type": "integer", "description": "The red component, in the [0-255] range." },
+                    { "name": "g", "type": "integer", "description": "The green component, in the [0-255] range." },
+                    { "name": "b", "type": "integer", "description": "The blue component, in the [0-255] range." },
+                    { "name": "a", "type": "number", "optional": true, "description": "The alpha component, in the [0-1] range (default: 1)." }
+                ],
+                "description": "A structure holding an RGBA color."
+            },
+            {
+                "id": "HighlightConfig",
+                "type": "object",
+                "properties": [
+                    { "name": "showInfo", "type": "boolean", "optional": true, "description": "Whether the node info tooltip should be shown (default: false)." },
+                    { "name": "contentColor", "$ref": "RGBA", "optional": true, "description": "The content box highlight fill color (default: transparent)." },
+                    { "name": "paddingColor", "$ref": "RGBA", "optional": true, "description": "The padding highlight fill color (default: transparent)." },
+                    { "name": "borderColor", "$ref": "RGBA", "optional": true, "description": "The border highlight fill color (default: transparent)." },
+                    { "name": "marginColor", "$ref": "RGBA", "optional": true, "description": "The margin highlight fill color (default: transparent)." }
+                ],
+                "description": "Configuration data for the highlighting of page elements."
+            }
+        ],
+        "commands": [
+            {
+                "name": "getDocument",
+                "returns": [
+                    { "name": "root", "$ref": "Node", "description": "Resulting node." }
+                ],
+                "description": "Returns the root DOM node to the caller."
+            },
+            {
+                "name": "requestChildNodes",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to get children for." }
+                ],
+                "description": "Requests that children of the node with given id are returned to the caller in form of <code>setChildNodes</code> events."
+            },
+            {
+                "name": "querySelector",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to query upon." },
+                    { "name": "selector", "type": "string", "description": "Selector string." }
+                ],
+                "returns": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Query selector result." }
+                ],
+                "description": "Executes <code>querySelector</code> on a given node."
+            },
+            {
+                "name": "querySelectorAll",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to query upon." },
+                    { "name": "selector", "type": "string", "description": "Selector string." }
+                ],
+                "returns": [
+                    { "name": "nodeIds", "type": "array", "items": { "$ref": "NodeId" }, "description": "Query selector result." }
+                ],
+                "description": "Executes <code>querySelectorAll</code> on a given node."
+            },
+            {
+                "name": "setNodeName",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to set name for." },
+                    { "name": "name", "type": "string", "description": "New node's name." }
+                ],
+                "returns": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "New node's id." }
+                ],
+                "description": "Sets node name for a node with given id."
+            },
+            {
+                "name": "setNodeValue",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to set value for." },
+                    { "name": "value", "type": "string", "description": "New node's value." }
+                ],
+                "description": "Sets node value for a node with given id."
+            },
+            {
+                "name": "removeNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to remove." }
+                ],
+                "description": "Removes node with given id."
+            },
+            {
+                "name": "setAttributeValue",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the element to set attribute for." },
+                    { "name": "name", "type": "string", "description": "Attribute name." },
+                    { "name": "value", "type": "string", "description": "Attribute value." }
+                ],
+                "description": "Sets attribute for an element with given id."
+            },
+            {
+                "name": "setAttributesAsText",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the element to set attributes for." },
+                    { "name": "text", "type": "string", "description": "Text with a number of attributes. Will parse this text using HTML parser." },
+                    { "name": "name", "type": "string", "optional": true, "description": "Attribute name to replace with new attributes derived from text in case text parsed successfully." }
+                ],
+                "description": "Sets attributes on element with given id. This method is useful when user edits some existing attribute value and types in several attribute name/value pairs."
+            },
+            {
+                "name": "removeAttribute",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the element to remove attribute from." },
+                    { "name": "name", "type": "string", "description": "Name of the attribute to remove." }
+                ],
+                "description": "Removes attribute with given name from an element with given id."
+            },
+            {
+                "name": "getEventListenersForNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to get listeners for." }
+                ],
+                "returns": [
+                    { "name": "listeners", "type": "array", "items": { "$ref": "EventListener"}, "description": "Array of relevant listeners." }
+                ],
+                "description": "Returns event listeners relevant to the node.",
+                "hidden": true
+            },
+            {
+                "name": "getOuterHTML",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to get markup for." }
+                ],
+                "returns": [
+                    { "name": "outerHTML", "type": "string", "description": "Outer HTML markup." }
+                ],
+                "description": "Returns node's HTML markup."
+            },
+            {
+                "name": "setOuterHTML",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to set markup for." },
+                    { "name": "outerHTML", "type": "string", "description": "Outer HTML markup to set." }
+                ],
+                "description": "Sets node HTML markup, returns new node id."
+            },
+            {
+                "name": "performSearch",
+                "parameters": [
+                    { "name": "query", "type": "string", "description": "Plain text or query selector or XPath search query." }
+                ],
+                "returns": [
+                    { "name": "searchId", "type": "string", "description": "Unique search session identifier." },
+                    { "name": "resultCount", "type": "integer", "description": "Number of search results." }
+                ],
+                "description": "Searches for a given string in the DOM tree. Use <code>getSearchResults</code> to access search results or <code>cancelSearch</code> to end this search session.",
+                "hidden": true
+            },
+            {
+                "name": "getSearchResults",
+                "parameters": [
+                    { "name": "searchId", "type": "string", "description": "Unique search session identifier." },
+                    { "name": "fromIndex", "type": "integer", "description": "Start index of the search result to be returned." },
+                    { "name": "toIndex", "type": "integer", "description": "End index of the search result to be returned." }
+                ],
+                "returns": [
+                    { "name": "nodeIds", "type": "array", "items": { "$ref": "NodeId" }, "description": "Ids of the search result nodes." }
+                ],
+                "description": "Returns search results from given <code>fromIndex</code> to given <code>toIndex</code> from the sarch with the given identifier.",
+                "hidden": true
+            },
+            {
+                "name": "discardSearchResults",
+                "parameters": [
+                    { "name": "searchId", "type": "string", "description": "Unique search session identifier." }
+                ],
+                "description": "Discards search results from the session with the given id. <code>getSearchResults</code> should no longer be called for that search.",
+                "hidden": true
+            },
+            {
+                "name": "requestNode",
+                "parameters": [
+                    { "name": "objectId", "$ref": "Runtime.RemoteObjectId", "description": "JavaScript object id to convert into node." }
+                ],
+                "returns": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Node id for given object." }
+                ],
+                "description": "Requests that the node is sent to the caller given the JavaScript node object reference. All nodes that form the path from the node to the root are also sent to the client as a series of <code>setChildNodes</code> notifications."
+            },
+            {
+                "name": "setInspectModeEnabled",
+                "hidden": true,
+                "parameters": [
+                    { "name": "enabled", "type": "boolean", "description": "True to enable inspection mode, false to disable it." },
+                    { "name": "highlightConfig", "$ref": "HighlightConfig", "optional": true, "description": "A descriptor for the highlight appearance of hovered-over nodes. May be omitted if <code>enabled == false</code>." }
+                ],
+                "description": "Enters the 'inspect' mode. In this mode, elements that user is hovering over are highlighted. Backend then generates 'inspect' command upon element selection."
+            },
+            {
+                "name": "highlightRect",
+                "parameters": [
+                    { "name": "x", "type": "integer", "description": "X coordinate" },
+                    { "name": "y", "type": "integer", "description": "Y coordinate" },
+                    { "name": "width", "type": "integer", "description": "Rectangle width" },
+                    { "name": "height", "type": "integer", "description": "Rectangle height" },
+                    { "name": "color", "$ref": "RGBA", "optional": true, "description": "The highlight fill color (default: transparent)." },
+                    { "name": "outlineColor", "$ref": "RGBA", "optional": true, "description": "The highlight outline color (default: transparent)." }
+                ],
+                "description": "Highlights given rectangle. Coordinates are absolute with respect to the main frame viewport."
+            },
+            {
+                "name": "highlightNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Identifier of the node to highlight." },
+                    { "name": "highlightConfig", "$ref": "HighlightConfig", "description": "A descriptor for the highlight appearance." }
+                ],
+                "description": "Highlights DOM node with given id."
+            },
+            {
+                "name": "hideHighlight",
+                "description": "Hides DOM node highlight."
+            },
+            {
+                "name": "highlightFrame",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Identifier of the frame to highlight." },
+                    { "name": "contentColor", "$ref": "RGBA", "optional": true, "description": "The content box highlight fill color (default: transparent)." },
+                    { "name": "contentOutlineColor", "$ref": "RGBA", "optional": true, "description": "The content box highlight outline color (default: transparent)." }
+                ],
+                "description": "Highlights owner element of the frame with given id.",
+                "hidden": true
+            },
+            {
+                "name": "pushNodeByPathToFrontend",
+                "parameters": [
+                    { "name": "path", "type": "string", "description": "Path to node in the proprietary format." }
+                ],
+                "returns": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node for given path." }
+                ],
+                "description": "Requests that the node is sent to the caller given its path. // FIXME, use XPath",
+                "hidden": true
+            },
+            {
+                "name": "resolveNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to resolve." },
+                    { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." }
+                ],
+                "returns": [
+                    { "name": "object", "$ref": "Runtime.RemoteObject", "description": "JavaScript object wrapper for given node." }
+                ],
+                "description": "Resolves JavaScript node object for given node id."
+            },
+            {
+                "name": "getAttributes",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to retrieve attibutes for." }
+                ],
+                "returns": [
+                    { "name": "attributes", "type": "array", "items": { "type": "string" }, "description": "An interleaved array of node attribute names and values." }
+                ],
+                "description": "Returns attributes for the specified node."
+            },
+            {
+                "name": "moveTo",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to drop." },
+                    { "name": "targetNodeId", "$ref": "NodeId", "description": "Id of the element to drop into." },
+                    { "name": "insertBeforeNodeId", "$ref": "NodeId", "optional": true, "description": "Drop node before given one." }
+                ],
+                "returns": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "New id of the moved node." }
+                ],
+                "description": "Moves node into the new container, places it before the given anchor."
+            }
+        ],
+        "events": [
+            {
+                "name": "documentUpdated",
+                "description": "Fired when <code>Document</code> has been totally updated. Node ids are no longer valid."
+            },
+            {
+                "name": "setChildNodes",
+                "parameters": [
+                    { "name": "parentId", "$ref": "NodeId", "description": "Parent node id to populate with children." },
+                    { "name": "nodes", "type": "array", "items": { "$ref": "Node"}, "description": "Child nodes array." }
+                ],
+                "description": "Fired when backend wants to provide client with the missing DOM structure. This happens upon most of the calls requesting node ids."
+            },
+            {
+                "name": "attributeModified",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                    { "name": "name", "type": "string", "description": "Attribute name." },
+                    { "name": "value", "type": "string", "description": "Attribute value." }
+                ],
+                "description": "Fired when <code>Element</code>'s attribute is modified."
+            },
+            {
+                "name": "attributeRemoved",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                    { "name": "name", "type": "string", "description": "A ttribute name." }
+                ],
+                "description": "Fired when <code>Element</code>'s attribute is removed."
+            },
+            {
+                "name": "inlineStyleInvalidated",
+                "parameters": [
+                    { "name": "nodeIds", "type": "array", "items": { "$ref": "NodeId" }, "description": "Ids of the nodes for which the inline styles have been invalidated." }
+                ],
+                "description": "Fired when <code>Element</code>'s inline style is modified via a CSS property modification.",
+                "hidden": true
+            },
+            {
+                "name": "characterDataModified",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                    { "name": "characterData", "type": "string", "description": "New text value." }
+                ],
+                "description": "Mirrors <code>DOMCharacterDataModified</code> event."
+            },
+            {
+                "name": "childNodeCountUpdated",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                    { "name": "childNodeCount", "type": "integer", "description": "New node count." }
+                ],
+                "description": "Fired when <code>Container</code>'s child node count has changed."
+            },
+            {
+                "name": "childNodeInserted",
+                "parameters": [
+                    { "name": "parentNodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                    { "name": "previousNodeId", "$ref": "NodeId", "description": "If of the previous siblint." },
+                    { "name": "node", "$ref": "Node", "description": "Inserted node data." }
+                ],
+                "description": "Mirrors <code>DOMNodeInserted</code> event."
+            },
+            {
+                "name": "childNodeRemoved",
+                "parameters": [
+                    { "name": "parentNodeId", "$ref": "NodeId", "description": "Parent id." },
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has been removed." }
+                ],
+                "description": "Mirrors <code>DOMNodeRemoved</code> event."
+            }
+        ]
+    },
+    {
+        "domain": "CSS",
+        "hidden": true,
+        "description": "This domain exposes CSS read/write operations. All CSS objects, like stylesheets, rules, and styles, have an associated <code>id</code> used in subsequent operations on the related object. Each object type has a specific <code>id</code> structure, and those are not interchangeable between objects of different kinds. CSS objects can be loaded using the <code>get*ForNode()</code> calls (which accept a DOM node id). Alternatively, a client can discover all the existing stylesheets with the <code>getAllStyleSheets()</code> method and subsequently load the required stylesheet contents using the <code>getStyleSheet[Text]()</code> methods.",
+        "types": [
+            {
+                "id": "CSSStyleId",
+                "type": "object",
+                "properties": [
+                    { "name": "styleSheetId", "type": "string", "description": "Enclosing stylesheet identifier." },
+                    { "name": "ordinal", "type": "integer", "description": "The style ordinal within the stylesheet." }
+                ],
+                "description": "This object identifies a CSS style in a unique way."
+            },
+            {
+                "id": "CSSRuleId",
+                "type": "object",
+                "properties": [
+                    { "name": "styleSheetId", "type": "string", "description": "Enclosing stylesheet identifier." },
+                    { "name": "ordinal", "type": "integer", "description": "The rule ordinal within the stylesheet." }
+                ],
+                "description": "This object identifies a CSS rule in a unique way."
+            },
+            {
+                "id": "PseudoIdRules",
+                "type": "object",
+                "properties": [
+                    { "name": "pseudoId", "type": "integer", "description": "Pseudo style identifier (see <code>enum PseudoId</code> in <code>RenderStyleConstants.h</code>)."},
+                    { "name": "rules", "type": "array", "items": { "$ref": "CSSRule" }, "description": "CSS rules applicable to the pseudo style."}
+                ],
+                "description": "CSS rule collection for a single pseudo style."
+            },
+            {
+                "id": "InheritedStyleEntry",
+                "type": "object",
+                "properties": [
+                    { "name": "inlineStyle", "$ref": "CSSStyle", "optional": true, "description": "The ancestor node's inline style, if any, in the style inheritance chain." },
+                    { "name": "matchedCSSRules", "type": "array", "items": { "$ref": "CSSRule" }, "description": "CSS rules matching the ancestor node in the style inheritance chain." }
+                ],
+                "description": "CSS rule collection for a single pseudo style."
+            },
+            {
+                "id": "CSSStyleAttribute",
+                "type": "object",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "DOM attribute name (e.g. \"width\")."},
+                    { "name": "style", "$ref": "CSSStyle", "description": "CSS style generated by the respective DOM attribute."}
+                ],
+                "description": "CSS style information for a DOM style attribute."
+            },
+            {
+                "id": "CSSStyleSheetHeader",
+                "type": "object",
+                "properties": [
+                    { "name": "styleSheetId", "type": "string", "description": "The stylesheet identifier."},
+                    { "name": "sourceURL", "type": "string", "description": "Stylesheet resource URL."},
+                    { "name": "title", "type": "string", "description": "Stylesheet title."},
+                    { "name": "disabled", "type": "boolean", "description": "Denotes whether the stylesheet is disabled."}
+                ],
+                "description": "CSS stylesheet metainformation."
+            },
+            {
+                "id": "CSSStyleSheetBody",
+                "type": "object",
+                "properties": [
+                    { "name": "styleSheetId", "type": "string", "description": "The stylesheet identifier."},
+                    { "name": "rules", "type": "array", "items": { "$ref": "CSSRule" }, "description": "Stylesheet resource URL."},
+                    { "name": "text", "type": "string", "optional": true, "description": "Stylesheet resource contents (if available)."}
+                ],
+                "description": "CSS stylesheet contents."
+            },
+            {
+                "id": "CSSRule",
+                "type": "object",
+                "properties": [
+                    { "name": "ruleId", "$ref": "CSSRuleId", "optional": true, "description": "The CSS rule identifier (absent for user agent stylesheet and user-specified stylesheet rules)."},
+                    { "name": "selectorText", "type": "string", "description": "Rule selector."},
+                    { "name": "sourceURL", "type": "string", "optional": true, "description": "Parent stylesheet resource URL (for regular rules)."},
+                    { "name": "sourceLine", "type": "integer", "description": "Line ordinal of the rule selector start character in the resource."},
+                    { "name": "origin", "type": "string", "enum": ["user", "user-agent", "inspector", "regular"], "description": "The parent stylesheet type: \"user\" for user stylesheets, \"user-agent\" for user-agent stylesheets, \"inspector\" for stylesheets created by the inspector (i.e. those holding new rules created with <code>addRule()</code>), \"regular\" for regular stylesheets."},
+                    { "name": "style", "$ref": "CSSStyle", "description": "Associated style declaration." },
+                    { "name": "selectorRange", "$ref": "SourceRange", "optional": true, "description": "The rule selector range in the underlying resource (if available)." },
+                    { "name": "media", "type": "array", "items": { "$ref": "CSSMedia" }, "optional": true, "description": "Media list array (for rules involving media queries). The array enumerates media queries starting with the innermost one, going outwards." }
+                ],
+                "description": "CSS rule representation."
+            },
+            {
+                "id": "SourceRange",
+                "type": "object",
+                "properties": [
+                    { "name": "start", "type": "integer", "description": "Start of range (inclusive)."},
+                    { "name": "end", "type": "integer", "description": "End of range (exclusive)."}
+                ],
+                "description": "Text range within a resource."
+            },
+            {
+                "id": "ShorthandEntry",
+                "type": "object"
+            },
+            {
+                "id": "CSSComputedStyleProperty",
+                "type": "object",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "Computed style property name." },
+                    { "name": "value", "type": "string", "description": "Computed style property value." }
+                ]
+            },            
+            {
+                "id": "CSSStyle",
+                "type": "object",
+                "properties": [
+                    { "name": "styleId", "$ref": "CSSStyleId", "optional": true, "description": "The CSS style identifier (absent for attribute styles)." },
+                    { "name": "cssProperties", "type": "array", "items": { "$ref": "CSSProperty" }, "description": "CSS properties in the style." },
+                    { "name": "shorthandEntries", "type": "array", "items": { "$ref": "ShorthandEntry" }, "description": "Computed values for all shorthands found in the style." },
+                    { "name": "cssText", "type": "string", "optional": true, "description": "Style declaration text (if available)." },
+                    { "name": "range", "$ref": "SourceRange", "optional": true, "description": "Style declaration range in the enclosing stylesheet (if available)." },
+                    { "name": "width", "type": "string", "optional": true, "description": "The effective \"width\" property value from this style." },
+                    { "name": "height", "type": "string", "optional": true, "description": "The effective \"height\" property value from this style." }
+                ],
+                "description": "CSS style representation."
+            },
+            {
+                "id": "CSSProperty",
+                "type": "object",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "The property name." },
+                    { "name": "value", "type": "string", "description": "The property value." },
+                    { "name": "priority", "type": "string", "optional": true, "description": "The property priority (implies \"\" if absent)." },
+                    { "name": "implicit", "type": "boolean", "optional": true, "description": "Whether the property is implicit (implies <code>false</code> if absent)." },
+                    { "name": "text", "type": "string", "optional": true, "description": "The full property text as specified in the style." },
+                    { "name": "parsedOk", "type": "boolean", "optional": true, "description": "Whether the property is understood by the browser (implies <code>true</code> if absent)." },
+                    { "name": "status", "type": "string", "enum": ["active", "inactive", "disabled", "style"], "optional": true, "description": "The property status: \"active\" (implied if absent) if the property is effective in the style, \"inactive\" if the property is overridden by a same-named property in this style later on, \"disabled\" if the property is disabled by the user, \"style\" if the property is reported by the browser rather than by the CSS source parser." },
+                    { "name": "shorthandName", "type": "string", "optional": true, "description": "The related shorthand property name (absent if this property is not a longhand)." },
+                    { "name": "range", "$ref": "SourceRange", "optional": true, "description": "The entire property range in the enclosing style declaration (if available)." }
+                ],
+                "description": "CSS style effective visual dimensions and source offsets."
+            },
+            {
+                "id": "CSSMedia",
+                "type": "object",
+                "properties": [
+                    { "name": "text", "type": "string", "description": "Media query text." },
+                    { "name": "source", "type": "string", "enum": ["mediaRule", "importRule", "linkedSheet", "inlineSheet"], "description": "Source of the media query: \"mediaRule\" if specified by a @media rule, \"importRule\" if specified by an @import rule, \"linkedSheet\" if specified by a \"media\" attribute in a linked stylesheet's LINK tag, \"inlineSheet\" if specified by a \"media\" attribute in an inline stylesheet's STYLE tag." },
+                    { "name": "sourceURL", "type": "string", "optional": true, "description": "URL of the document containing the media query description." },
+                    { "name": "sourceLine", "type": "integer", "optional": true, "description": "Line in the document containing the media query (not defined for the \"stylesheet\" source)." }
+                ],
+                "description": "CSS media query descriptor."
+            },
+            {
+                "id": "SelectorProfileEntry",
+                "type": "object",
+                "properties": [
+                    { "name": "selector", "type": "string", "description": "CSS selector of the corresponding rule." },
+                    { "name": "url", "type": "string", "description": "URL of the resource containing the corresponding rule." },
+                    { "name": "lineNumber", "type": "integer", "description": "Selector line number in the resource for the corresponding rule." },
+                    { "name": "time", "type": "number", "description": "Total time this rule handling contributed to the browser running time during profiling (in milliseconds.)" },
+                    { "name": "hitCount", "type": "integer", "description": "Number of times this rule was considered a candidate for matching against DOM elements." },
+                    { "name": "matchCount", "type": "integer", "description": "Number of times this rule actually matched a DOM element." }
+                ],
+                "description": "CSS selector profile entry."
+            },
+            {
+                "id": "SelectorProfile",
+                "type": "object",
+                "properties": [
+                    { "name": "totalTime", "type": "number", "description": "Total processing time for all selectors in the profile (in milliseconds.)" },
+                    { "name": "data", "type": "array", "items": { "$ref": "SelectorProfileEntry" }, "description": "CSS selector profile entries." }
+                ]
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables the CSS agent for the given page. Clients should not assume that the CSS agent has been enabled until the result of this command is received."
+            },
+            {
+                "name": "disable",
+                "description": "Disables the CSS agent for the given page."
+            },
+            {
+                "name": "getMatchedStylesForNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId" },
+                    { "name": "forcedPseudoClasses", "type": "array", "items": { "type": "string", "enum": ["active", "focus", "hover", "visited"] }, "optional": true, "description": "Element pseudo classes to force when computing applicable style rules." },
+                    { "name": "includePseudo", "type": "boolean", "optional": true, "description": "Whether to include pseudo styles (default: true)." },
+                    { "name": "includeInherited", "type": "boolean", "optional": true, "description": "Whether to include inherited styles (default: true)." }
+                ],
+                "returns": [
+                    { "name": "matchedCSSRules", "type": "array", "items": { "$ref": "CSSRule" }, "optional": true, "description": "CSS rules matching this node, from all applicable stylesheets." },
+                    { "name": "pseudoElements", "type": "array", "items": { "$ref": "PseudoIdRules" }, "optional": true, "description": "Pseudo style rules for this node." },
+                    { "name": "inherited", "type": "array", "items": { "$ref": "InheritedStyleEntry" }, "optional": true, "description": "A chain of inherited styles (from the immediate node parent up to the DOM tree root)." }
+                ],
+                "description": "Returns requested styles for a DOM node identified by <code>nodeId</code>."
+            },
+            {
+                "name": "getInlineStylesForNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId" }
+                ],
+                "returns": [
+                    { "name": "inlineStyle", "$ref": "CSSStyle", "optional": true, "description": "Inline style for the specified DOM node." },
+                    { "name": "styleAttributes", "type": "array", "items": { "$ref": "CSSStyleAttribute" }, "optional": true, "description": "Entries for style-related element attributes (e.g. width=20)."}
+                ],
+                "description": "Returns the styles defined inline (explicitly in the \"style\" attribute and implicitly, using DOM attributes) for a DOM node identified by <code>nodeId</code>."
+            },
+            {
+                "name": "getComputedStyleForNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId" },
+                    { "name": "forcedPseudoClasses", "type": "array", "items": { "type": "string", "enum": ["active", "focus", "hover", "visited"] }, "optional": true, "description": "Element pseudo classes to force when computing applicable style rules." }
+                ],
+                "returns": [
+                    { "name": "computedStyle", "type": "array", "items": { "$ref": "CSSComputedStyleProperty" }, "description": "Computed style for the specified DOM node." }
+                ],
+                "description": "Returns the computed style for a DOM node identified by <code>nodeId</code>."
+            },
+            {
+                "name": "getAllStyleSheets",
+                "returns": [
+                    { "name": "headers", "type": "array", "items": { "$ref": "CSSStyleSheetHeader" }, "description": "Descriptor entries for all available stylesheets." }
+                ],
+                "description": "Returns metainfo entries for all known stylesheets."
+            },
+            {
+                "name": "getStyleSheet",
+                "parameters": [
+                    { "name": "styleSheetId", "type": "string" }
+                ],
+                "returns": [
+                    { "name": "styleSheet", "$ref": "CSSStyleSheetBody", "description": "Stylesheet contents for the specified <code>styleSheetId</code>." }
+                ],
+                "description": "Returns stylesheet data for the specified <code>styleSheetId</code>."
+            },
+            {
+                "name": "getStyleSheetText",
+                "parameters": [
+                    { "name": "styleSheetId", "type": "string" }
+                ],
+                "returns": [
+                    { "name": "text", "type": "string", "description": "The stylesheet text." }
+                ],
+                "description": "Returns the current textual content and the URL for a stylesheet."
+            },
+            {
+                "name": "setStyleSheetText",
+                "parameters": [
+                    { "name": "styleSheetId", "type": "string" },
+                    { "name": "text", "type": "string" }
+                ],
+                "description": "Sets the new stylesheet text, thereby invalidating all existing <code>CSSStyleId</code>'s and <code>CSSRuleId</code>'s contained by this stylesheet."
+            },
+            {
+                "name": "setPropertyText",
+                "parameters": [
+                    { "name": "styleId", "$ref": "CSSStyleId" },
+                    { "name": "propertyIndex", "type": "integer" },
+                    { "name": "text", "type": "string" },
+                    { "name": "overwrite", "type": "boolean" }
+                ],
+                "returns": [
+                    { "name": "style", "$ref": "CSSStyle", "description": "The resulting style after the property text modification." }
+                ],
+                "description": "Sets the new <code>text</code> for a property in the respective style, at offset <code>propertyIndex</code>. If <code>overwrite</code> is <code>true</code>, a property at the given offset is overwritten, otherwise inserted. <code>text</code> entirely replaces the property <code>name: value</code>."
+            },
+            {
+                "name": "toggleProperty",
+                "parameters": [
+                    { "name": "styleId", "$ref": "CSSStyleId" },
+                    { "name": "propertyIndex", "type": "integer" },
+                    { "name": "disable", "type": "boolean" }
+                ],
+                "returns": [
+                    { "name": "style", "$ref": "CSSStyle", "description": "The resulting style after the property toggling." }
+                ],
+                "description": "Toggles the property in the respective style, at offset <code>propertyIndex</code>. The <code>disable</code> parameter denotes whether the property should be disabled (i.e. removed from the style declaration). If <code>disable == false</code>, the property gets put back into its original place in the style declaration."
+            },
+            {
+                "name": "setRuleSelector",
+                "parameters": [
+                    { "name": "ruleId", "$ref": "CSSRuleId" },
+                    { "name": "selector", "type": "string" }
+                ],
+                "returns": [
+                    { "name": "rule", "$ref": "CSSRule", "description": "The resulting rule after the selector modification." }
+                ],
+                "description": "Modifies the rule selector."
+            },
+            {
+                "name": "addRule",
+                "parameters": [
+                    { "name": "contextNodeId", "$ref": "DOM.NodeId" },
+                    { "name": "selector", "type": "string" }
+                ],
+                "returns": [
+                    { "name": "rule", "$ref": "CSSRule", "description": "The newly created rule." }
+                ],
+                "description": "Creates a new empty rule with the given <code>selector</code> in a special \"inspector\" stylesheet in the owner document of the context node."
+            },
+            {
+                "name": "getSupportedCSSProperties",
+                "returns": [
+                    { "name": "cssProperties", "type": "array", "items": { "type": "string" }, "description": "Supported property names." }
+                ],
+                "description": "Returns all supported CSS property names."
+            },
+            {
+                "name": "startSelectorProfiler"
+            },
+            {
+                "name": "stopSelectorProfiler",
+                "returns": [
+                    { "name": "profile", "$ref": "SelectorProfile" }
+                ]
+            }
+        ],
+        "events": [
+            {
+                "name": "mediaQueryResultChanged",
+                "description": "Fires whenever a MediaQuery result changes (for example, after a browser window has been resized.) The current implementation considers only viewport-dependent media features."
+            }
+        ]
+    },
+    {
+        "domain": "Timeline",
+        "description": "Timeline provides its clients with instrumentation records that are generated during the page runtime. Timeline instrumentation can be started and stopped using corresponding commands. While timeline is started, it is generating timeline event records.",
+        "types": [
+            {
+                "id": "TimelineEvent",
+                "type": "object",
+                "properties": [
+                    { "name": "type", "type": "string", "description": "Event type." },
+                    { "name": "data", "type": "object", "description": "Event data." },
+                    { "name": "children", "type": "array", "optional": true, "items": { "$ref": "TimelineEvent" }, "description": "Nested records." }
+                ],
+                "description": "Timeline record contains information about the recorded activity."
+            }
+        ],
+        "commands": [
+            {
+                "name": "start",
+                "parameters": [
+                    { "name": "maxCallStackDepth", "optional": true, "type": "integer", "description": "Samples JavaScript stack traces up to <code>maxCallStackDepth</code>, defaults to 5." }
+                ],
+                "description": "Starts capturing instrumentation events."
+            },
+            {
+                "name": "stop",
+                "description": "Stops capturing instrumentation events."
+            },
+            {
+                "name": "setIncludeMemoryDetails",
+                "parameters": [
+                    { "name": "enabled", "type": "boolean", "description": "True to start collecting DOM counters." }
+                ],
+                "hidden": true,
+                "description": "Starts calculating various DOM statistics and sending them as part of timeline events."
+            }
+        ],
+        "events": [
+            {
+                "name": "eventRecorded",
+                "parameters": [
+                    { "name": "record", "$ref": "TimelineEvent", "description": "Timeline event record data." }
+                ],
+                "description": "Fired for every instrumentation event while timeline is started."
+            }
+        ]
+    },
+    {
+        "domain": "Debugger",
+        "description": "Debugger domain exposes JavaScript debugging capabilities. It allows setting and removing breakpoints, stepping through execution, exploring stack traces, etc.",
+        "types": [
+            {
+                "id": "BreakpointId",
+                "type": "string",
+                "description": "Breakpoint identifier."
+            },
+            {
+                "id": "ScriptId",
+                "type": "string",
+                "description": "Unique script identifier."
+            },
+            {
+                "id": "CallFrameId",
+                "type": "string",
+                "description": "Call frame identifier."
+            },
+            {
+                "id": "Location",
+                "type": "object",
+                "properties": [
+                    { "name": "scriptId", "$ref": "ScriptId", "description": "Script identifier as reported in the <code>Debugger.scriptParsed</code>." },
+                    { "name": "lineNumber", "type": "integer", "description": "Line number in the script." },
+                    { "name": "columnNumber", "type": "integer", "optional": true, "description": "Column number in the script." }
+                ],
+                "description": "Location in the source code."
+            },
+            {
+                "id": "FunctionDetails",
+                "hidden": true,
+                "type": "object",
+                "properties": [
+                    { "name": "location", "$ref": "Location", "description": "Location of the function." },
+                    { "name": "name", "type": "string", "optional": true, "description": "Name of the function. Not present for anonymous functions." },
+                    { "name": "displayName", "type": "string", "optional": true, "description": "Display name of the function(specified in 'displayName' property on the function object)." },
+                    { "name": "inferredName", "type": "string", "optional": true, "description": "Name of the function inferred from its initial assignment." }
+                ],
+                "description": "Information about the function."
+            },
+            {
+                "id": "CallFrame",
+                "type": "object",
+                "properties": [
+                    { "name": "callFrameId", "$ref": "CallFrameId", "description": "Call frame identifier. This identifier is only valid while the virtual machine is paused." },
+                    { "name": "functionName", "type": "string", "description": "Name of the JavaScript function called on this call frame." },
+                    { "name": "location", "$ref": "Location", "description": "Location in the source code." },
+                    { "name": "scopeChain", "type": "array", "items": { "$ref": "Scope" }, "description": "Scope chain for this call frame." },
+                    { "name": "this", "$ref": "Runtime.RemoteObject", "description": "<code>this</code> object for this call frame." }
+                ],
+                "description": "JavaScript call frame. Array of call frames form the call stack."
+            },
+            {
+                "id": "Scope",
+                "type": "object",
+                "properties": [
+                    { "name": "type", "type": "string", "enum": ["global", "local", "with", "closure", "catch"], "description": "Scope type." },
+                    { "name": "object", "$ref": "Runtime.RemoteObject", "description": "Object representing the scope. For <code>global</code> and <code>with</code> scopes it represents the actual object; for the rest of the scopes, it is artificial transient object enumerating scope variables as its properties." }
+                ],
+                "description": "Scope description."
+            }
+        ],
+        "commands": [
+            {
+                "name": "causesRecompilation",
+                "returns": [
+                    { "name": "result", "type": "boolean", "description": "True if enabling debugger causes scripts recompilation." }
+                ],
+                "hidden": true,
+                "description": "Tells whether enabling debugger causes scripts recompilation."
+            },
+            {
+                "name": "supportsNativeBreakpoints",
+                "returns": [
+                    { "name": "result", "type": "boolean", "description": "True if debugger supports native breakpoints." }
+                ],
+                "hidden": true,
+                "description": "Tells whether debugger supports native breakpoints."
+            },
+            {
+                "name": "enable",
+                "description": "Enables debugger for the given page. Clients should not assume that the debugging has been enabled until the result for this command is received."
+            },
+            {
+                "name": "disable",
+                "description": "Disables debugger for given page."
+            },
+            {
+                "name": "setBreakpointsActive",
+                "parameters": [
+                    { "name": "active", "type": "boolean", "description": "New value for breakpoints active state." }
+                ],
+                "description": "Activates / deactivates all breakpoints on the page."
+            },
+            {
+                "name": "setBreakpointByUrl",
+                "parameters": [
+                    { "name": "lineNumber", "type": "integer", "description": "Line number to set breakpoint at." },
+                    { "name": "url", "type": "string", "optional": true, "description": "URL of the resources to set breakpoint on." },
+                    { "name": "urlRegex", "type": "string", "optional": true, "description": "Regex pattern for the URLs of the resources to set breakpoints on. Either <code>url</code> or <code>urlRegex</code> must be specified." },
+                    { "name": "columnNumber", "type": "integer", "optional": true, "description": "Offset in the line to set breakpoint at." },
+                    { "name": "condition", "type": "string", "optional": true, "description": "Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true." }
+                ],
+                "returns": [
+                    { "name": "breakpointId", "$ref": "BreakpointId", "description": "Id of the created breakpoint for further reference." },
+                    { "name": "locations", "optional": true, "type": "array", "items": { "$ref": "Location"}, "description": "List of the locations this breakpoint resolved into upon addition." }
+                ],
+                "description": "Sets JavaScript breakpoint at given location specified either by URL or URL regex. Once this command is issued, all existing parsed scripts will have breakpoints resolved and returned in <code>locations</code> property. Further matching script parsing will result in subsequent <code>breakpointResolved</code> events issued. This logical breakpoint will survive page reloads."
+            },
+            {
+                "name": "setBreakpoint",
+                "parameters": [
+                    { "name": "location", "$ref": "Location", "description": "Location to set breakpoint in." },
+                    { "name": "condition", "type": "string", "optional": true, "description": "Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true." }
+                ],
+                "returns": [
+                    { "name": "breakpointId", "$ref": "BreakpointId", "description": "Id of the created breakpoint for further reference." },
+                    { "name": "actualLocation", "$ref": "Location", "description": "Location this breakpoint resolved into." }
+                ],
+                "description": "Sets JavaScript breakpoint at a given location."
+            },
+            {
+                "name": "removeBreakpoint",
+                "parameters": [
+                    { "name": "breakpointId", "$ref": "BreakpointId" }
+                ],
+                "description": "Removes JavaScript breakpoint."
+            },
+            {
+                "name": "continueToLocation",
+                "parameters": [
+                    { "name": "location", "$ref": "Location", "description": "Location to continue to." }
+                ],
+                "description": "Continues execution until specific location is reached."
+            },
+            {
+                "name": "stepOver",
+                "description": "Steps over the statement."
+            },
+            {
+                "name": "stepInto",
+                "description": "Steps into the function call."
+            },
+            {
+                "name": "stepOut",
+                "description": "Steps out of the function call."
+            },
+            {
+                "name": "pause",
+                "description": "Stops on the next JavaScript statement."
+            },
+            {
+                "name": "resume",
+                "description": "Resumes JavaScript execution."
+            },
+            {
+                "name": "searchInContent",
+                "parameters": [
+                    { "name": "scriptId", "$ref": "ScriptId", "description": "Id of the script to search in." },
+                    { "name": "query", "type": "string", "description": "String to search for."  },
+                    { "name": "caseSensitive", "type": "boolean", "optional": true, "description": "If true, search is case sensitive." },
+                    { "name": "isRegex", "type": "boolean", "optional": true, "description": "If true, treats string parameter as regex." }
+                ],
+                "returns": [
+                    { "name": "result", "type": "array", "items": { "$ref": "Page.SearchMatch" }, "description": "List of search matches." }
+                ],
+                "description": "Searches for given string in script content."
+            },
+            {
+                "name": "canSetScriptSource",
+                "returns": [
+                    { "name": "result", "type": "boolean", "description": "True if <code>setScriptSource</code> is supported." }
+                ],
+                "description": "Tells whether <code>setScriptSource</code> is supported."
+            },
+            {
+                "name": "setScriptSource",
+                "parameters": [
+                    { "name": "scriptId", "$ref": "ScriptId", "description": "Id of the script to edit." },
+                    { "name": "scriptSource", "type": "string", "description": "New content of the script." },
+                    { "name": "preview", "type": "boolean", "optional": true, "description": " If true the change will not actually be applied. Preview mode may be used to get result description without actually modifying the code.", "hidden": true }
+                ],
+                "returns": [
+                    { "name": "callFrames", "type": "array", "optional": true, "items": { "$ref": "CallFrame"}, "description": "New stack trace in case editing has happened while VM was stopped." },
+                    { "name": "result", "type": "object", "optional": true, "description": "VM-specific description of the changes applied.", "hidden": true }
+                ],
+                "description": "Edits JavaScript source live."
+            },
+            {
+                "name": "getScriptSource",
+                "parameters": [
+                    { "name": "scriptId", "$ref": "ScriptId", "description": "Id of the script to get source for." }
+                ],
+                "returns": [
+                    { "name": "scriptSource", "type": "string", "description": "Script source." }
+                ],
+                "description": "Returns source for the script with given id."
+            },
+            {
+                "name": "getFunctionDetails",
+                "hidden": true,
+                "parameters": [
+                    { "name": "functionId", "$ref": "Runtime.RemoteObjectId", "description": "Id of the function to get location for." }
+                ],
+                "returns": [
+                    { "name": "details", "$ref": "FunctionDetails", "description": "Information about the function." }
+                ],
+                "description": "Returns detailed informtation on given function."
+            },
+            {
+                "name": "setPauseOnExceptions",
+                "parameters": [
+                    { "name": "state", "type": "string", "enum": ["none", "uncaught", "all"], "description": "Pause on exceptions mode." }
+                ],
+                "description": "Defines pause on exceptions state. Can be set to stop on all exceptions, uncaught exceptions or no exceptions. Initial pause on exceptions state is <code>none</code>."
+            },
+            {
+                "name": "evaluateOnCallFrame",
+                "parameters": [
+                    { "name": "callFrameId", "$ref": "CallFrameId", "description": "Call frame identifier to evaluate on." },
+                    { "name": "expression", "type": "string", "description": "Expression to evaluate." },
+                    { "name": "objectGroup", "type": "string", "optional": true, "description": "String object group name to put result into (allows rapid releasing resulting object handles using <code>releaseObjectGroup</code>)." },
+                    { "name": "includeCommandLineAPI", "type": "boolean", "optional": true, "description": "Specifies whether command line API should be available to the evaluated expression, defaults to false.", "hidden": true },
+                    { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object that should be sent by value." }
+                ],
+                "returns": [
+                    { "name": "result", "$ref": "Runtime.RemoteObject", "description": "Object wrapper for the evaluation result." },
+                    { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." }
+                ],
+                "description": "Evaluates expression on a given call frame."
+            }
+        ],
+        "events": [
+            {
+                "name": "globalObjectCleared",
+                "description": "Called when global has been cleared and debugger client should reset its state. Happens upon navigation or reload."
+            },
+            {
+                "name": "scriptParsed",
+                "parameters": [
+                    { "name": "scriptId", "$ref": "ScriptId", "description": "Identifier of the script parsed." },
+                    { "name": "url", "type": "string", "description": "URL or name of the script parsed (if any)." },
+                    { "name": "startLine", "type": "integer", "description": "Line offset of the script within the resource with given URL (for script tags)." },
+                    { "name": "startColumn", "type": "integer", "description": "Column offset of the script within the resource with given URL." },
+                    { "name": "endLine", "type": "integer", "description": "Last line of the script." },
+                    { "name": "endColumn", "type": "integer", "description": "Length of the last line of the script." },
+                    { "name": "isContentScript", "type": "boolean", "optional": true, "description": "Determines whether this script is a user extension script." },
+                    { "name": "sourceMapURL", "type": "string", "optional": true, "description": "URL of source map associated with script (if any)." }
+                ],
+                "description": "Fired when virtual machine parses script. This event is also fired for all known and uncollected scripts upon enabling debugger."
+            },
+            {
+                "name": "scriptFailedToParse",
+                "parameters": [
+                    { "name": "url", "type": "string", "description": "URL of the script that failed to parse." },
+                    { "name": "scriptSource", "type": "string", "description": "Source text of the script that failed to parse." },
+                    { "name": "startLine", "type": "integer", "description": "Line offset of the script within the resource." },
+                    { "name": "errorLine", "type": "integer", "description": "Line with error." },
+                    { "name": "errorMessage", "type": "string", "description": "Parse error message." }
+                ],
+                "description": "Fired when virtual machine fails to parse the script."
+            },
+            {
+                "name": "breakpointResolved",
+                "parameters": [
+                    { "name": "breakpointId", "$ref": "BreakpointId", "description": "Breakpoint unique identifier." },
+                    { "name": "location", "$ref": "Location", "description": "Actual breakpoint location." }
+                ],
+                "description": "Fired when breakpoint is resolved to an actual script and location."
+            },
+            {
+                "name": "paused",
+                "parameters": [
+                    { "name": "callFrames", "type": "array", "items": { "$ref": "CallFrame" }, "description": "Call stack the virtual machine stopped on." },
+                    { "name": "reason", "type": "string", "enum": [ "XHR", "DOM", "EventListener", "exception", "other" ], "description": "Pause reason." },
+                    { "name": "data", "type": "object", "optional": true, "description": "Object containing break-specific auxiliary properties." }
+                ],
+                "description": "Fired when the virtual machine stopped on breakpoint or exception or any other stop criteria."
+            },
+            {
+                "name": "resumed",
+                "description": "Fired when the virtual machine resumed execution."
+            }
+        ]
+    },
+    {
+        "domain": "DOMDebugger",
+        "description": "DOM debugging allows setting breakpoints on particular DOM operations and events. JavaScript execution will stop on these operations as if there was a regular breakpoint set.",
+        "types": [
+            {
+                "id": "DOMBreakpointType",
+                "type": "string",
+                "enum": ["subtree-modified", "attribute-modified", "node-removed"],
+                "description": "DOM breakpoint type."
+            }
+        ],
+        "commands": [
+            {
+                "name": "setDOMBreakpoint",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId", "description": "Identifier of the node to set breakpoint on." },
+                    { "name": "type", "$ref": "DOMBreakpointType", "description": "Type of the operation to stop upon." }
+                ],
+                "description": "Sets breakpoint on particular operation with DOM."
+            },
+            {
+                "name": "removeDOMBreakpoint",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId", "description": "Identifier of the node to remove breakpoint from." },
+                    { "name": "type", "$ref": "DOMBreakpointType", "description": "Type of the breakpoint to remove." }
+                ],
+                "description": "Removes DOM breakpoint that was set using <code>setDOMBreakpoint</code>."
+            },
+            {
+                "name": "setEventListenerBreakpoint",
+                "parameters": [
+                    { "name": "eventName", "type": "string", "description": "DOM Event name to stop on (any DOM event will do)." }
+                ],
+                "description": "Sets breakpoint on particular DOM event."
+            },
+            {
+                "name": "removeEventListenerBreakpoint",
+                "parameters": [
+                    { "name": "eventName", "type": "string", "description": "Event name." }
+                ],
+                "description": "Removes breakpoint on particular DOM event."
+            },
+            {
+                "name": "setInstrumentationBreakpoint",
+                "parameters": [
+                    { "name": "eventName", "type": "string", "description": "Instrumentation name to stop on." }
+                ],
+                "description": "Sets breakpoint on particular native event.",
+                "hidden": true
+            },
+            {
+                "name": "removeInstrumentationBreakpoint",
+                "parameters": [
+                    { "name": "eventName", "type": "string", "description": "Instrumentation name to stop on." }
+                ],
+                "description": "Sets breakpoint on particular native event.",
+                "hidden": true
+            },
+            {
+                "name": "setXHRBreakpoint",
+                "parameters": [
+                    { "name": "url", "type": "string", "description": "Resource URL substring. All XHRs having this substring in the URL will get stopped upon." }
+                ],
+                "description": "Sets breakpoint on XMLHttpRequest."
+            },
+            {
+                "name": "removeXHRBreakpoint",
+                "parameters": [
+                    { "name": "url", "type": "string", "description": "Resource URL substring." }
+                ],
+                "description": "Removes breakpoint from XMLHttpRequest."
+            }
+        ]
+    },
+    {
+        "domain": "Profiler",
+        "hidden": true,
+        "types": [
+            {
+                "id": "Profile",
+                "type": "object",
+                "description": "Profile."
+            },
+            {
+                "id": "ProfileHeader",
+                "type": "object",
+                "description": "Profile header."
+            }
+        ],
+        "commands": [
+            {
+                "name": "causesRecompilation",
+                "returns": [
+                    { "name": "result", "type": "boolean" }
+                ]
+            },
+            {
+                "name": "isSampling",
+                "returns": [
+                    { "name": "result", "type": "boolean" }
+                ]
+            },
+            {
+                "name": "hasHeapProfiler",
+                "returns": [
+                    { "name": "result", "type": "boolean" }
+                ]
+            },
+            {
+                "name": "enable"
+            },
+            {
+                "name": "disable"
+            },
+            {
+                "name": "start"
+            },
+            {
+                "name": "stop"
+            },
+            {
+                "name": "getProfileHeaders",
+                "returns": [
+                    { "name": "headers", "type": "array", "items": { "$ref": "ProfileHeader"} }
+                ]
+            },
+            {
+                "name": "getProfile",
+                "parameters": [
+                    { "name": "type", "type": "string" },
+                    { "name": "uid", "type": "integer" }
+                ],
+                "returns": [
+                    { "name": "profile", "$ref": "Profile" }
+                ]
+            },
+            {
+                "name": "removeProfile",
+                "parameters": [
+                    { "name": "type", "type": "string" },
+                    { "name": "uid", "type": "integer" }
+                ]
+            },
+            {
+                "name": "clearProfiles"
+            },
+            {
+                "name": "takeHeapSnapshot"
+            },
+            {
+                "name": "collectGarbage"
+            },
+            {
+                "name": "getObjectByHeapObjectId",
+                "parameters": [
+                    { "name": "objectId", "type": "integer" }
+                ],
+                "returns": [
+                    { "name": "result", "$ref": "Runtime.RemoteObject", "description": "Evaluation result." }
+                ]
+            }
+        ],
+        "events": [
+            {
+                "name": "addProfileHeader",
+                "parameters": [
+                    { "name": "header", "$ref": "ProfileHeader" }
+                ]
+            },
+            {
+                "name": "addHeapSnapshotChunk",
+                "parameters": [
+                    { "name": "uid", "type": "integer" },
+                    { "name": "chunk", "type": "string" }
+                ]
+            },
+            {
+                "name": "finishHeapSnapshot",
+                "parameters": [
+                    { "name": "uid", "type": "integer" }
+                ]
+            },
+            {
+                "name": "setRecordingProfile",
+                "parameters": [
+                    { "name": "isProfiling", "type": "boolean" }
+                ]
+            },
+            {
+                "name": "resetProfiles"
+            },
+            {
+                "name": "reportHeapSnapshotProgress",
+                "parameters": [
+                    { "name": "done", "type": "integer" },
+                    { "name": "total", "type": "integer" }
+                ]
+            }
+        ]
+    },
+    {
+        "domain": "Worker",
+        "hidden": true,
+        "types": [],
+        "commands": [
+            {
+                "name": "setWorkerInspectionEnabled",
+                "parameters": [
+                    { "name": "value", "type": "boolean" }
+                ]
+            },
+            {
+                "name": "sendMessageToWorker",
+                "parameters": [
+                    { "name": "workerId", "type": "integer" },
+                    { "name": "message", "type": "object" }
+                ]
+            },
+            {
+                "name": "connectToWorker",
+                "parameters": [
+                    { "name": "workerId", "type": "integer" }
+                ]
+            },
+            {
+                "name": "disconnectFromWorker",
+                "parameters": [
+                    { "name": "workerId", "type": "integer" }
+                ]
+            },
+            {
+                "name": "setAutoconnectToWorkers",
+                "parameters": [
+                    { "name": "value", "type": "boolean" }
+                ]
+            }
+        ],
+        "events": [
+            {
+                "name": "workerCreated",
+                "parameters": [
+                    { "name": "workerId", "type": "integer" },
+                    { "name": "url", "type": "string" },
+                    { "name": "inspectorConnected", "type": "boolean" }
+                ]
+            },
+            {
+                "name": "workerTerminated",
+                "parameters": [
+                    { "name": "workerId", "type": "integer" }
+                ]
+            },
+            {
+                "name": "dispatchMessageFromWorker",
+                "parameters": [
+                    { "name": "workerId", "type": "integer" },
+                    { "name": "message", "type": "object" }
+                ]
+            },
+            {
+                "name": "disconnectedFromWorker"
+            }
+        ]
+    }]
+}

--- a/source/ProtocolGenerator/Inspector-1.1.json
+++ b/source/ProtocolGenerator/Inspector-1.1.json
@@ -1,0 +1,3981 @@
+{
+    "version": { "major": "1", "minor": "1" },
+    "domains": [{
+        "domain": "Inspector",
+        "hidden": true,
+        "types": [],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables inspector domain notifications."
+            },
+            {
+                "name": "disable",
+                "description": "Disables inspector domain notifications."
+            },
+            {
+                "name": "reset",
+                "description": "Resets all domains."
+            }
+        ],
+        "events": [
+            {
+                "name": "evaluateForTestInFrontend",
+                "parameters": [
+                    { "name": "testCallId", "type": "integer" },
+                    { "name": "script", "type": "string" }
+                ]
+            },
+            {
+                "name": "inspect",
+                "parameters": [
+                    { "name": "object", "$ref": "Runtime.RemoteObject" },
+                    { "name": "hints", "type": "object" }
+                ]
+            },
+            {
+                "name": "detached",
+                "description": "Fired when remote debugging connection is about to be terminated. Contains detach reason.",
+                "parameters": [
+                    { "name": "reason", "type": "string", "description": "The reason why connection has been terminated." }
+                ]
+            },
+            {
+                "name": "targetCrashed",
+                "description": "Fired when debugging target has crashed"
+            }
+        ]
+    },
+    {
+        "domain": "Memory",
+        "hidden": true,
+        "types": [
+            {
+                "id": "MemoryBlock",
+                "type": "object",
+                "properties": [
+                    { "name": "size", "type": "number", "optional": true, "description": "Size of the block in bytes if available" },
+                    { "name": "name", "type": "string", "description": "Unique name used to identify the component that allocated this block" },
+                    { "name": "children", "type": "array", "optional": true, "items": { "$ref": "MemoryBlock" }}
+                ]
+            },
+            {
+                "id": "HeapSnapshotChunk",
+                "type": "object",
+                "properties": [
+                    { "name": "strings", "type": "array", "items": { "type": "string" }, "description": "An array of strings that were found since last update." },
+                    { "name": "nodes", "type": "array", "items": { "type": "integer" }, "description": "An array of nodes that were found since last update." },
+                    { "name": "edges", "type": "array", "items": { "type": "integer" }, "description": "An array of edges that were found since last update." },
+                    { "name": "baseToRealNodeId", "type": "array", "items": { "type": "integer" }, "description": "An array of integers for nodeId remapping. Even nodeId has to be mapped to the following odd nodeId." }
+                ]
+            }
+        ],
+        "commands": [
+            {
+                "name": "getDOMCounters",
+                "returns": [
+                    { "name": "documents", "type": "integer" },
+                    { "name": "nodes", "type": "integer" },
+                    { "name": "jsEventListeners", "type": "integer" }
+                ]
+            }
+        ],
+        "events": [
+            {
+                "name": "addNativeSnapshotChunk",
+                "parameters": [
+                    { "name": "chunk", "$ref": "HeapSnapshotChunk", "description": "A chunk of the serialized the snapshot." }
+                ]
+            }
+        ]
+    },
+    {
+        "domain": "Page",
+        "description": "Actions and events related to the inspected page belong to the page domain.",
+        "types": [
+            {
+                "id": "ResourceType",
+                "type": "string",
+                "enum": ["Document", "Stylesheet", "Image", "Font", "Script", "XHR", "WebSocket", "Other"],
+                "description": "Resource type as it was perceived by the rendering engine."
+            },
+            {
+              "id": "FrameId",
+              "type": "string",
+              "description": "Unique frame identifier."
+            },
+            {
+                "id": "Frame",
+                "type": "object",
+                "description": "Information about the Frame on the page.",
+                "properties": [
+                    { "name": "id", "type": "string", "description": "Frame unique identifier." },
+                    { "name": "parentId", "type": "string", "optional": true, "description": "Parent frame identifier." },
+                    { "name": "loaderId", "$ref": "Network.LoaderId", "description": "Identifier of the loader associated with this frame." },
+                    { "name": "name", "type": "string", "optional": true, "description": "Frame's name as specified in the tag." },
+                    { "name": "url", "type": "string", "description": "Frame document's URL." },
+                    { "name": "securityOrigin", "type": "string", "description": "Frame document's security origin." },
+                    { "name": "mimeType", "type": "string", "description": "Frame document's mimeType as determined by the browser." }
+                ]
+            },
+            {
+                "id": "FrameResourceTree",
+                "type": "object",
+                "description": "Information about the Frame hierarchy along with their cached resources.",
+                "properties": [
+                    { "name": "frame", "$ref": "Frame", "description": "Frame information for this tree item." },
+                    { "name": "childFrames", "type": "array", "optional": true, "items": { "$ref": "FrameResourceTree" }, "description": "Child frames." },
+                    { "name": "resources", "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": [
+                                { "name": "url", "type": "string", "description": "Resource URL." },
+                                { "name": "type", "$ref": "ResourceType", "description": "Type of this resource." },
+                                { "name": "mimeType", "type": "string", "description": "Resource mimeType as determined by the browser." },
+                                { "name": "failed", "type": "boolean", "optional": true, "description": "True if the resource failed to load." },
+                                { "name": "canceled", "type": "boolean", "optional": true, "description": "True if the resource was canceled during loading." }
+                            ]
+                        },
+                        "description": "Information about frame resources."
+                    }
+                ],
+                "hidden": true
+            },
+            {
+                "id": "SearchMatch",
+                "type": "object",
+                "description": "Search match for resource.",
+                "properties": [
+                    { "name": "lineNumber", "type": "number", "description": "Line number in resource content." },
+                    { "name": "lineContent", "type": "string", "description": "Line with match content." }
+                ],
+                "hidden": true
+            },
+            {
+                "id": "SearchResult",
+                "type": "object",
+                "description": "Search result for resource.",
+                "properties": [
+                    { "name": "url", "type": "string", "description": "Resource URL." },
+                    { "name": "frameId", "$ref": "FrameId", "description": "Resource frame id." },
+                    { "name": "matchesCount", "type": "number", "description": "Number of matches in the resource content." }
+                ],
+                "hidden": true
+            },
+            {
+                "id": "Cookie",
+                "type": "object",
+                "description": "Cookie object",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "Cookie name." },
+                    { "name": "value", "type": "string", "description": "Cookie value." },
+                    { "name": "domain", "type": "string", "description": "Cookie domain." },
+                    { "name": "path", "type": "string", "description": "Cookie path." },
+                    { "name": "expires", "type": "number", "description": "Cookie expires." },
+                    { "name": "size", "type": "integer", "description": "Cookie size." },
+                    { "name": "httpOnly", "type": "boolean", "description": "True if cookie is http-only." },
+                    { "name": "secure", "type": "boolean", "description": "True if cookie is secure." },
+                    { "name": "session", "type": "boolean", "description": "True in case of session cookie." }
+                ],
+                "hidden": true
+            },
+            {
+                "id": "ScriptIdentifier",
+                "type": "string",
+                "description": "Unique script identifier.",
+                "hidden": true
+            },
+            {
+                "id": "NavigationEntry",
+                "type": "object",
+                "description": "Navigation history entry.",
+                "properties": [
+                  { "name": "id", "type": "integer", "description": "Unique id of the navigation history entry." },
+                  { "name": "url", "type": "string", "description": "URL of the navigation history entry." },
+                  { "name": "title", "type": "string", "description": "Title of the navigation history entry." }
+                ],
+                "hidden": true
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables page domain notifications."
+            },
+            {
+                "name": "disable",
+                "description": "Disables page domain notifications."
+            },
+            {
+                "name": "addScriptToEvaluateOnLoad",
+                "parameters": [
+                    { "name": "scriptSource", "type": "string" }
+                ],
+                "returns": [
+                    { "name": "identifier", "$ref": "ScriptIdentifier", "description": "Identifier of the added script." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "removeScriptToEvaluateOnLoad",
+                "parameters": [
+                    { "name": "identifier", "$ref": "ScriptIdentifier" }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "reload",
+                "parameters": [
+                    { "name": "ignoreCache", "type": "boolean", "optional": true, "description": "If true, browser cache is ignored (as if the user pressed Shift+refresh)." },
+                    { "name": "scriptToEvaluateOnLoad", "type": "string", "optional": true, "description": "If set, the script will be injected into all frames of the inspected page after reload." },
+                    { "name": "scriptPreprocessor", "type": "string", "optional": true, "description": "Script body that should evaluate to function that will preprocess all the scripts before their compilation.", "hidden": true }
+                ],
+                "description": "Reloads given page optionally ignoring the cache."
+            },
+            {
+                "name": "navigate",
+                "parameters": [
+                    { "name": "url", "type": "string", "description": "URL to navigate the page to." }
+                ],
+                "description": "Navigates current page to the given URL."
+            },
+            {
+              "name": "getNavigationHistory",
+              "parameters": [],
+              "returns": [
+                { "name": "currentIndex", "type": "integer", "description": "Index of the current navigation history entry." },
+                { "name": "entries", "type": "array", "items": { "$ref": "NavigationEntry"}, "description": "Array of navigation history entries." }
+              ],
+              "description": "Returns navigation history for the current page.",
+              "hidden": true
+            },
+            {
+              "name": "navigateToHistoryEntry",
+              "parameters": [
+                  { "name": "entryId", "type": "integer", "description": "Unique id of the entry to navigate to." }
+              ],
+              "description": "Navigates current page to the given history entry.",
+              "hidden": true
+            },
+            {
+                "name": "getCookies",
+                "returns": [
+                    { "name": "cookies", "type": "array", "items": { "$ref": "Cookie"}, "description": "Array of cookie objects." },
+                    { "name": "cookiesString", "type": "string", "description": "document.cookie string representation of the cookies." }
+                ],
+                "description": "Returns all browser cookies. Depending on the backend support, will either return detailed cookie information in the <code>cookie</code> field or string cookie representation using <code>cookieString</code>.",
+                "hidden": true
+            },
+            {
+                "name": "deleteCookie",
+                "parameters": [
+                    { "name": "cookieName", "type": "string", "description": "Name of the cookie to remove." },
+                    { "name": "url", "type": "string", "description": "URL to match cooke domain and path." }
+                ],
+                "description": "Deletes browser cookie with given name, domain and path.",
+                "hidden": true
+            },
+            {
+                "name": "getResourceTree",
+                "description": "Returns present frame / resource tree structure.",
+                "returns": [
+                    { "name": "frameTree", "$ref": "FrameResourceTree", "description": "Present frame / resource tree structure." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "getResourceContent",
+                "description": "Returns content of the given resource.",
+                "parameters": [
+                    { "name": "frameId", "$ref": "FrameId", "description": "Frame id to get resource for." },
+                    { "name": "url", "type": "string", "description": "URL of the resource to get content for." }
+                ],
+                "returns": [
+                    { "name": "content", "type": "string", "description": "Resource content." },
+                    { "name": "base64Encoded", "type": "boolean", "description": "True, if content was served as base64." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "searchInResource",
+                "description": "Searches for given string in resource content.",
+                "parameters": [
+                    { "name": "frameId", "$ref": "FrameId", "description": "Frame id for resource to search in." },
+                    { "name": "url", "type": "string", "description": "URL of the resource to search in." },
+                    { "name": "query", "type": "string", "description": "String to search for."  },
+                    { "name": "caseSensitive", "type": "boolean", "optional": true, "description": "If true, search is case sensitive." },
+                    { "name": "isRegex", "type": "boolean", "optional": true, "description": "If true, treats string parameter as regex." }
+                ],
+                "returns": [
+                    { "name": "result", "type": "array", "items": { "$ref": "SearchMatch" }, "description": "List of search matches." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "searchInResources",
+                "description": "Searches for given string in frame / resource tree structure.",
+                "parameters": [
+                    { "name": "text", "type": "string", "description": "String to search for."  },
+                    { "name": "caseSensitive", "type": "boolean", "optional": true, "description": "If true, search is case sensitive." },
+                    { "name": "isRegex", "type": "boolean", "optional": true, "description": "If true, treats string parameter as regex." }
+                ],
+                "returns": [
+                    { "name": "result", "type": "array", "items": { "$ref": "SearchResult" }, "description": "List of search results." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "setDocumentContent",
+                "description": "Sets given markup as the document's HTML.",
+                "parameters": [
+                    { "name": "frameId", "$ref": "FrameId", "description": "Frame id to set HTML for." },
+                    { "name": "html", "type": "string", "description": "HTML content to set."  }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "setDeviceMetricsOverride",
+                "description": "Overrides the values of device screen dimensions (window.screen.width, window.screen.height, window.innerWidth, window.innerHeight, and \"device-width\"/\"device-height\"-related CSS media query results) and the font scale factor.",
+                "parameters": [
+                    { "name": "width", "type": "integer", "description": "Overriding width value in pixels (minimum 0, maximum 10000000). 0 disables the override." },
+                    { "name": "height", "type": "integer", "description": "Overriding height value in pixels (minimum 0, maximum 10000000). 0 disables the override." },
+                    { "name": "fontScaleFactor", "type": "number", "description": "Overriding font scale factor value (must be positive). 1 disables the override." },
+                    { "name": "fitWindow", "type": "boolean", "description": "Whether a view that exceeds the available browser window area should be scaled down to fit." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "setShowPaintRects",
+                "description": "Requests that backend shows paint rectangles",
+                "parameters": [
+                    { "name": "result", "type": "boolean", "description": "True for showing paint rectangles" }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "setShowDebugBorders",
+                "description": "Requests that backend shows debug borders on layers",
+                "parameters": [
+                    { "name": "show", "type": "boolean", "description": "True for showing debug borders" }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "setShowFPSCounter",
+                "description": "Requests that backend shows the FPS counter",
+                "parameters": [
+                    { "name": "show", "type": "boolean", "description": "True for showing the FPS counter" }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "setContinuousPaintingEnabled",
+                "description": "Requests that backend enables continuous painting",
+                "parameters": [
+                    { "name": "enabled", "type": "boolean", "description": "True for enabling cointinuous painting" }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "setShowScrollBottleneckRects",
+                "description": "Requests that backend shows scroll bottleneck rects",
+                "parameters": [
+                    { "name": "show", "type": "boolean", "description": "True for showing scroll bottleneck rects" }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "getScriptExecutionStatus",
+                "description": "Determines if scripts can be executed in the page.",
+                "returns": [
+                    { "name": "result", "type": "string", "enum": ["allowed", "disabled", "forbidden"], "description": "Script execution status: \"allowed\" if scripts can be executed, \"disabled\" if script execution has been disabled through page settings, \"forbidden\" if script execution for the given page is not possible for other reasons." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "setScriptExecutionDisabled",
+                "description": "Switches script execution in the page.",
+                "parameters": [
+                    { "name": "value", "type": "boolean", "description": "Whether script execution should be disabled in the page." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "setGeolocationOverride",
+                "description": "Overrides the Geolocation Position or Error.",
+                "parameters": [
+                    { "name": "latitude", "type": "number", "optional": true, "description": "Mock longitude"},
+                    { "name": "longitude", "type": "number", "optional": true, "description": "Mock latitude"},
+                    { "name": "accuracy", "type": "number", "optional": true, "description": "Mock accuracy"}
+                ]
+            },
+            {
+                "name": "clearGeolocationOverride",
+                "description": "Clears the overriden Geolocation Position and Error."
+            },
+            {
+                "name": "setDeviceOrientationOverride",
+                "description": "Overrides the Device Orientation.",
+                "parameters": [
+                    { "name": "alpha", "type": "number", "description": "Mock alpha"},
+                    { "name": "beta", "type": "number", "description": "Mock beta"},
+                    { "name": "gamma", "type": "number", "description": "Mock gamma"}
+                ],
+                "hidden": true
+            },
+            {
+                "name": "clearDeviceOrientationOverride",
+                "description": "Clears the overridden Device Orientation.",
+                "hidden": true
+            },
+            {
+                "name": "setTouchEmulationEnabled",
+                "parameters": [
+                    { "name": "enabled", "type": "boolean", "description": "Whether the touch event emulation should be enabled." }
+                ],
+                "description": "Toggles mouse event-based touch event emulation.",
+                "hidden": true
+            },
+            {
+                "name": "setEmulatedMedia",
+                "parameters": [
+                    { "name": "media", "type": "string", "description": "Media type to emulate. Empty string disables the override." }
+                ],
+                "description": "Emulates the given media for CSS media queries.",
+                "hidden": true
+            },
+            {
+                "name": "captureScreenshot",
+                "description": "Capture page screenshot.",
+                "parameters": [
+                    { "name": "format", "type": "string", "optional": true, "enum": ["jpeg", "png"], "description": "Image compression format." },
+                    { "name": "quality", "type": "integer", "hidden": true, "optional": true, "description": "Compression quality from range [0..100]." },
+                    { "name": "maxWidth", "type": "integer", "hidden": true, "optional": true, "description": "Maximum screenshot width." },
+                    { "name": "maxHeight", "type": "integer", "hidden": true, "optional": true, "description": "Maximum screenshot height." }
+                ],
+                "returns": [
+                    { "name": "data", "type": "string", "description": "Base64-encoded image data (PNG)." },
+                    { "name": "deviceScaleFactor", "type": "number", "hidden": true, "description": "Device scale factor." },
+                    { "name": "pageScaleFactor", "type": "number", "hidden": true, "description": "Page scale factor." },
+                    { "name": "viewport", "$ref": "DOM.Rect", "hidden": true, "description": "Viewport in CSS pixels." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "startScreencast",
+                "description": "Starts sending each frame using the <code>screencastFrame</code> event.",
+                "parameters": [
+                    { "name": "format", "type": "string", "optional": true, "enum": ["jpeg", "png"], "description": "Image compression format." },
+                    { "name": "quality", "type": "integer", "optional": true, "description": "Compression quality from range [0..100]." },
+                    { "name": "maxWidth", "type": "integer", "optional": true, "description": "Maximum screenshot width." },
+                    { "name": "maxHeight", "type": "integer", "optional": true, "description": "Maximum screenshot height." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "stopScreencast",
+                "description": "Stops sending each frame in the <code>screencastFrame</code>.",
+                "hidden": true
+            },
+            {
+                "name": "handleJavaScriptDialog",
+                "description": "Accepts or dismisses a JavaScript initiated dialog (alert, confirm, prompt, or onbeforeunload).",
+                "parameters": [
+                    { "name": "accept", "type": "boolean", "description": "Whether to accept or dismiss the dialog." },
+                    { "name": "promptText", "type": "string", "optional": true, "description": "The text to enter into the dialog prompt before accepting. Used only if this is a prompt dialog." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "setShowViewportSizeOnResize",
+                "description": "Paints viewport size upon main frame resize.",
+                "parameters": [
+                    { "name": "show", "type": "boolean", "description": "Whether to paint size or not." },
+                    { "name": "showGrid", "type": "boolean", "optional": true, "description": "Whether to paint grid as well." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "setForceCompositingMode",
+                "description": "Force accelerated compositing mode for inspected page.",
+                "parameters": [
+                    { "name": "force", "type": "boolean", "description": "Whether to force accelerated compositing or not." }
+                ],
+                "hidden": true
+            }
+        ],
+        "events": [
+            {
+                "name": "domContentEventFired",
+                "parameters": [
+                    { "name": "timestamp", "type": "number" }
+                ]
+            },
+            {
+                "name": "loadEventFired",
+                "parameters": [
+                    { "name": "timestamp", "type": "number" }
+                ]
+            },
+            {
+                "name": "frameAttached",
+                "description": "Fired when frame has been attached to its parent.",
+                "parameters": [
+                    { "name": "frameId", "$ref": "FrameId", "description": "Id of the frame that has been attached." }
+                ]
+            },
+            {
+                "name": "frameNavigated",
+                "description": "Fired once navigation of the frame has completed. Frame is now associated with the new loader.",
+                "parameters": [
+                    { "name": "frame", "$ref": "Frame", "description": "Frame object." }
+                ]
+            },
+            {
+                "name": "frameDetached",
+                "description": "Fired when frame has been detached from its parent.",
+                "parameters": [
+                    { "name": "frameId", "$ref": "FrameId", "description": "Id of the frame that has been detached." }
+                ]
+            },
+            {
+                "name": "frameStartedLoading",
+                "description": "Fired when frame has started loading.",
+                "parameters": [
+                    { "name": "frameId", "$ref": "FrameId", "description": "Id of the frame that has started loading." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "frameStoppedLoading",
+                "description": "Fired when frame has stopped loading.",
+                "parameters": [
+                    { "name": "frameId", "$ref": "FrameId", "description": "Id of the frame that has stopped loading." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "frameScheduledNavigation",
+                "description": "Fired when frame schedules a potential navigation.",
+                "parameters": [
+                    { "name": "frameId", "$ref": "FrameId", "description": "Id of the frame that has scheduled a navigation." },
+                    { "name": "delay", "type": "number", "description": "Delay (in seconds) until the navigation is scheduled to begin. The navigation is not guaranteed to start." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "frameClearedScheduledNavigation",
+                "description": "Fired when frame no longer has a scheduled navigation.",
+                "parameters": [
+                    { "name": "frameId", "$ref": "FrameId", "description": "Id of the frame that has cleared its scheduled navigation." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "javascriptDialogOpening",
+                "description": "Fired when a JavaScript initiated dialog (alert, confirm, prompt, or onbeforeunload) is about to open.",
+                "parameters": [
+                    { "name": "message", "type": "string", "description": "Message that will be displayed by the dialog." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "javascriptDialogClosed",
+                "description": "Fired when a JavaScript initiated dialog (alert, confirm, prompt, or onbeforeunload) has been closed.",
+                "hidden": true
+            },
+            {
+                "name": "scriptsEnabled",
+                "description": "Fired when the JavaScript is enabled/disabled on the page",
+                "parameters": [
+                    { "name": "isEnabled", "type": "boolean", "description": "Whether script execution is enabled or disabled on the page." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "screencastFrame",
+                "description": "Compressed image data requested by the <code>startScreencast</code>.",
+                "parameters": [
+                    { "name": "data", "type": "string", "description": "Base64-encoded compressed image." },
+                    { "name": "deviceScaleFactor", "type": "number", "hidden": true, "optional": true, "description": "Device scale factor." },
+                    { "name": "pageScaleFactor", "type": "number", "hidden": true, "optional": true, "description": "Page scale factor." },
+                    { "name": "viewport", "$ref": "DOM.Rect", "hidden": true, "optional": true, "description": "Viewport in CSS pixels." },
+                    { "name": "offsetTop", "type": "number", "hidden": true, "optional": true, "description": "Top offset in DIP." },
+                    { "name": "offsetBottom", "type": "number", "hidden": true, "optional": true, "description": "Bottom offset in DIP." }
+                ],
+                "hidden": true
+            }
+        ]
+    },
+    {
+        "domain": "Runtime",
+        "description": "Runtime domain exposes JavaScript runtime by means of remote evaluation and mirror objects. Evaluation results are returned as mirror object that expose object type, string representation and unique identifier that can be used for further object reference. Original objects are maintained in memory unless they are either explicitly released or are released along with the other objects in their object group.",
+        "types": [
+            {
+                "id": "RemoteObjectId",
+                "type": "string",
+                "description": "Unique object identifier."
+            },
+            {
+                "id": "RemoteObject",
+                "type": "object",
+                "description": "Mirror object referencing original JavaScript object.",
+                "properties": [
+                    { "name": "type", "type": "string", "enum": ["object", "function", "undefined", "string", "number", "boolean"], "description": "Object type." },
+                    { "name": "subtype", "type": "string", "optional": true, "enum": ["array", "null", "node", "regexp", "date"], "description": "Object subtype hint. Specified for <code>object</code> type values only." },
+                    { "name": "className", "type": "string", "optional": true, "description": "Object class (constructor) name. Specified for <code>object</code> type values only." },
+                    { "name": "value", "type": "any", "optional": true, "description": "Remote object value (in case of primitive values or JSON values if it was requested)." },
+                    { "name": "description", "type": "string", "optional": true, "description": "String representation of the object." },
+                    { "name": "objectId", "$ref": "RemoteObjectId", "optional": true, "description": "Unique object identifier (for non-primitive values)." },
+                    { "name": "preview", "$ref": "ObjectPreview", "optional": true, "description": "Preview containing abbreviated property values.", "hidden": true }
+                ]
+            },
+            {
+                "id": "ObjectPreview",
+                "type": "object",
+                "hidden": true,
+                "description": "Object containing abbreviated remote object value.",
+                "properties": [
+                    { "name": "lossless", "type": "boolean", "description": "Determines whether preview is lossless (contains all information of the original object)." },
+                    { "name": "overflow", "type": "boolean", "description": "True iff some of the properties of the original did not fit." },
+                    { "name": "properties", "type": "array", "items": { "$ref": "PropertyPreview" }, "description": "List of the properties." }
+                ]
+            },
+            {
+                "id": "PropertyPreview",
+                "type": "object",
+                "hidden": true,
+                "properties": [
+                    { "name": "name", "type": "string", "description": "Property name." },
+	                { "name": "type", "type": "string", "enum": ["object", "function", "undefined", "string", "number", "boolean"], "description": "Object type." },
+	                { "name": "value", "type": "string", "optional": true, "description": "User-friendly property value string." },
+	                { "name": "valuePreview", "$ref": "ObjectPreview", "optional": true, "description": "Nested value preview." },
+	                { "name": "subtype", "type": "string", "optional": true, "enum": ["array", "null", "node", "regexp", "date"], "description": "Object subtype hint. Specified for <code>object</code> type values only." }
+                ]
+            },
+            {
+                "id": "PropertyDescriptor",
+                "type": "object",
+                "description": "Object property descriptor.",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "Property name." },
+                    { "name": "value", "$ref": "RemoteObject", "optional": true, "description": "The value associated with the property." },
+                    { "name": "writable", "type": "boolean", "optional": true, "description": "True if the value associated with the property may be changed (data descriptors only)." },
+                    { "name": "get", "$ref": "RemoteObject", "optional": true, "description": "A function which serves as a getter for the property, or <code>undefined</code> if there is no getter (accessor descriptors only)." },
+                    { "name": "set", "$ref": "RemoteObject", "optional": true, "description": "A function which serves as a setter for the property, or <code>undefined</code> if there is no setter (accessor descriptors only)." },
+                    { "name": "configurable", "type": "boolean", "description": "True if the type of this property descriptor may be changed and if the property may be deleted from the corresponding object." },
+                    { "name": "enumerable", "type": "boolean", "description": "True if this property shows up during enumeration of the properties on the corresponding object." },
+                    { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." },
+                    { "name": "isOwn", "optional": true, "type": "boolean", "description": "True if the property is owned for the object.", "hidden": true }
+
+                ]
+            },
+            {
+                "id": "InternalPropertyDescriptor",
+                "type": "object",
+                "description": "Object internal property descriptor. This property isn't normally visible in JavaScript code.",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "Conventional property name." },
+                    { "name": "value", "$ref": "RemoteObject", "optional": true, "description": "The value associated with the property." }
+                ],
+                "hidden": true
+            },
+            {
+                "id": "CallArgument",
+                "type": "object",
+                "description": "Represents function call argument. Either remote object id <code>objectId</code> or primitive <code>value</code> or neither of (for undefined) them should be specified.",
+                "properties": [
+                    { "name": "value", "type": "any", "optional": true, "description": "Primitive value." },
+                    { "name": "objectId", "$ref": "RemoteObjectId", "optional": true, "description": "Remote object handle." }
+                ]
+            },
+            {
+                "id": "ExecutionContextId",
+                "type": "integer",
+                "description": "Id of an execution context."
+            },
+            {
+                "id": "ExecutionContextDescription",
+                "type": "object",
+                "description": "Description of an isolated world.",
+                "properties": [
+                    { "name": "id", "$ref": "ExecutionContextId", "description": "Unique id of the execution context. It can be used to specify in which execution context script evaluation should be performed." },
+                    { "name": "isPageContext", "type": "boolean", "description": "True if this is a context where inpspected web page scripts run. False if it is a content script isolated context.", "hidden": true },
+                    { "name": "name", "type": "string", "description": "Human readable name describing given context.", "hidden": true},
+                    { "name": "frameId", "$ref": "Page.FrameId", "description": "Id of the owning frame." }
+                ]
+            }
+
+        ],
+        "commands": [
+            {
+                "name": "evaluate",
+                "parameters": [
+                    { "name": "expression", "type": "string", "description": "Expression to evaluate." },
+                    { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." },
+                    { "name": "includeCommandLineAPI", "type": "boolean", "optional": true, "description": "Determines whether Command Line API should be available during the evaluation.", "hidden": true },
+                    { "name": "doNotPauseOnExceptionsAndMuteConsole", "type": "boolean", "optional": true, "description": "Specifies whether evaluation should stop on exceptions and mute console. Overrides setPauseOnException state.", "hidden": true },
+                    { "name": "contextId", "$ref": "Runtime.ExecutionContextId", "optional": true, "description": "Specifies in which isolated context to perform evaluation. Each content script lives in an isolated context and this parameter may be used to specify one of those contexts. If the parameter is omitted or 0 the evaluation will be performed in the context of the inspected page." },
+                    { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object that should be sent by value." },
+                    { "name": "generatePreview", "type": "boolean", "optional": true, "hidden": true, "description": "Whether preview should be generated for the result." }
+                ],
+                "returns": [
+                    { "name": "result", "$ref": "RemoteObject", "description": "Evaluation result." },
+                    { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." }
+                ],
+                "description": "Evaluates expression on global object."
+            },
+            {
+                "name": "callFunctionOn",
+                "parameters": [
+                    { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to call function on." },
+                    { "name": "functionDeclaration", "type": "string", "description": "Declaration of the function to call." },
+                    { "name": "arguments", "type": "array", "items": { "$ref": "CallArgument", "description": "Call argument." }, "optional": true, "description": "Call arguments. All call arguments must belong to the same JavaScript world as the target object." },
+                    { "name": "doNotPauseOnExceptionsAndMuteConsole", "type": "boolean", "optional": true, "description": "Specifies whether function call should stop on exceptions and mute console. Overrides setPauseOnException state.", "hidden": true },
+                    { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object which should be sent by value." },
+                    { "name": "generatePreview", "type": "boolean", "optional": true, "hidden": true, "description": "Whether preview should be generated for the result." }
+                ],
+                "returns": [
+                    { "name": "result", "$ref": "RemoteObject", "description": "Call result." },
+                    { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." }
+                ],
+                "description": "Calls function with given declaration on the given object. Object group of the result is inherited from the target object."
+            },
+            {
+                "name": "getProperties",
+                "parameters": [
+                    { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to return properties for." },
+                    { "name": "ownProperties", "optional": true, "type": "boolean", "description": "If true, returns properties belonging only to the element itself, not to its prototype chain." },
+                    { "name": "accessorPropertiesOnly", "optional": true, "type": "boolean", "description": "If true, returns accessor properties (with getter/setter) only; internal properties are not returned either.", "hidden": true }
+                ],
+                "returns": [
+                    { "name": "result", "type": "array", "items": { "$ref": "PropertyDescriptor"}, "description": "Object properties." },
+                    { "name": "internalProperties", "optional": true, "type": "array", "items": { "$ref": "InternalPropertyDescriptor"}, "description": "Internal object properties (only of the element itself).", "hidden": true }
+                ],
+                "description": "Returns properties of a given object. Object group of the result is inherited from the target object."
+            },
+            {
+                "name": "releaseObject",
+                "parameters": [
+                    { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to release." }
+                ],
+                "description": "Releases remote object with given id."
+            },
+            {
+                "name": "releaseObjectGroup",
+                "parameters": [
+                    { "name": "objectGroup", "type": "string", "description": "Symbolic object group name." }
+                ],
+                "description": "Releases all remote objects that belong to a given group."
+            },
+            {
+                "name": "run",
+                "hidden": true,
+                "description": "Tells inspected instance(worker or page) that it can run in case it was started paused."
+            },
+            {
+                "name": "enable",
+                "description": "Enables reporting of execution contexts creation by means of <code>executionContextCreated</code> event. When the reporting gets enabled the event will be sent immediately for each existing execution context."
+            },
+            {
+                "name": "disable",
+                "hidden": true,
+                "description": "Disables reporting of execution contexts creation."
+            }
+        ],
+        "events": [
+            {
+                "name": "executionContextCreated",
+                "parameters": [
+                    { "name": "context", "$ref": "ExecutionContextDescription", "description": "A newly created execution contex." }
+                ],
+                "description": "Issued when new execution context is created."
+            }
+        ]
+    },
+    {
+        "domain": "Console",
+        "description": "Console domain defines methods and events for interaction with the JavaScript console. Console collects messages created by means of the <a href='http://getfirebug.com/wiki/index.php/Console_API'>JavaScript Console API</a>. One needs to enable this domain using <code>enable</code> command in order to start receiving the console messages. Browser collects messages issued while console domain is not enabled as well and reports them using <code>messageAdded</code> notification upon enabling.",
+        "types": [
+            {
+                "id": "Timestamp",
+                "type": "number",
+                "description": "Number of seconds since epoch.",
+                "hidden": true
+            },
+            {
+                "id": "ConsoleMessage",
+                "type": "object",
+                "description": "Console message.",
+                "properties": [
+                    { "name": "source", "type": "string", "enum": ["xml", "javascript", "network", "console-api", "storage", "appcache", "rendering", "css", "security", "other", "deprecation"], "description": "Message source." },
+                    { "name": "level", "type": "string", "enum": ["log", "warning", "error", "debug"], "description": "Message severity." },
+                    { "name": "text", "type": "string", "description": "Message text." },
+                    { "name": "type", "type": "string", "optional": true, "enum": ["log", "dir", "dirxml", "table", "trace", "clear", "startGroup", "startGroupCollapsed", "endGroup", "assert", "timing", "profile", "profileEnd"], "description": "Console message type." },
+                    { "name": "url", "type": "string", "optional": true, "description": "URL of the message origin." },
+                    { "name": "line", "type": "integer", "optional": true, "description": "Line number in the resource that generated this message." },
+                    { "name": "column", "type": "integer", "optional": true, "description": "Column number in the resource that generated this message." },
+                    { "name": "repeatCount", "type": "integer", "optional": true, "description": "Repeat count for repeated messages." },
+                    { "name": "parameters", "type": "array", "items": { "$ref": "Runtime.RemoteObject" }, "optional": true, "description": "Message parameters in case of the formatted message." },
+                    { "name": "stackTrace", "$ref": "StackTrace", "optional": true, "description": "JavaScript stack trace for assertions and error messages." },
+                    { "name": "networkRequestId", "$ref": "Network.RequestId", "optional": true, "description": "Identifier of the network request associated with this message." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp, when this message was fired.", "hidden": true }
+                ]
+            },
+            {
+                "id": "CallFrame",
+                "type": "object",
+                "description": "Stack entry for console errors and assertions.",
+                "properties": [
+                    { "name": "functionName", "type": "string", "description": "JavaScript function name." },
+                    { "name": "scriptId", "type": "string", "description": "JavaScript script id." },
+                    { "name": "url", "type": "string", "description": "JavaScript script name or url." },
+                    { "name": "lineNumber", "type": "integer", "description": "JavaScript script line number." },
+                    { "name": "columnNumber", "type": "integer", "description": "JavaScript script column number." }
+                ]
+            },
+            {
+                "id": "StackTrace",
+                "type": "array",
+                "items": { "$ref": "CallFrame" },
+                "description": "Call frames for assertions or error messages."
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables console domain, sends the messages collected so far to the client by means of the <code>messageAdded</code> notification."
+            },
+            {
+                "name": "disable",
+                "description": "Disables console domain, prevents further console messages from being reported to the client."
+            },
+            {
+                "name": "clearMessages",
+                "description": "Clears console messages collected in the browser."
+            },
+            {
+                "name": "setMonitoringXHREnabled",
+                "parameters": [
+                    { "name": "enabled", "type": "boolean", "description": "Monitoring enabled state." }
+                ],
+                "description": "Toggles monitoring of XMLHttpRequest. If <code>true</code>, console will receive messages upon each XHR issued.",
+                "hidden": true
+            },
+            {
+                "name": "addInspectedNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId", "description": "DOM node id to be accessible by means of $x command line API." }
+                ],
+                "description": "Enables console to refer to the node with given id via $x (see Command Line API for more details $x functions).",
+                "hidden": true
+            },
+            {
+                "name": "addInspectedHeapObject",
+                "parameters": [
+                    { "name": "heapObjectId", "type": "integer" }
+                ],
+                "hidden": true
+            }
+        ],
+        "events": [
+            {
+                "name": "messageAdded",
+                "parameters": [
+                    { "name": "message", "$ref": "ConsoleMessage", "description": "Console message that has been added." }
+                ],
+                "description": "Issued when new console message is added."
+            },
+            {
+                "name": "messageRepeatCountUpdated",
+                "parameters": [
+                    { "name": "count", "type": "integer", "description": "New repeat count value." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp of most recent message in batch.", "hidden": true }
+                ],
+                "description": "Issued when subsequent message(s) are equal to the previous one(s)."
+            },
+            {
+                "name": "messagesCleared",
+                "description": "Issued when console is cleared. This happens either upon <code>clearMessages</code> command or after page navigation."
+            }
+        ]
+    },
+    {
+        "domain": "Network",
+        "description": "Network domain allows tracking network activities of the page. It exposes information about http, file, data and other requests and responses, their headers, bodies, timing, etc.",
+        "types": [
+            {
+                "id": "LoaderId",
+                "type": "string",
+                "description": "Unique loader identifier."
+            },
+            {
+                "id": "RequestId",
+                "type": "string",
+                "description": "Unique request identifier."
+            },
+            {
+                "id": "Timestamp",
+                "type": "number",
+                "description": "Number of seconds since epoch."
+            },
+            {
+                "id": "Headers",
+                "type": "object",
+                "description": "Request / response headers as keys / values of JSON object."
+            },
+            {
+                "id": "ResourceTiming",
+                "type": "object",
+                "description": "Timing information for the request.",
+                "properties": [
+                    { "name": "requestTime", "type": "number", "description": "Timing's requestTime is a baseline in seconds, while the other numbers are ticks in milliseconds relatively to this requestTime." },
+                    { "name": "proxyStart", "type": "number", "description": "Started resolving proxy." },
+                    { "name": "proxyEnd", "type": "number", "description": "Finished resolving proxy." },
+                    { "name": "dnsStart", "type": "number", "description": "Started DNS address resolve." },
+                    { "name": "dnsEnd", "type": "number", "description": "Finished DNS address resolve." },
+                    { "name": "connectStart", "type": "number", "description": "Started connecting to the remote host." },
+                    { "name": "connectEnd", "type": "number", "description": "Connected to the remote host." },
+                    { "name": "sslStart", "type": "number", "description": "Started SSL handshake." },
+                    { "name": "sslEnd", "type": "number", "description": "Finished SSL handshake." },
+                    { "name": "sendStart", "type": "number", "description": "Started sending request." },
+                    { "name": "sendEnd", "type": "number", "description": "Finished sending request." },
+                    { "name": "receiveHeadersEnd", "type": "number", "description": "Finished receiving response headers." }
+                ]
+            },
+            {
+                "id": "Request",
+                "type": "object",
+                "description": "HTTP request data.",
+                "properties": [
+                    { "name": "url", "type": "string", "description": "Request URL." },
+                    { "name": "method", "type": "string", "description": "HTTP request method." },
+                    { "name": "headers", "$ref": "Headers", "description": "HTTP request headers." },
+                    { "name": "postData", "type": "string", "optional": true, "description": "HTTP POST request data." }
+                ]
+            },
+            {
+                "id": "Response",
+                "type": "object",
+                "description": "HTTP response data.",
+                "properties": [
+                    { "name": "url", "type": "string", "description": "Response URL. This URL can be different from CachedResource.url in case of redirect." },
+                    { "name": "status", "type": "number", "description": "HTTP response status code." },
+                    { "name": "statusText", "type": "string", "description": "HTTP response status text." },
+                    { "name": "headers", "$ref": "Headers", "description": "HTTP response headers." },
+                    { "name": "headersText", "type": "string", "optional": true, "description": "HTTP response headers text." },
+                    { "name": "mimeType", "type": "string", "description": "Resource mimeType as determined by the browser." },
+                    { "name": "requestHeaders", "$ref": "Headers", "optional": true, "description": "Refined HTTP request headers that were actually transmitted over the network." },
+                    { "name": "requestHeadersText", "type": "string", "optional": true, "description": "HTTP request headers text." },
+                    { "name": "connectionReused", "type": "boolean", "description": "Specifies whether physical connection was actually reused for this request." },
+                    { "name": "connectionId", "type": "number", "description": "Physical connection id that was actually used for this request." },
+                    { "name": "fromDiskCache", "type": "boolean", "optional": true, "description": "Specifies that the request was served from the disk cache." },
+                    { "name": "timing", "$ref": "ResourceTiming", "optional": true, "description": "Timing information for the given request." }
+                ]
+            },
+            {
+                "id": "WebSocketRequest",
+                "type": "object",
+                "description": "WebSocket request data.",
+                "hidden": true,
+                "properties": [
+                    { "name": "headers", "$ref": "Headers", "description": "HTTP response headers." }
+                ]
+            },
+            {
+                "id": "WebSocketResponse",
+                "type": "object",
+                "description": "WebSocket response data.",
+                "hidden": true,
+                "properties": [
+                    { "name": "status", "type": "number", "description": "HTTP response status code." },
+                    { "name": "statusText", "type": "string", "description": "HTTP response status text." },
+                    { "name": "headers", "$ref": "Headers", "description": "HTTP response headers." }
+                ]
+            },
+            {
+                "id": "WebSocketFrame",
+                "type": "object",
+                "description": "WebSocket frame data.",
+                "hidden": true,
+                "properties": [
+                    { "name": "opcode", "type": "number", "description": "WebSocket frame opcode." },
+                    { "name": "mask", "type": "boolean", "description": "WebSocke frame mask." },
+                    { "name": "payloadData", "type": "string", "description": "WebSocke frame payload data." }
+                ]
+            },
+            {
+                "id": "CachedResource",
+                "type": "object",
+                "description": "Information about the cached resource.",
+                "properties": [
+                    { "name": "url", "type": "string", "description": "Resource URL. This is the url of the original network request." },
+                    { "name": "type", "$ref": "Page.ResourceType", "description": "Type of this resource." },
+                    { "name": "response", "$ref": "Response", "optional": true, "description": "Cached response data." },
+                    { "name": "bodySize", "type": "number", "description": "Cached response body size." }
+                ]
+            },
+            {
+                "id": "Initiator",
+                "type": "object",
+                "description": "Information about the request initiator.",
+                "properties": [
+                    { "name": "type", "type": "string", "enum": ["parser", "script", "other"], "description": "Type of this initiator." },
+                    { "name": "stackTrace", "$ref": "Console.StackTrace", "optional": true, "description": "Initiator JavaScript stack trace, set for Script only." },
+                    { "name": "url", "type": "string", "optional": true, "description": "Initiator URL, set for Parser type only." },
+                    { "name": "lineNumber", "type": "number", "optional": true, "description": "Initiator line number, set for Parser type only." }
+                ]
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables network tracking, network events will now be delivered to the client."
+            },
+            {
+                "name": "disable",
+                "description": "Disables network tracking, prevents network events from being sent to the client."
+            },
+            {
+                "name": "setUserAgentOverride",
+                "description": "Allows overriding user agent with the given string.",
+                "parameters": [
+                    { "name": "userAgent", "type": "string", "description": "User agent to use." }
+                ]
+            },
+            {
+                "name": "setExtraHTTPHeaders",
+                "description": "Specifies whether to always send extra HTTP headers with the requests from this page.",
+                "parameters": [
+                    { "name": "headers", "$ref": "Headers", "description": "Map with extra HTTP headers." }
+                ]
+            },
+            {
+                "name": "getResponseBody",
+                "description": "Returns content served for the given request.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Identifier of the network request to get content for." }
+                ],
+                "returns": [
+                    { "name": "body", "type": "string", "description": "Response body." },
+                    { "name": "base64Encoded", "type": "boolean", "description": "True, if content was sent as base64." }
+                ]
+            },
+            {
+                "name": "replayXHR",
+                "description": "This method sends a new XMLHttpRequest which is identical to the original one. The following parameters should be identical: method, url, async, request body, extra headers, withCredentials attribute, user, password.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Identifier of XHR to replay." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "canClearBrowserCache",
+                "description": "Tells whether clearing browser cache is supported.",
+                "returns": [
+                    { "name": "result", "type": "boolean", "description": "True if browser cache can be cleared." }
+                ]
+            },
+            {
+                "name": "clearBrowserCache",
+                "description": "Clears browser cache."
+            },
+            {
+                "name": "canClearBrowserCookies",
+                "description": "Tells whether clearing browser cookies is supported.",
+                "returns": [
+                    { "name": "result", "type": "boolean", "description": "True if browser cookies can be cleared." }
+                ]
+            },
+            {
+                "name": "clearBrowserCookies",
+                "description": "Clears browser cookies."
+            },
+            {
+                "name": "setCacheDisabled",
+                "parameters": [
+                    { "name": "cacheDisabled", "type": "boolean", "description": "Cache disabled state." }
+                ],
+                "description": "Toggles ignoring cache for each request. If <code>true</code>, cache will not be used."
+            },
+            {
+                "name": "loadResourceForFrontend",
+                "async": true,
+                "parameters": [
+                    { "name": "frameId", "$ref": "Page.FrameId", "description": "Frame to load the resource from." },
+                    { "name": "url", "type": "string", "description": "URL of the resource to load." },
+                    { "name": "requestHeaders", "$ref": "Network.Headers", "optional": true, "description": "Request headers." }
+                ],
+                "returns": [
+                    { "name": "statusCode", "type": "number", "description": "HTTP status code." },
+                    { "name": "responseHeaders", "$ref": "Network.Headers", "description": "Response headers." },
+                    { "name": "content", "type": "string", "description": "Resource content." }
+                ],
+                "description": "Loads a resource in the context of a frame on the inspected page without cross origin checks.",
+                "hidden": true
+            }
+        ],
+        "events": [
+            {
+                "name": "requestWillBeSent",
+                "description": "Fired when page is about to send HTTP request.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "frameId", "$ref": "Page.FrameId", "description": "Frame identifier.", "hidden": true },
+                    { "name": "loaderId", "$ref": "LoaderId", "description": "Loader identifier." },
+                    { "name": "documentURL", "type": "string", "description": "URL of the document this request is loaded for." },
+                    { "name": "request", "$ref": "Request", "description": "Request data." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "initiator", "$ref": "Initiator", "description": "Request initiator." },
+                    { "name": "redirectResponse", "optional": true, "$ref": "Response", "description": "Redirect response data." }
+                ]
+            },
+            {
+                "name": "requestServedFromCache",
+                "description": "Fired if request ended up loading from cache.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." }
+                ]
+            },
+            {
+                "name": "responseReceived",
+                "description": "Fired when HTTP response is available.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "frameId", "$ref": "Page.FrameId", "description": "Frame identifier.", "hidden": true },
+                    { "name": "loaderId", "$ref": "LoaderId", "description": "Loader identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "type", "$ref": "Page.ResourceType", "description": "Resource type." },
+                    { "name": "response", "$ref": "Response", "description": "Response data." }
+                ]
+            },
+            {
+                "name": "dataReceived",
+                "description": "Fired when data chunk was received over the network.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "dataLength", "type": "integer", "description": "Data chunk length." },
+                    { "name": "encodedDataLength", "type": "integer", "description": "Actual bytes received (might be less than dataLength for compressed encodings)." }
+                ]
+            },
+            {
+                "name": "loadingFinished",
+                "description": "Fired when HTTP request has finished loading.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." }
+                ]
+            },
+            {
+                "name": "loadingFailed",
+                "description": "Fired when HTTP request has failed to load.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "errorText", "type": "string", "description": "User friendly error message." },
+                    { "name": "canceled", "type": "boolean", "optional": true, "description": "True if loading was canceled." }
+                ]
+            },
+            {
+                "name": "webSocketWillSendHandshakeRequest",
+                "description": "Fired when WebSocket is about to initiate handshake.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "request", "$ref": "WebSocketRequest", "description": "WebSocket request data." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "webSocketHandshakeResponseReceived",
+                "description": "Fired when WebSocket handshake response becomes available.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "response", "$ref": "WebSocketResponse", "description": "WebSocket response data." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "webSocketCreated",
+                "description": "Fired upon WebSocket creation.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "url", "type": "string", "description": "WebSocket request URL." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "webSocketClosed",
+                "description": "Fired when WebSocket is closed.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "webSocketFrameReceived",
+                "description": "Fired when WebSocket frame is received.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "response", "$ref": "WebSocketFrame", "description": "WebSocket response data." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "webSocketFrameError",
+                "description": "Fired when WebSocket frame error occurs.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "errorMessage", "type": "string", "description": "WebSocket frame error message." }
+                ],
+                "hidden": true
+            },
+            {
+                "name": "webSocketFrameSent",
+                "description": "Fired when WebSocket frame is sent.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "response", "$ref": "WebSocketFrame", "description": "WebSocket response data." }
+                ],
+                "hidden": true
+            }
+        ]
+    },
+    {
+        "domain": "Database",
+        "hidden": true,
+        "types": [
+            {
+                "id": "DatabaseId",
+                "type": "string",
+                "description": "Unique identifier of Database object.",
+                "hidden": true
+            },
+            {
+                "id": "Database",
+                "type": "object",
+                "description": "Database object.",
+                "hidden": true,
+                "properties": [
+                    { "name": "id", "$ref": "DatabaseId", "description": "Database ID." },
+                    { "name": "domain", "type": "string", "description": "Database domain." },
+                    { "name": "name", "type": "string", "description": "Database name." },
+                    { "name": "version", "type": "string", "description": "Database version." }
+                ]
+            },
+            {
+                "id": "Error",
+                "type": "object",
+                "description": "Database error.",
+                "properties": [
+                    { "name": "message", "type": "string", "description": "Error message." },
+                    { "name": "code", "type": "integer", "description": "Error code." }
+                ]
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables database tracking, database events will now be delivered to the client."
+            },
+            {
+                "name": "disable",
+                "description": "Disables database tracking, prevents database events from being sent to the client."
+            },
+            {
+                "name": "getDatabaseTableNames",
+                "parameters": [
+                    { "name": "databaseId", "$ref": "DatabaseId" }
+                ],
+                "returns": [
+                    { "name": "tableNames", "type": "array", "items": { "type": "string" } }
+                ]
+            },
+            {
+                "name": "executeSQL",
+                "async": true,
+                "parameters": [
+                    { "name": "databaseId", "$ref": "DatabaseId" },
+                    { "name": "query", "type": "string" }
+                ],
+                "returns": [
+                    { "name": "columnNames", "type": "array", "optional": true, "items": { "type": "string" } },
+                    { "name": "values", "type": "array", "optional": true, "items": { "type": "any" }},
+                    { "name": "sqlError", "$ref": "Error", "optional": true }
+                ]
+            }
+        ],
+        "events": [
+            {
+                "name": "addDatabase",
+                "parameters": [
+                    { "name": "database", "$ref": "Database" }
+                ]
+            }
+        ]
+    },
+    {
+        "domain": "IndexedDB",
+        "hidden": true,
+        "types": [
+            {
+                "id": "DatabaseWithObjectStores",
+                "type": "object",
+                "description": "Database with an array of object stores.",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "Database name." },
+                    { "name": "version", "type": "string", "description": "Deprecated string database version." },
+                    { "name": "intVersion", "type": "integer", "description": "Integer database version." },
+                    { "name": "objectStores", "type": "array", "items": { "$ref": "ObjectStore" }, "description": "Object stores in this database." }
+                ]
+            },
+            {
+                "id": "ObjectStore",
+                "type": "object",
+                "description": "Object store.",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "Object store name." },
+                    { "name": "keyPath", "$ref": "KeyPath", "description": "Object store key path." },
+                    { "name": "autoIncrement", "type": "boolean", "description": "If true, object store has auto increment flag set." },
+                    { "name": "indexes", "type": "array", "items": { "$ref": "ObjectStoreIndex" }, "description": "Indexes in this object store." }
+                ]
+            },
+            {
+                "id": "ObjectStoreIndex",
+                "type": "object",
+                "description": "Object store index.",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "Index name." },
+                    { "name": "keyPath", "$ref": "KeyPath", "description": "Index key path." },
+                    { "name": "unique", "type": "boolean", "description": "If true, index is unique." },
+                    { "name": "multiEntry", "type": "boolean", "description": "If true, index allows multiple entries for a key." }
+                ]
+            },
+            {
+                "id": "Key",
+                "type": "object",
+                "description": "Key.",
+                "properties": [
+                    { "name": "type", "type": "string", "enum": ["number", "string", "date", "array"], "description": "Key type." },
+                    { "name": "number", "type": "number", "optional": true, "description": "Number value." },
+                    { "name": "string", "type": "string", "optional": true, "description": "String value." },
+                    { "name": "date", "type": "number", "optional": true, "description": "Date value." },
+                    { "name": "array", "type": "array", "optional": true, "items": { "$ref": "Key" }, "description": "Array value." }
+                ]
+            },
+            {
+                "id": "KeyRange",
+                "type": "object",
+                "description": "Key range.",
+                "properties": [
+                    { "name": "lower", "$ref": "Key", "optional": true, "description": "Lower bound." },
+                    { "name": "upper", "$ref": "Key", "optional": true, "description": "Upper bound." },
+                    { "name": "lowerOpen", "type": "boolean", "description": "If true lower bound is open." },
+                    { "name": "upperOpen", "type": "boolean", "description": "If true upper bound is open." }
+                ]
+            },
+            {
+                "id": "DataEntry",
+                "type": "object",
+                "description": "Data entry.",
+                "properties": [
+                    { "name": "key", "$ref": "Runtime.RemoteObject", "description": "Key." },
+                    { "name": "primaryKey", "$ref": "Runtime.RemoteObject", "description": "Primary key." },
+                    { "name": "value", "$ref": "Runtime.RemoteObject", "description": "Value." }
+                ]
+            },
+            {
+                "id": "KeyPath",
+                "type": "object",
+                "description": "Key path.",
+                "properties": [
+                    { "name": "type", "type": "string", "enum": ["null", "string", "array"], "description": "Key path type." },
+                    { "name": "string", "type": "string", "optional": true, "description": "String value." },
+                    { "name": "array", "type": "array", "optional": true, "items": { "type": "string" }, "description": "Array value." }
+                ]
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables events from backend."
+            },
+            {
+                "name": "disable",
+                "description": "Disables events from backend."
+            },
+            {
+                "name": "requestDatabaseNames",
+                "async": true,
+                "parameters": [
+                    { "name": "securityOrigin", "type": "string", "description": "Security origin." }
+                ],
+                "returns": [
+                    { "name": "databaseNames", "type": "array", "items": { "type": "string" }, "description": "Database names for origin." }
+                ],
+                "description": "Requests database names for given security origin."
+            },
+            {
+                "name": "requestDatabase",
+                "async": true,
+                "parameters": [
+                    { "name": "securityOrigin", "type": "string", "description": "Security origin." },
+                    { "name": "databaseName", "type": "string", "description": "Database name." }
+                ],
+                "returns": [
+                    { "name": "databaseWithObjectStores", "$ref": "DatabaseWithObjectStores", "description": "Database with an array of object stores." }
+                ],
+                "description": "Requests database with given name in given frame."
+            },
+            {
+                "name": "requestData",
+                "async": true,
+                "parameters": [
+                    { "name": "securityOrigin", "type": "string", "description": "Security origin." },
+                    { "name": "databaseName", "type": "string", "description": "Database name." },
+                    { "name": "objectStoreName", "type": "string", "description": "Object store name." },
+                    { "name": "indexName", "type": "string", "description": "Index name, empty string for object store data requests." },
+                    { "name": "skipCount", "type": "integer", "description": "Number of records to skip." },
+                    { "name": "pageSize", "type": "integer", "description": "Number of records to fetch." },
+                    { "name": "keyRange", "$ref": "KeyRange", "optional": true, "description": "Key range." }
+                ],
+                "returns": [
+                    { "name": "objectStoreDataEntries", "type": "array", "items": { "$ref": "DataEntry" }, "description": "Array of object store data entries." },
+                    { "name": "hasMore", "type": "boolean", "description": "If true, there are more entries to fetch in the given range." }
+                ],
+                "description": "Requests data from object store or index."
+            },
+            {
+                "name": "clearObjectStore",
+                "async": true,
+                "parameters": [
+                    { "name": "securityOrigin", "type": "string", "description": "Security origin." },
+                    { "name": "databaseName", "type": "string", "description": "Database name." },
+                    { "name": "objectStoreName", "type": "string", "description": "Object store name." }
+                ],
+                "returns": [
+                ],
+                "description": "Clears all entries from an object store."
+            }
+        ]
+    },
+    {
+        "domain": "DOMStorage",
+        "hidden": true,
+        "description": "Query and modify DOM storage.",
+        "types": [
+            {
+                "id": "StorageId",
+                "type": "object",
+                "description": "DOM Storage identifier.",
+                "hidden": true,
+                "properties": [
+                    { "name": "securityOrigin", "type": "string", "description": "Security origin for the storage." },
+                    { "name": "isLocalStorage", "type": "boolean", "description": "Whether the storage is local storage (not session storage)." }
+                ]
+            },
+            {
+                "id": "Item",
+                "type": "array",
+                "description": "DOM Storage item.",
+                "hidden": true,
+                "items": { "type": "string" }
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables storage tracking, storage events will now be delivered to the client."
+            },
+            {
+                "name": "disable",
+                "description": "Disables storage tracking, prevents storage events from being sent to the client."
+            },
+            {
+                "name": "getDOMStorageItems",
+                "parameters": [
+                    { "name": "storageId", "$ref": "StorageId" }
+                ],
+                "returns": [
+                    { "name": "entries", "type": "array", "items": { "$ref": "Item" } }
+                ]
+            },
+            {
+                "name": "setDOMStorageItem",
+                "parameters": [
+                    { "name": "storageId", "$ref": "StorageId" },
+                    { "name": "key", "type": "string" },
+                    { "name": "value", "type": "string" }
+                ]
+            },
+            {
+                "name": "removeDOMStorageItem",
+                "parameters": [
+                    { "name": "storageId", "$ref": "StorageId" },
+                    { "name": "key", "type": "string" }
+                ]
+            }
+        ],
+        "events": [
+            {
+                "name": "domStorageItemsCleared",
+                "parameters": [
+                    { "name": "storageId",  "$ref": "StorageId" }
+                ]
+            },
+            {
+                "name": "domStorageItemRemoved",
+                "parameters": [
+                    { "name": "storageId",  "$ref": "StorageId" },
+                    { "name": "key", "type": "string" }
+                ]
+            },
+            {
+                "name": "domStorageItemAdded",
+                "parameters": [
+                    { "name": "storageId",  "$ref": "StorageId" },
+                    { "name": "key", "type": "string" },
+                    { "name": "newValue", "type": "string" }
+                ]
+            },
+            {
+                "name": "domStorageItemUpdated",
+                "parameters": [
+                    { "name": "storageId",  "$ref": "StorageId" },
+                    { "name": "key", "type": "string" },
+                    { "name": "oldValue", "type": "string" },
+                    { "name": "newValue", "type": "string" }
+                ]
+            }
+        ]
+    },
+    {
+        "domain": "ApplicationCache",
+        "hidden": true,
+        "types": [
+            {
+                "id": "ApplicationCacheResource",
+                "type": "object",
+                "description": "Detailed application cache resource information.",
+                "properties": [
+                    { "name": "url", "type": "string", "description": "Resource url." },
+                    { "name": "size", "type": "integer", "description": "Resource size." },
+                    { "name": "type", "type": "string", "description": "Resource type." }
+                ]
+            },
+            {
+                "id": "ApplicationCache",
+                "type": "object",
+                "description": "Detailed application cache information.",
+                "properties": [
+                    { "name": "manifestURL", "type": "string", "description": "Manifest URL." },
+                    { "name": "size", "type": "number", "description": "Application cache size." },
+                    { "name": "creationTime", "type": "number", "description": "Application cache creation time." },
+                    { "name": "updateTime", "type": "number", "description": "Application cache update time." },
+                    { "name": "resources", "type": "array", "items": { "$ref": "ApplicationCacheResource" }, "description": "Application cache resources." }
+                ]
+            },
+            {
+                "id": "FrameWithManifest",
+                "type": "object",
+                "description": "Frame identifier - manifest URL pair.",
+                "properties": [
+                    { "name": "frameId", "$ref": "Page.FrameId", "description": "Frame identifier." },
+                    { "name": "manifestURL", "type": "string", "description": "Manifest URL." },
+                    { "name": "status", "type": "integer", "description": "Application cache status." }
+                ]
+            }
+        ],
+        "commands": [
+            {
+                "name": "getFramesWithManifests",
+                "returns": [
+                    { "name": "frameIds", "type": "array", "items": { "$ref": "FrameWithManifest" }, "description": "Array of frame identifiers with manifest urls for each frame containing a document associated with some application cache." }
+                ],
+                "description": "Returns array of frame identifiers with manifest urls for each frame containing a document associated with some application cache."
+            },
+            {
+                "name": "enable",
+                "description": "Enables application cache domain notifications."
+            },
+            {
+                "name": "getManifestForFrame",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Page.FrameId", "description": "Identifier of the frame containing document whose manifest is retrieved." }
+                ],
+                "returns": [
+                    { "name": "manifestURL", "type": "string", "description": "Manifest URL for document in the given frame." }
+                ],
+                "description": "Returns manifest URL for document in the given frame."
+            },
+            {
+                "name": "getApplicationCacheForFrame",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Page.FrameId", "description": "Identifier of the frame containing document whose application cache is retrieved." }
+                ],
+                "returns": [
+                    { "name": "applicationCache", "$ref": "ApplicationCache", "description": "Relevant application cache data for the document in given frame." }
+                ],
+                "description": "Returns relevant application cache data for the document in given frame."
+            }
+        ],
+        "events": [
+            {
+                "name": "applicationCacheStatusUpdated",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Page.FrameId", "description": "Identifier of the frame containing document whose application cache updated status." },
+                    { "name": "manifestURL", "type": "string", "description": "Manifest URL." },
+                    { "name": "status", "type": "integer", "description": "Updated application cache status." }
+                ]
+            },
+            {
+                "name": "networkStateUpdated",
+                "parameters": [
+                    { "name": "isNowOnline", "type": "boolean" }
+                ]
+            }
+        ]
+    },
+    {
+        "domain": "FileSystem",
+        "hidden": true,
+        "types": [
+            {
+                "id": "Entry",
+                "type": "object",
+                "properties": [
+                    { "name": "url", "type": "string", "description": "filesystem: URL for the entry." },
+                    { "name": "name", "type": "string", "description": "The name of the file or directory." },
+                    { "name": "isDirectory", "type": "boolean", "description": "True if the entry is a directory." },
+                    { "name": "mimeType", "type": "string", "optional": true, "description": "MIME type of the entry, available for a file only." },
+                    { "name": "resourceType", "$ref": "Page.ResourceType", "optional": true, "description": "ResourceType of the entry, available for a file only." },
+                    { "name": "isTextFile", "type": "boolean", "optional": true, "description": "True if the entry is a text file." }
+                ],
+                "description": "Represents a browser side file or directory."
+            },
+            {
+                "id": "Metadata",
+                "type": "object",
+                "properties": [
+                    { "name": "modificationTime", "type": "number", "description": "Modification time." },
+                    { "name": "size", "type": "number", "description": "File size. This field is always zero for directories." }
+                ],
+                "description": "Represents metadata of a file or entry."
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables events from backend."
+            },
+            {
+                "name": "disable",
+                "description": "Disables events from backend."
+            },
+            {
+                "name": "requestFileSystemRoot",
+                "async": true,
+                "parameters": [
+                    { "name": "origin", "type": "string", "description": "Security origin of requesting FileSystem. One of frames in current page needs to have this security origin." },
+                    { "name": "type", "type": "string", "enum": ["temporary", "persistent"], "description": "FileSystem type of requesting FileSystem." }
+                ],
+                "returns": [
+                    { "name": "errorCode", "type": "integer", "description": "0, if no error. Otherwise, errorCode is set to FileError::ErrorCode value." },
+                    { "name": "root", "$ref": "Entry", "optional": true, "description": "Contains root of the requested FileSystem if the command completed successfully." }
+                ],
+                "description": "Returns root directory of the FileSystem, if exists."
+            },
+            {
+                "name": "requestDirectoryContent",
+                "async": true,
+                "parameters": [
+                    { "name": "url", "type": "string", "description": "URL of the directory that the frontend is requesting to read from." }
+                ],
+                "returns": [
+                    { "name": "errorCode", "type": "integer", "description": "0, if no error. Otherwise, errorCode is set to FileError::ErrorCode value." },
+                    { "name": "entries", "type": "array", "items": { "$ref": "Entry" }, "optional": true, "description": "Contains all entries on directory if the command completed successfully." }
+                ],
+                "description": "Returns content of the directory."
+            },
+            {
+                "name": "requestMetadata",
+                "async": true,
+                "parameters": [
+                    { "name": "url", "type": "string", "description": "URL of the entry that the frontend is requesting to get metadata from." }
+                ],
+                "returns": [
+                    { "name": "errorCode", "type": "integer", "description": "0, if no error. Otherwise, errorCode is set to FileError::ErrorCode value." },
+                    { "name": "metadata", "$ref": "Metadata", "optional": true, "description": "Contains metadata of the entry if the command completed successfully." }
+                ],
+                "description": "Returns metadata of the entry."
+            },
+            {
+                "name": "requestFileContent",
+                "async": true,
+                "parameters": [
+                    { "name": "url", "type": "string", "description": "URL of the file that the frontend is requesting to read from." },
+                    { "name": "readAsText", "type": "boolean", "description": "True if the content should be read as text, otherwise the result will be returned as base64 encoded text." },
+                    { "name": "start", "type": "integer", "optional": true, "description": "Specifies the start of range to read." },
+                    { "name": "end", "type": "integer", "optional": true, "description": "Specifies the end of range to read exclusively." },
+                    { "name": "charset", "type": "string", "optional": true, "description": "Overrides charset of the content when content is served as text." }
+                ],
+                "returns": [
+                    { "name": "errorCode", "type": "integer", "description": "0, if no error. Otherwise, errorCode is set to FileError::ErrorCode value." },
+                    { "name": "content", "type": "string", "optional": true, "description": "Content of the file." },
+                    { "name": "charset", "type": "string", "optional": true, "description": "Charset of the content if it is served as text." }
+                ],
+                "description": "Returns content of the file. Result should be sliced into [start, end)."
+            },
+            {
+                "name": "deleteEntry",
+                "async": true,
+                "parameters": [
+                    { "name": "url", "type": "string", "description": "URL of the entry to delete." }
+                ],
+                "returns": [
+                    { "name": "errorCode", "type": "integer", "description": "0, if no error. Otherwise errorCode is set to FileError::ErrorCode value." }
+                ],
+                "description": "Deletes specified entry. If the entry is a directory, the agent deletes children recursively."
+            }
+        ]
+    },
+    {
+        "domain": "DOM",
+        "description": "This domain exposes DOM read/write operations. Each DOM Node is represented with its mirror object that has an <code>id</code>. This <code>id</code> can be used to get additional information on the Node, resolve it into the JavaScript object wrapper, etc. It is important that client receives DOM events only for the nodes that are known to the client. Backend keeps track of the nodes that were sent to the client and never sends the same node twice. It is client's responsibility to collect information about the nodes that were sent to the client.<p>Note that <code>iframe</code> owner elements will return corresponding document elements as their child nodes.</p>",
+        "types": [
+            {
+                "id": "NodeId",
+                "type": "integer",
+                "description": "Unique DOM node identifier."
+            },
+            {
+                "id": "BackendNodeId",
+                "type": "integer",
+                "description": "Unique DOM node identifier used to reference a node that may not have been pushed to the front-end.",
+                "hidden": true
+            },
+            {
+                "id": "Node",
+                "type": "object",
+                "properties": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Node identifier that is passed into the rest of the DOM messages as the <code>nodeId</code>. Backend will only push node with given <code>id</code> once. It is aware of all requested nodes and will only fire DOM events for nodes known to the client." },
+                    { "name": "nodeType", "type": "integer", "description": "<code>Node</code>'s nodeType." },
+                    { "name": "nodeName", "type": "string", "description": "<code>Node</code>'s nodeName." },
+                    { "name": "localName", "type": "string", "description": "<code>Node</code>'s localName." },
+                    { "name": "nodeValue", "type": "string", "description": "<code>Node</code>'s nodeValue." },
+                    { "name": "childNodeCount", "type": "integer", "optional": true, "description": "Child count for <code>Container</code> nodes." },
+                    { "name": "children", "type": "array", "optional": true, "items": { "$ref": "Node" }, "description": "Child nodes of this node when requested with children." },
+                    { "name": "attributes", "type": "array", "optional": true, "items": { "type": "string" }, "description": "Attributes of the <code>Element</code> node in the form of flat array <code>[name1, value1, name2, value2]</code>." },
+                    { "name": "documentURL", "type": "string", "optional": true, "description": "Document URL that <code>Document</code> or <code>FrameOwner</code> node points to." },
+                    { "name": "baseURL", "type": "string", "optional": true, "description": "Base URL that <code>Document</code> or <code>FrameOwner</code> node uses for URL completion.", "hidden": true },
+                    { "name": "publicId", "type": "string", "optional": true, "description": "<code>DocumentType</code>'s publicId." },
+                    { "name": "systemId", "type": "string", "optional": true, "description": "<code>DocumentType</code>'s systemId." },
+                    { "name": "internalSubset", "type": "string", "optional": true, "description": "<code>DocumentType</code>'s internalSubset." },
+                    { "name": "xmlVersion", "type": "string", "optional": true, "description": "<code>Document</code>'s XML version in case of XML documents." },
+                    { "name": "name", "type": "string", "optional": true, "description": "<code>Attr</code>'s name." },
+                    { "name": "value", "type": "string", "optional": true, "description": "<code>Attr</code>'s value." },
+                    { "name": "frameId", "$ref": "Page.FrameId", "optional": true, "description": "Frame ID for frame owner elements.", "hidden": true },
+                    { "name": "contentDocument", "$ref": "Node", "optional": true, "description": "Content document for frame owner elements." },
+                    { "name": "shadowRoots", "type": "array", "optional": true, "items": { "$ref": "Node" }, "description": "Shadow root list for given element host.", "hidden": true },
+                    { "name": "templateContent", "$ref": "Node", "optional": true, "description": "Content document fragment for template elements", "hidden": true }
+                ],
+                "description": "DOM interaction is implemented in terms of mirror objects that represent the actual DOM nodes. DOMNode is a base node mirror type."
+            },
+            {
+                "id": "EventListener",
+                "type": "object",
+                "hidden": true,
+                "properties": [
+                    { "name": "type", "type": "string", "description": "<code>EventListener</code>'s type." },
+                    { "name": "useCapture", "type": "boolean", "description": "<code>EventListener</code>'s useCapture." },
+                    { "name": "isAttribute", "type": "boolean", "description": "<code>EventListener</code>'s isAttribute." },
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Target <code>DOMNode</code> id." },
+                    { "name": "handlerBody", "type": "string", "description": "Event handler function body." },
+                    { "name": "location", "$ref": "Debugger.Location", "optional": true, "description": "Handler code location." },
+                    { "name": "sourceName", "type": "string", "optional": true, "description": "Source script URL." },
+                    { "name": "handler", "$ref": "Runtime.RemoteObject", "optional": true, "description": "Event handler function value." }
+                ],
+                "description": "DOM interaction is implemented in terms of mirror objects that represent the actual DOM nodes. DOMNode is a base node mirror type."
+            },
+            {
+                "id": "RGBA",
+                "type": "object",
+                "properties": [
+                    { "name": "r", "type": "integer", "description": "The red component, in the [0-255] range." },
+                    { "name": "g", "type": "integer", "description": "The green component, in the [0-255] range." },
+                    { "name": "b", "type": "integer", "description": "The blue component, in the [0-255] range." },
+                    { "name": "a", "type": "number", "optional": true, "description": "The alpha component, in the [0-1] range (default: 1)." }
+                ],
+                "description": "A structure holding an RGBA color."
+            },
+            {
+                "id": "Quad",
+                "type": "array",
+                "items": { "type": "number" },
+                "minItems": 8,
+                "maxItems": 8,
+                "description": "An array of quad vertices, x immediately followed by y for each point, points clock-wise.",
+                "hidden": true
+            },
+            {
+                "id": "BoxModel",
+                "type": "object",
+                "hidden": true,
+                "properties": [
+                    { "name": "content", "$ref": "Quad", "description": "Content box" },
+                    { "name": "padding", "$ref": "Quad", "description": "Padding box" },
+                    { "name": "border", "$ref": "Quad", "description": "Border box" },
+                    { "name": "margin", "$ref": "Quad", "description": "Margin box" },
+                    { "name": "width", "type": "integer", "description": "Node width" },
+                    { "name": "height", "type": "integer", "description": "Node height" },
+                    { "name": "shapeOutside", "type": "string", "description": "CSS Shape Outside" }
+                ],
+                "description": "Box model."
+            },
+            {
+                "id": "Rect",
+                "type": "object",
+                "hidden": true,
+                "properties": [
+                    { "name": "x", "type": "number", "description": "X coordinate" },
+                    { "name": "y", "type": "number", "description": "Y coordinate" },
+                    { "name": "width", "type": "number", "description": "Rectangle width" },
+                    { "name": "height", "type": "number", "description": "Rectangle height" }
+                ],
+                "description": "Rectangle."
+            },
+            {
+                "id": "HighlightConfig",
+                "type": "object",
+                "properties": [
+                    { "name": "showInfo", "type": "boolean", "optional": true, "description": "Whether the node info tooltip should be shown (default: false)." },
+                    { "name": "contentColor", "$ref": "RGBA", "optional": true, "description": "The content box highlight fill color (default: transparent)." },
+                    { "name": "paddingColor", "$ref": "RGBA", "optional": true, "description": "The padding highlight fill color (default: transparent)." },
+                    { "name": "borderColor", "$ref": "RGBA", "optional": true, "description": "The border highlight fill color (default: transparent)." },
+                    { "name": "marginColor", "$ref": "RGBA", "optional": true, "description": "The margin highlight fill color (default: transparent)." },
+                    { "name": "eventTargetColor", "$ref": "RGBA", "optional": true, "hidden": true, "description": "The event target element highlight fill color (default: transparent)." }
+                ],
+                "description": "Configuration data for the highlighting of page elements."
+            }
+        ],
+        "commands": [
+            {
+                "name": "getDocument",
+                "returns": [
+                    { "name": "root", "$ref": "Node", "description": "Resulting node." }
+                ],
+                "description": "Returns the root DOM node to the caller."
+            },
+            {
+                "name": "requestChildNodes",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to get children for." },
+                    { "name": "depth", "type": "integer", "optional": true, "description": "The maximum depth at which children should be retrieved, defaults to 1. Use -1 for the entire subtree or provide an integer larger than 0.", "hidden": true }
+                ],
+                "description": "Requests that children of the node with given id are returned to the caller in form of <code>setChildNodes</code> events where not only immediate children are retrieved, but all children down to the specified depth."
+            },
+            {
+                "name": "querySelector",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to query upon." },
+                    { "name": "selector", "type": "string", "description": "Selector string." }
+                ],
+                "returns": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Query selector result." }
+                ],
+                "description": "Executes <code>querySelector</code> on a given node."
+            },
+            {
+                "name": "querySelectorAll",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to query upon." },
+                    { "name": "selector", "type": "string", "description": "Selector string." }
+                ],
+                "returns": [
+                    { "name": "nodeIds", "type": "array", "items": { "$ref": "NodeId" }, "description": "Query selector result." }
+                ],
+                "description": "Executes <code>querySelectorAll</code> on a given node."
+            },
+            {
+                "name": "setNodeName",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to set name for." },
+                    { "name": "name", "type": "string", "description": "New node's name." }
+                ],
+                "returns": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "New node's id." }
+                ],
+                "description": "Sets node name for a node with given id."
+            },
+            {
+                "name": "setNodeValue",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to set value for." },
+                    { "name": "value", "type": "string", "description": "New node's value." }
+                ],
+                "description": "Sets node value for a node with given id."
+            },
+            {
+                "name": "removeNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to remove." }
+                ],
+                "description": "Removes node with given id."
+            },
+            {
+                "name": "setAttributeValue",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the element to set attribute for." },
+                    { "name": "name", "type": "string", "description": "Attribute name." },
+                    { "name": "value", "type": "string", "description": "Attribute value." }
+                ],
+                "description": "Sets attribute for an element with given id."
+            },
+            {
+                "name": "setAttributesAsText",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the element to set attributes for." },
+                    { "name": "text", "type": "string", "description": "Text with a number of attributes. Will parse this text using HTML parser." },
+                    { "name": "name", "type": "string", "optional": true, "description": "Attribute name to replace with new attributes derived from text in case text parsed successfully." }
+                ],
+                "description": "Sets attributes on element with given id. This method is useful when user edits some existing attribute value and types in several attribute name/value pairs."
+            },
+            {
+                "name": "removeAttribute",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the element to remove attribute from." },
+                    { "name": "name", "type": "string", "description": "Name of the attribute to remove." }
+                ],
+                "description": "Removes attribute with given name from an element with given id."
+            },
+            {
+                "name": "getEventListenersForNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to get listeners for." },
+                    { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name for handler value. Handler value is not returned without this parameter specified." }
+                ],
+                "returns": [
+                    { "name": "listeners", "type": "array", "items": { "$ref": "EventListener"}, "description": "Array of relevant listeners." }
+                ],
+                "description": "Returns event listeners relevant to the node.",
+                "hidden": true
+            },
+            {
+                "name": "getOuterHTML",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to get markup for." }
+                ],
+                "returns": [
+                    { "name": "outerHTML", "type": "string", "description": "Outer HTML markup." }
+                ],
+                "description": "Returns node's HTML markup."
+            },
+            {
+                "name": "setOuterHTML",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to set markup for." },
+                    { "name": "outerHTML", "type": "string", "description": "Outer HTML markup to set." }
+                ],
+                "description": "Sets node HTML markup, returns new node id."
+            },
+            {
+                "name": "performSearch",
+                "parameters": [
+                    { "name": "query", "type": "string", "description": "Plain text or query selector or XPath search query." }
+                ],
+                "returns": [
+                    { "name": "searchId", "type": "string", "description": "Unique search session identifier." },
+                    { "name": "resultCount", "type": "integer", "description": "Number of search results." }
+                ],
+                "description": "Searches for a given string in the DOM tree. Use <code>getSearchResults</code> to access search results or <code>cancelSearch</code> to end this search session.",
+                "hidden": true
+            },
+            {
+                "name": "getSearchResults",
+                "parameters": [
+                    { "name": "searchId", "type": "string", "description": "Unique search session identifier." },
+                    { "name": "fromIndex", "type": "integer", "description": "Start index of the search result to be returned." },
+                    { "name": "toIndex", "type": "integer", "description": "End index of the search result to be returned." }
+                ],
+                "returns": [
+                    { "name": "nodeIds", "type": "array", "items": { "$ref": "NodeId" }, "description": "Ids of the search result nodes." }
+                ],
+                "description": "Returns search results from given <code>fromIndex</code> to given <code>toIndex</code> from the sarch with the given identifier.",
+                "hidden": true
+            },
+            {
+                "name": "discardSearchResults",
+                "parameters": [
+                    { "name": "searchId", "type": "string", "description": "Unique search session identifier." }
+                ],
+                "description": "Discards search results from the session with the given id. <code>getSearchResults</code> should no longer be called for that search.",
+                "hidden": true
+            },
+            {
+                "name": "requestNode",
+                "parameters": [
+                    { "name": "objectId", "$ref": "Runtime.RemoteObjectId", "description": "JavaScript object id to convert into node." }
+                ],
+                "returns": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Node id for given object." }
+                ],
+                "description": "Requests that the node is sent to the caller given the JavaScript node object reference. All nodes that form the path from the node to the root are also sent to the client as a series of <code>setChildNodes</code> notifications."
+            },
+            {
+                "name": "setInspectModeEnabled",
+                "hidden": true,
+                "parameters": [
+                    { "name": "enabled", "type": "boolean", "description": "True to enable inspection mode, false to disable it." },
+                    { "name": "inspectShadowDOM", "type": "boolean", "optional": true, "description": "True to enable inspection mode for shadow DOM." },
+                    { "name": "highlightConfig", "$ref": "HighlightConfig", "optional": true, "description": "A descriptor for the highlight appearance of hovered-over nodes. May be omitted if <code>enabled == false</code>." }
+                ],
+                "description": "Enters the 'inspect' mode. In this mode, elements that user is hovering over are highlighted. Backend then generates 'inspectNodeRequested' event upon element selection."
+            },
+            {
+                "name": "highlightRect",
+                "parameters": [
+                    { "name": "x", "type": "integer", "description": "X coordinate" },
+                    { "name": "y", "type": "integer", "description": "Y coordinate" },
+                    { "name": "width", "type": "integer", "description": "Rectangle width" },
+                    { "name": "height", "type": "integer", "description": "Rectangle height" },
+                    { "name": "color", "$ref": "RGBA", "optional": true, "description": "The highlight fill color (default: transparent)." },
+                    { "name": "outlineColor", "$ref": "RGBA", "optional": true, "description": "The highlight outline color (default: transparent)." }
+                ],
+                "description": "Highlights given rectangle. Coordinates are absolute with respect to the main frame viewport."
+            },
+            {
+                "name": "highlightQuad",
+                "parameters": [
+                    { "name": "quad", "$ref": "Quad", "description": "Quad to highlight" },
+                    { "name": "color", "$ref": "RGBA", "optional": true, "description": "The highlight fill color (default: transparent)." },
+                    { "name": "outlineColor", "$ref": "RGBA", "optional": true, "description": "The highlight outline color (default: transparent)." }
+                ],
+                "description": "Highlights given quad. Coordinates are absolute with respect to the main frame viewport.",
+                "hidden": true
+            },
+            {
+                "name": "highlightNode",
+                "parameters": [
+                    { "name": "highlightConfig", "$ref": "HighlightConfig",  "description": "A descriptor for the highlight appearance." },
+                    { "name": "nodeId", "$ref": "NodeId", "optional": true, "description": "Identifier of the node to highlight." },
+                    { "name": "objectId", "$ref": "Runtime.RemoteObjectId", "optional": true, "description": "JavaScript object id of the node to be highlighted.", "hidden": true }
+                ],
+                "description": "Highlights DOM node with given id or with the given JavaScript object wrapper. Either nodeId or objectId must be specified."
+            },
+            {
+                "name": "hideHighlight",
+                "description": "Hides DOM node highlight."
+            },
+            {
+                "name": "highlightFrame",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Page.FrameId", "description": "Identifier of the frame to highlight." },
+                    { "name": "contentColor", "$ref": "RGBA", "optional": true, "description": "The content box highlight fill color (default: transparent)." },
+                    { "name": "contentOutlineColor", "$ref": "RGBA", "optional": true, "description": "The content box highlight outline color (default: transparent)." }
+                ],
+                "description": "Highlights owner element of the frame with given id.",
+                "hidden": true
+            },
+            {
+                "name": "pushNodeByPathToFrontend",
+                "parameters": [
+                    { "name": "path", "type": "string", "description": "Path to node in the proprietary format." }
+                ],
+                "returns": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node for given path." }
+                ],
+                "description": "Requests that the node is sent to the caller given its path. // FIXME, use XPath",
+                "hidden": true
+            },
+            {
+                "name": "pushNodeByBackendIdToFrontend",
+                "parameters": [
+                    { "name": "backendNodeId", "$ref": "BackendNodeId", "description": "The backend node id of the node." }
+                ],
+                "returns": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "The pushed node's id." }
+                ],
+                "description": "Requests that the node is sent to the caller given its backend node id.",
+                "hidden": true
+            },
+            {
+                "name": "releaseBackendNodeIds",
+                "parameters": [
+                    { "name": "nodeGroup", "type": "string", "description": "The backend node ids group name." }
+                ],
+                "description": "Requests that group of <code>BackendNodeIds</code> is released.",
+                "hidden": true
+            },
+            {
+                "name": "resolveNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to resolve." },
+                    { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." }
+                ],
+                "returns": [
+                    { "name": "object", "$ref": "Runtime.RemoteObject", "description": "JavaScript object wrapper for given node." }
+                ],
+                "description": "Resolves JavaScript node object for given node id."
+            },
+            {
+                "name": "getAttributes",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to retrieve attibutes for." }
+                ],
+                "returns": [
+                    { "name": "attributes", "type": "array", "items": { "type": "string" }, "description": "An interleaved array of node attribute names and values." }
+                ],
+                "description": "Returns attributes for the specified node."
+            },
+            {
+                "name": "moveTo",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to drop." },
+                    { "name": "targetNodeId", "$ref": "NodeId", "description": "Id of the element to drop into." },
+                    { "name": "insertBeforeNodeId", "$ref": "NodeId", "optional": true, "description": "Drop node before given one." }
+                ],
+                "returns": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "New id of the moved node." }
+                ],
+                "description": "Moves node into the new container, places it before the given anchor."
+            },
+            {
+                "name": "undo",
+                "description": "Undoes the last performed action.",
+                "hidden": true
+            },
+            {
+                "name": "redo",
+                "description": "Re-does the last undone action.",
+                "hidden": true
+            },
+            {
+                "name": "markUndoableState",
+                "description": "Marks last undoable state.",
+                "hidden": true
+            },
+            {
+                "name": "focus",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to focus." }
+                ],
+                "description": "Focuses the given element.",
+                "hidden": true
+            },
+            {
+                "name": "setFileInputFiles",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the file input node to set files for." },
+                    { "name": "files", "type": "array", "items": { "type": "string" }, "description": "Array of file paths to set." }
+                ],
+                "description": "Sets files for the given file input element.",
+                "hidden": true
+            },
+            {
+                "name": "getBoxModel",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to get box model for." }
+                ],
+                "returns": [
+                    { "name": "model", "$ref": "BoxModel", "description": "Box model for the node." }
+                ],
+                "description": "Returns boxes for the currently selected nodes.",
+                "hidden": true
+            },
+            {
+                "name": "getNodeForLocation",
+                "parameters": [
+                    { "name": "x", "type": "integer", "description": "X coordinate." },
+                    { "name": "y", "type": "integer", "description": "Y coordinate." }
+                ],
+                "returns": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node at given coordinates." }
+                ],
+                "description": "Returns node id at given location.",
+                "hidden": true
+            }
+        ],
+        "events": [
+            {
+                "name": "documentUpdated",
+                "description": "Fired when <code>Document</code> has been totally updated. Node ids are no longer valid."
+            },
+            {
+                "name": "inspectNodeRequested",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to inspect." }
+                ],
+                "description": "Fired when the node should be inspected. This happens after call to <code>setInspectModeEnabled</code>.",
+                "hidden" : true
+            },
+            {
+                "name": "setChildNodes",
+                "parameters": [
+                    { "name": "parentId", "$ref": "NodeId", "description": "Parent node id to populate with children." },
+                    { "name": "nodes", "type": "array", "items": { "$ref": "Node"}, "description": "Child nodes array." }
+                ],
+                "description": "Fired when backend wants to provide client with the missing DOM structure. This happens upon most of the calls requesting node ids."
+            },
+            {
+                "name": "attributeModified",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                    { "name": "name", "type": "string", "description": "Attribute name." },
+                    { "name": "value", "type": "string", "description": "Attribute value." }
+                ],
+                "description": "Fired when <code>Element</code>'s attribute is modified."
+            },
+            {
+                "name": "attributeRemoved",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                    { "name": "name", "type": "string", "description": "A ttribute name." }
+                ],
+                "description": "Fired when <code>Element</code>'s attribute is removed."
+            },
+            {
+                "name": "inlineStyleInvalidated",
+                "parameters": [
+                    { "name": "nodeIds", "type": "array", "items": { "$ref": "NodeId" }, "description": "Ids of the nodes for which the inline styles have been invalidated." }
+                ],
+                "description": "Fired when <code>Element</code>'s inline style is modified via a CSS property modification.",
+                "hidden": true
+            },
+            {
+                "name": "characterDataModified",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                    { "name": "characterData", "type": "string", "description": "New text value." }
+                ],
+                "description": "Mirrors <code>DOMCharacterDataModified</code> event."
+            },
+            {
+                "name": "childNodeCountUpdated",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                    { "name": "childNodeCount", "type": "integer", "description": "New node count." }
+                ],
+                "description": "Fired when <code>Container</code>'s child node count has changed."
+            },
+            {
+                "name": "childNodeInserted",
+                "parameters": [
+                    { "name": "parentNodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                    { "name": "previousNodeId", "$ref": "NodeId", "description": "If of the previous siblint." },
+                    { "name": "node", "$ref": "Node", "description": "Inserted node data." }
+                ],
+                "description": "Mirrors <code>DOMNodeInserted</code> event."
+            },
+            {
+                "name": "childNodeRemoved",
+                "parameters": [
+                    { "name": "parentNodeId", "$ref": "NodeId", "description": "Parent id." },
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has been removed." }
+                ],
+                "description": "Mirrors <code>DOMNodeRemoved</code> event."
+            },
+            {
+                "name": "shadowRootPushed",
+                "parameters": [
+                    { "name": "hostId", "$ref": "NodeId", "description": "Host element id." },
+                    { "name": "root", "$ref": "Node", "description": "Shadow root." }
+                ],
+                "description": "Called when shadow root is pushed into the element.",
+                "hidden": true
+            },
+            {
+                "name": "shadowRootPopped",
+                "parameters": [
+                    { "name": "hostId", "$ref": "NodeId", "description": "Host element id." },
+                    { "name": "rootId", "$ref": "NodeId", "description": "Shadow root id." }
+                ],
+                "description": "Called when shadow root is popped from the element.",
+                "hidden": true
+            }
+        ]
+    },
+    {
+        "domain": "CSS",
+        "hidden": true,
+        "description": "This domain exposes CSS read/write operations. All CSS objects (stylesheets, rules, and styles) have an associated <code>id</code> used in subsequent operations on the related object. Each object type has a specific <code>id</code> structure, and those are not interchangeable between objects of different kinds. CSS objects can be loaded using the <code>get*ForNode()</code> calls (which accept a DOM node id). A client can also discover all the existing stylesheets with the <code>getAllStyleSheets()</code> method (or keeping track of the <code>styleSheetAdded</code>/<code>styleSheetRemoved</code> events) and subsequently load the required stylesheet contents using the <code>getStyleSheet[Text]()</code> methods.",
+        "types": [
+            {
+                "id": "StyleSheetId",
+                "type": "string"
+            },
+            {
+                "id": "CSSStyleId",
+                "type": "object",
+                "properties": [
+                    { "name": "styleSheetId", "$ref": "StyleSheetId", "description": "Enclosing stylesheet identifier." },
+                    { "name": "ordinal", "type": "integer", "description": "The style ordinal within the stylesheet." }
+                ],
+                "description": "This object identifies a CSS style in a unique way."
+            },
+            {
+                "id": "StyleSheetOrigin",
+                "type": "string",
+                "enum": ["user", "user-agent", "inspector", "regular"],
+                "description": "Stylesheet type: \"user\" for user stylesheets, \"user-agent\" for user-agent stylesheets, \"inspector\" for stylesheets created by the inspector (i.e. those holding the \"via inspector\" rules), \"regular\" for regular stylesheets."
+            },
+            {
+                "id": "CSSRuleId",
+                "type": "object",
+                "properties": [
+                    { "name": "styleSheetId", "$ref": "StyleSheetId", "description": "Enclosing stylesheet identifier." },
+                    { "name": "ordinal", "type": "integer", "description": "The rule ordinal within the stylesheet." }
+                ],
+                "description": "This object identifies a CSS rule in a unique way."
+            },
+            {
+                "id": "PseudoIdMatches",
+                "type": "object",
+                "properties": [
+                    { "name": "pseudoId", "type": "integer", "description": "Pseudo style identifier (see <code>enum PseudoId</code> in <code>RenderStyleConstants.h</code>)."},
+                    { "name": "matches", "type": "array", "items": { "$ref": "RuleMatch" }, "description": "Matches of CSS rules applicable to the pseudo style."}
+                ],
+                "description": "CSS rule collection for a single pseudo style."
+            },
+            {
+                "id": "InheritedStyleEntry",
+                "type": "object",
+                "properties": [
+                    { "name": "inlineStyle", "$ref": "CSSStyle", "optional": true, "description": "The ancestor node's inline style, if any, in the style inheritance chain." },
+                    { "name": "matchedCSSRules", "type": "array", "items": { "$ref": "RuleMatch" }, "description": "Matches of CSS rules matching the ancestor node in the style inheritance chain." }
+                ],
+                "description": "CSS rule collection for a single pseudo style."
+            },
+            {
+                "id": "RuleMatch",
+                "type": "object",
+                "properties": [
+                    { "name": "rule", "$ref": "CSSRule", "description": "CSS rule in the match." },
+                    { "name": "matchingSelectors", "type": "array", "items": { "type": "integer" }, "description": "Matching selector indices in the rule's selectorList selectors (0-based)." }
+                ],
+                "description": "Match data for a CSS rule."
+            },
+            {
+                "id": "SelectorList",
+                "type": "object",
+                "properties": [
+                    { "name": "selectors", "type": "array", "items": { "type": "string" }, "description": "Selectors in the list." },
+                    { "name": "text", "type": "string", "description": "Rule selector text." },
+                    { "name": "range", "$ref": "SourceRange", "optional": true, "description": "Rule selector range in the underlying resource (if available)." }
+                ],
+                "description": "Selector list data."
+            },
+            {
+                "id": "CSSStyleAttribute",
+                "type": "object",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "DOM attribute name (e.g. \"width\")."},
+                    { "name": "style", "$ref": "CSSStyle", "description": "CSS style generated by the respective DOM attribute."}
+                ],
+                "description": "CSS style information for a DOM style attribute."
+            },
+            {
+                "id": "CSSStyleSheetHeader",
+                "type": "object",
+                "properties": [
+                    { "name": "styleSheetId", "$ref": "StyleSheetId", "description": "The stylesheet identifier."},
+                    { "name": "frameId", "$ref": "Page.FrameId", "description": "Owner frame identifier."},
+                    { "name": "sourceURL", "type": "string", "description": "Stylesheet resource URL."},
+                    { "name": "sourceMapURL", "type": "string", "optional": true, "description": "URL of source map associated with the stylesheet (if any)." },
+                    { "name": "origin", "$ref": "StyleSheetOrigin", "description": "Stylesheet origin."},
+                    { "name": "title", "type": "string", "description": "Stylesheet title."},
+                    { "name": "disabled", "type": "boolean", "description": "Denotes whether the stylesheet is disabled."},
+                    { "name": "hasSourceURL", "type": "boolean", "optional": true, "description": "Whether the sourceURL field value comes from the sourceURL comment." },
+                    { "name": "isInline", "type": "boolean", "description": "Whether this stylesheet is created for STYLE tag by parser. This flag is not set for document.written STYLE tags." },
+                    { "name": "startLine", "type": "number", "description": "Line offset of the stylesheet within the resource (zero based)." },
+                    { "name": "startColumn", "type": "number", "description": "Column offset of the stylesheet within the resource (zero based)." }
+                ],
+                "description": "CSS stylesheet metainformation."
+            },
+            {
+                "id": "CSSStyleSheetBody",
+                "type": "object",
+                "properties": [
+                    { "name": "styleSheetId", "$ref": "StyleSheetId", "description": "The stylesheet identifier."},
+                    { "name": "rules", "type": "array", "items": { "$ref": "CSSRule" }, "description": "Stylesheet resource URL."},
+                    { "name": "text", "type": "string", "optional": true, "description": "Stylesheet resource contents (if available)."}
+                ],
+                "description": "CSS stylesheet contents."
+            },
+            {
+                "id": "CSSRule",
+                "type": "object",
+                "properties": [
+                    { "name": "ruleId", "$ref": "CSSRuleId", "optional": true, "description": "The CSS rule identifier (absent for user agent stylesheet and user-specified stylesheet rules)."},
+                    { "name": "selectorList", "$ref": "SelectorList", "description": "Rule selector data." },
+                    { "name": "sourceURL", "type": "string", "optional": true, "description": "Parent stylesheet resource URL (for regular rules)."},
+                    { "name": "origin", "$ref": "StyleSheetOrigin", "description": "Parent stylesheet's origin."},
+                    { "name": "style", "$ref": "CSSStyle", "description": "Associated style declaration." },
+                    { "name": "media", "type": "array", "items": { "$ref": "CSSMedia" }, "optional": true, "description": "Media list array (for rules involving media queries). The array enumerates media queries starting with the innermost one, going outwards." }
+                ],
+                "description": "CSS rule representation."
+            },
+            {
+                "id": "SourceRange",
+                "type": "object",
+                "properties": [
+                    { "name": "startLine", "type": "integer", "description": "Start line of range." },
+                    { "name": "startColumn", "type": "integer", "description": "Start column of range (inclusive)." },
+                    { "name": "endLine", "type": "integer", "description": "End line of range" },
+                    { "name": "endColumn", "type": "integer", "description": "End column of range (exclusive)." }
+                ],
+                "description": "Text range within a resource. All numbers are zero-based."
+            },
+            {
+                "id": "ShorthandEntry",
+                "type": "object",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "Shorthand name." },
+                    { "name": "value", "type": "string", "description": "Shorthand value." }
+                ]
+            },
+            {
+                "id": "CSSPropertyInfo",
+                "type": "object",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "Property name." },
+                    { "name": "longhands", "type": "array", "optional": true, "items": { "type": "string" }, "description": "Longhand property names." }
+                ]
+            },
+            {
+                "id": "CSSComputedStyleProperty",
+                "type": "object",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "Computed style property name." },
+                    { "name": "value", "type": "string", "description": "Computed style property value." }
+                ]
+            },
+            {
+                "id": "CSSStyle",
+                "type": "object",
+                "properties": [
+                    { "name": "styleId", "$ref": "CSSStyleId", "optional": true, "description": "The CSS style identifier (absent for attribute styles)." },
+                    { "name": "cssProperties", "type": "array", "items": { "$ref": "CSSProperty" }, "description": "CSS properties in the style." },
+                    { "name": "shorthandEntries", "type": "array", "items": { "$ref": "ShorthandEntry" }, "description": "Computed values for all shorthands found in the style." },
+                    { "name": "cssText", "type": "string", "optional": true, "description": "Style declaration text (if available)." },
+                    { "name": "range", "$ref": "SourceRange", "optional": true, "description": "Style declaration range in the enclosing stylesheet (if available)." },
+                    { "name": "width", "type": "string", "optional": true, "description": "The effective \"width\" property value from this style." },
+                    { "name": "height", "type": "string", "optional": true, "description": "The effective \"height\" property value from this style." }
+                ],
+                "description": "CSS style representation."
+            },
+            {
+                "id": "CSSProperty",
+                "type": "object",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "The property name." },
+                    { "name": "value", "type": "string", "description": "The property value." },
+                    { "name": "priority", "type": "string", "optional": true, "description": "The property priority (implies \"\" if absent)." },
+                    { "name": "implicit", "type": "boolean", "optional": true, "description": "Whether the property is implicit (implies <code>false</code> if absent)." },
+                    { "name": "text", "type": "string", "optional": true, "description": "The full property text as specified in the style." },
+                    { "name": "parsedOk", "type": "boolean", "optional": true, "description": "Whether the property is understood by the browser (implies <code>true</code> if absent)." },
+                    { "name": "status", "type": "string", "enum": ["active", "inactive", "disabled", "style"], "optional": true, "description": "The property status: \"active\" if the property is effective in the style, \"inactive\" if the property is overridden by a same-named property in this style later on, \"disabled\" if the property is disabled by the user, \"style\" (implied if absent) if the property is reported by the browser rather than by the CSS source parser." },
+                    { "name": "range", "$ref": "SourceRange", "optional": true, "description": "The entire property range in the enclosing style declaration (if available)." }
+                ],
+                "description": "CSS property declaration data."
+            },
+            {
+                "id": "CSSMedia",
+                "type": "object",
+                "properties": [
+                    { "name": "text", "type": "string", "description": "Media query text." },
+                    { "name": "source", "type": "string", "enum": ["mediaRule", "importRule", "linkedSheet", "inlineSheet"], "description": "Source of the media query: \"mediaRule\" if specified by a @media rule, \"importRule\" if specified by an @import rule, \"linkedSheet\" if specified by a \"media\" attribute in a linked stylesheet's LINK tag, \"inlineSheet\" if specified by a \"media\" attribute in an inline stylesheet's STYLE tag." },
+                    { "name": "sourceURL", "type": "string", "optional": true, "description": "URL of the document containing the media query description." },
+                    { "name": "range", "$ref": "SourceRange", "optional": true, "description": "The associated rule (@media or @import) header range in the enclosing stylesheet (if available)." },
+                    { "name": "parentStyleSheetId", "$ref": "StyleSheetId", "optional": true, "description": "Identifier of the stylesheet containing this object (if exists)." }
+                ],
+                "description": "CSS media query descriptor."
+            },
+            {
+                "id": "SelectorProfileEntry",
+                "type": "object",
+                "properties": [
+                    { "name": "selector", "type": "string", "description": "CSS selector of the corresponding rule." },
+                    { "name": "url", "type": "string", "description": "URL of the resource containing the corresponding rule." },
+                    { "name": "lineNumber", "type": "integer", "description": "Selector line number in the resource for the corresponding rule." },
+                    { "name": "time", "type": "number", "description": "Total time this rule handling contributed to the browser running time during profiling (in milliseconds)." },
+                    { "name": "hitCount", "type": "integer", "description": "Number of times this rule was considered a candidate for matching against DOM elements." },
+                    { "name": "matchCount", "type": "integer", "description": "Number of times this rule actually matched a DOM element." }
+                ],
+                "description": "CSS selector profile entry."
+            },
+            {
+                "id": "SelectorProfile",
+                "type": "object",
+                "properties": [
+                    { "name": "totalTime", "type": "number", "description": "Total processing time for all selectors in the profile (in milliseconds)." },
+                    { "name": "data", "type": "array", "items": { "$ref": "SelectorProfileEntry" }, "description": "CSS selector profile entries." }
+                ]
+            },
+            {
+                "id": "Region",
+                "type": "object",
+                "properties": [
+                    { "name": "regionOverset", "type": "string", "enum": ["overset", "fit", "empty"], "description": "The \"overset\" attribute of a Named Flow." },
+                    { "name": "nodeId", "$ref": "DOM.NodeId", "description": "The corresponding DOM node id." }
+                ],
+                "description": "This object represents a region that flows from a Named Flow.",
+                "hidden": true
+            },
+            {
+                "id": "NamedFlow",
+                "type": "object",
+                "properties": [
+                    { "name": "documentNodeId", "$ref": "DOM.NodeId", "description": "The document node id." },
+                    { "name": "name", "type": "string", "description": "Named Flow identifier." },
+                    { "name": "overset", "type": "boolean", "description": "The \"overset\" attribute of a Named Flow." },
+                    { "name": "content", "type": "array", "items": { "$ref": "DOM.NodeId" }, "description": "An array of nodes that flow into the Named Flow." },
+                    { "name": "regions", "type": "array", "items": { "$ref": "Region" }, "description": "An array of regions associated with the Named Flow." }
+                ],
+                "description": "This object represents a Named Flow.",
+                "hidden": true
+            },
+            {
+                "id": "PlatformFontUsage",
+                "type": "object",
+                "properties": [
+                    { "name": "familyName", "type": "string", "description": "Font's family name reported by platform."},
+                    { "name": "glyphCount", "type": "number", "description": "Amount of glyphs that were rendered with this font."}
+                ],
+                "description": "Information about amount of glyphs that were rendered with given font."
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables the CSS agent for the given page. Clients should not assume that the CSS agent has been enabled until the result of this command is received."
+            },
+            {
+                "name": "disable",
+                "description": "Disables the CSS agent for the given page."
+            },
+            {
+                "name": "getMatchedStylesForNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId" },
+                    { "name": "includePseudo", "type": "boolean", "optional": true, "description": "Whether to include pseudo styles (default: true)." },
+                    { "name": "includeInherited", "type": "boolean", "optional": true, "description": "Whether to include inherited styles (default: true)." }
+                ],
+                "returns": [
+                    { "name": "matchedCSSRules", "type": "array", "items": { "$ref": "RuleMatch" }, "optional": true, "description": "CSS rules matching this node, from all applicable stylesheets." },
+                    { "name": "pseudoElements", "type": "array", "items": { "$ref": "PseudoIdMatches" }, "optional": true, "description": "Pseudo style matches for this node." },
+                    { "name": "inherited", "type": "array", "items": { "$ref": "InheritedStyleEntry" }, "optional": true, "description": "A chain of inherited styles (from the immediate node parent up to the DOM tree root)." }
+                ],
+                "description": "Returns requested styles for a DOM node identified by <code>nodeId</code>."
+            },
+            {
+                "name": "getInlineStylesForNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId" }
+                ],
+                "returns": [
+                    { "name": "inlineStyle", "$ref": "CSSStyle", "optional": true, "description": "Inline style for the specified DOM node." },
+                    { "name": "attributesStyle", "$ref": "CSSStyle", "optional": true, "description": "Attribute-defined element style (e.g. resulting from \"width=20 height=100%\")."}
+                ],
+                "description": "Returns the styles defined inline (explicitly in the \"style\" attribute and implicitly, using DOM attributes) for a DOM node identified by <code>nodeId</code>."
+            },
+            {
+                "name": "getComputedStyleForNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId" }
+                ],
+                "returns": [
+                    { "name": "computedStyle", "type": "array", "items": { "$ref": "CSSComputedStyleProperty" }, "description": "Computed style for the specified DOM node." }
+                ],
+                "description": "Returns the computed style for a DOM node identified by <code>nodeId</code>."
+            },
+            {
+                "name": "getPlatformFontsForNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId" }
+                ],
+                "returns": [
+                    { "name": "cssFamilyName", "type": "string", "description": "Font family name which is determined by computed style." },
+                    { "name": "fonts", "type": "array", "items": { "$ref": "PlatformFontUsage"}, "description": "Usage statistics for every employed platform font." }
+                ],
+                "description": "Requests information about platform fonts which we used to render child TextNodes in the given node.",
+                "hidden": true
+            },
+            {
+                "name": "getAllStyleSheets",
+                "returns": [
+                    { "name": "headers", "type": "array", "items": { "$ref": "CSSStyleSheetHeader" }, "description": "Descriptor entries for all available stylesheets." }
+                ],
+                "description": "Returns metainfo entries for all known stylesheets."
+            },
+            {
+                "name": "getStyleSheet",
+                "parameters": [
+                    { "name": "styleSheetId", "$ref": "StyleSheetId" }
+                ],
+                "returns": [
+                    { "name": "styleSheet", "$ref": "CSSStyleSheetBody", "description": "Stylesheet contents for the specified <code>styleSheetId</code>." }
+                ],
+                "description": "Returns stylesheet data for the specified <code>styleSheetId</code>."
+            },
+            {
+                "name": "getStyleSheetText",
+                "parameters": [
+                    { "name": "styleSheetId", "$ref": "StyleSheetId" }
+                ],
+                "returns": [
+                    { "name": "text", "type": "string", "description": "The stylesheet text." }
+                ],
+                "description": "Returns the current textual content and the URL for a stylesheet."
+            },
+            {
+                "name": "setStyleSheetText",
+                "parameters": [
+                    { "name": "styleSheetId", "$ref": "StyleSheetId" },
+                    { "name": "text", "type": "string" }
+                ],
+                "description": "Sets the new stylesheet text, thereby invalidating all existing <code>CSSStyleId</code>'s and <code>CSSRuleId</code>'s contained by this stylesheet."
+            },
+            {
+                "name": "setStyleText",
+                "parameters": [
+                    { "name": "styleId", "$ref": "CSSStyleId" },
+                    { "name": "text", "type": "string" }
+                ],
+                "returns": [
+                    { "name": "style", "$ref": "CSSStyle", "description": "The resulting style after the text modification." }
+                ],
+                "description": "Updates the CSSStyleDeclaration text."
+            },
+            {
+                "name": "setPropertyText",
+                "parameters": [
+                    { "name": "styleId", "$ref": "CSSStyleId" },
+                    { "name": "propertyIndex", "type": "integer" },
+                    { "name": "text", "type": "string" },
+                    { "name": "overwrite", "type": "boolean" }
+                ],
+                "returns": [
+                    { "name": "style", "$ref": "CSSStyle", "description": "The resulting style after the property text modification." }
+                ],
+                "description": "Sets the new <code>text</code> for a property in the respective style, at offset <code>propertyIndex</code>. If <code>overwrite</code> is <code>true</code>, a property at the given offset is overwritten, otherwise inserted. <code>text</code> entirely replaces the property <code>name: value</code>."
+            },
+            {
+                "name": "toggleProperty",
+                "parameters": [
+                    { "name": "styleId", "$ref": "CSSStyleId" },
+                    { "name": "propertyIndex", "type": "integer" },
+                    { "name": "disable", "type": "boolean" }
+                ],
+                "returns": [
+                    { "name": "style", "$ref": "CSSStyle", "description": "The resulting style after the property toggling." }
+                ],
+                "description": "Toggles the property in the respective style, at offset <code>propertyIndex</code>. The <code>disable</code> parameter denotes whether the property should be disabled (i.e. removed from the style declaration). If <code>disable == false</code>, the property gets put back into its original place in the style declaration."
+            },
+            {
+                "name": "setRuleSelector",
+                "parameters": [
+                    { "name": "ruleId", "$ref": "CSSRuleId" },
+                    { "name": "selector", "type": "string" }
+                ],
+                "returns": [
+                    { "name": "rule", "$ref": "CSSRule", "description": "The resulting rule after the selector modification." }
+                ],
+                "description": "Modifies the rule selector."
+            },
+            {
+                "name": "addRule",
+                "parameters": [
+                    { "name": "contextNodeId", "$ref": "DOM.NodeId" },
+                    { "name": "selector", "type": "string" }
+                ],
+                "returns": [
+                    { "name": "rule", "$ref": "CSSRule", "description": "The newly created rule." }
+                ],
+                "description": "Creates a new empty rule with the given <code>selector</code> in a special \"inspector\" stylesheet in the owner document of the context node."
+            },
+            {
+                "name": "getSupportedCSSProperties",
+                "returns": [
+                    { "name": "cssProperties", "type": "array", "items": { "$ref": "CSSPropertyInfo" }, "description": "Supported property metainfo." }
+                ],
+                "description": "Returns all supported CSS property names."
+            },
+            {
+                "name": "forcePseudoState",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId", "description": "The element id for which to force the pseudo state." },
+                    { "name": "forcedPseudoClasses", "type": "array", "items": { "type": "string", "enum": ["active", "focus", "hover", "visited"] }, "description": "Element pseudo classes to force when computing the element's style." }
+                ],
+                "description": "Ensures that the given node will have specified pseudo-classes whenever its style is computed by the browser."
+            },
+            {
+                "name": "getNamedFlowCollection",
+                "parameters": [
+                    { "name": "documentNodeId", "$ref": "DOM.NodeId", "description": "The document node id for which to get the Named Flow Collection." }
+                ],
+                "returns": [
+                    { "name": "namedFlows", "type": "array", "items": { "$ref": "NamedFlow" }, "description": "An array containing the Named Flows in the document." }
+                ],
+                "description": "Returns the Named Flows from the document.",
+                "hidden": true
+            }
+        ],
+        "events": [
+            {
+                "name": "mediaQueryResultChanged",
+                "description": "Fires whenever a MediaQuery result changes (for example, after a browser window has been resized.) The current implementation considers only viewport-dependent media features."
+            },
+            {
+                "name": "styleSheetChanged",
+                "parameters": [
+                    { "name": "styleSheetId", "$ref": "StyleSheetId" }
+                ],
+                "description": "Fired whenever a stylesheet is changed as a result of the client operation."
+            },
+            {
+                "name": "styleSheetAdded",
+                "parameters": [
+                    { "name": "header", "$ref": "CSSStyleSheetHeader", "description": "Added stylesheet metainfo." }
+                ],
+                "description": "Fired whenever an active document stylesheet is added."
+            },
+            {
+                "name": "styleSheetRemoved",
+                "parameters": [
+                    { "name": "styleSheetId", "$ref": "StyleSheetId", "description": "Identifier of the removed stylesheet." }
+                ],
+                "description": "Fired whenever an active document stylesheet is removed."
+            },
+            {
+                "name": "namedFlowCreated",
+                "parameters": [
+                    { "name": "namedFlow", "$ref": "NamedFlow", "description": "The new Named Flow." }
+                ],
+                "description": "Fires when a Named Flow is created.",
+                "hidden": true
+            },
+            {
+                "name": "namedFlowRemoved",
+                "parameters": [
+                    { "name": "documentNodeId", "$ref": "DOM.NodeId", "description": "The document node id." },
+                    { "name": "flowName", "type": "string", "description": "Identifier of the removed Named Flow." }
+                ],
+                "description": "Fires when a Named Flow is removed: has no associated content nodes and regions.",
+                "hidden": true
+            },
+            {
+                "name": "regionLayoutUpdated",
+                "parameters": [
+                    { "name": "namedFlow", "$ref": "NamedFlow", "description": "The Named Flow whose layout may have changed." }
+                ],
+                "description": "Fires when a Named Flow's layout may have changed.",
+                "hidden": true
+            },
+            {
+                "name": "regionOversetChanged",
+                "parameters": [
+                    { "name": "namedFlow", "$ref": "NamedFlow", "description": "The Named Flow containing the regions whose regionOverset values changed." }
+                ],
+                "description": "Fires if any of the regionOverset values changed in a Named Flow's region chain.",
+                "hidden": true
+            }
+        ]
+    },
+    {
+        "domain": "Timeline",
+        "description": "Timeline provides its clients with instrumentation records that are generated during the page runtime. Timeline instrumentation can be started and stopped using corresponding commands. While timeline is started, it is generating timeline event records.",
+        "types": [
+            {
+                "id": "DOMCounters",
+                "type": "object",
+                "properties": [
+                    { "name": "documents", "type": "integer" },
+                    { "name": "nodes", "type": "integer" },
+                    { "name": "jsEventListeners", "type": "integer" }
+                ],
+                "description": "Current values of DOM counters.",
+                "hidden": true
+            },
+            {
+                "id": "TimelineEvent",
+                "type": "object",
+                "properties": [
+                    { "name": "type", "type": "string", "description": "Event type." },
+                    { "name": "thread", "type": "string", "optional": true, "description": "If present, identifies the thread that produced the event.", "hidden": true },
+                    { "name": "data", "type": "object", "description": "Event data." },
+                    { "name": "children", "type": "array", "optional": true, "items": { "$ref": "TimelineEvent" }, "description": "Nested records." },
+                    { "name": "counters", "$ref": "DOMCounters", "optional": true, "hidden": true, "description": "Current values of DOM counters." },
+                    { "name": "usedHeapSize", "type": "integer", "optional": true, "hidden": true, "description": "Current size of JS heap." },
+                    { "name": "nativeHeapStatistics", "type": "object", "optional": true, "hidden": true, "description": "Native heap statistics." }
+                ],
+                "description": "Timeline record contains information about the recorded activity."
+            }
+        ],
+        "commands": [
+            {
+                "name": "start",
+                "parameters": [
+                    { "name": "maxCallStackDepth", "optional": true, "type": "integer", "description": "Samples JavaScript stack traces up to <code>maxCallStackDepth</code>, defaults to 5." },
+                    { "name": "includeDomCounters", "optional": true, "type": "boolean", "hidden": true, "description": "Whether DOM counters data should be included into timeline events." },
+                    { "name": "includeNativeMemoryStatistics", "optional": true, "type": "boolean", "hidden": true, "description": "Whether native memory usage statistics should be reported as part of timeline events." }
+
+                ],
+                "description": "Starts capturing instrumentation events."
+            },
+            {
+                "name": "stop",
+                "description": "Stops capturing instrumentation events."
+            }
+        ],
+        "events": [
+            {
+                "name": "eventRecorded",
+                "parameters": [
+                    { "name": "record", "$ref": "TimelineEvent", "description": "Timeline event record data." }
+                ],
+                "description": "Fired for every instrumentation event while timeline is started."
+            }
+        ]
+    },
+    {
+        "domain": "Debugger",
+        "description": "Debugger domain exposes JavaScript debugging capabilities. It allows setting and removing breakpoints, stepping through execution, exploring stack traces, etc.",
+        "types": [
+            {
+                "id": "BreakpointId",
+                "type": "string",
+                "description": "Breakpoint identifier."
+            },
+            {
+                "id": "ScriptId",
+                "type": "string",
+                "description": "Unique script identifier."
+            },
+            {
+                "id": "CallFrameId",
+                "type": "string",
+                "description": "Call frame identifier."
+            },
+            {
+                "id": "Location",
+                "type": "object",
+                "properties": [
+                    { "name": "scriptId", "$ref": "ScriptId", "description": "Script identifier as reported in the <code>Debugger.scriptParsed</code>." },
+                    { "name": "lineNumber", "type": "integer", "description": "Line number in the script (0-based)." },
+                    { "name": "columnNumber", "type": "integer", "optional": true, "description": "Column number in the script (0-based)." }
+                ],
+                "description": "Location in the source code."
+            },
+            {
+                "id": "FunctionDetails",
+                "hidden": true,
+                "type": "object",
+                "properties": [
+                    { "name": "location", "$ref": "Location", "description": "Location of the function." },
+                    { "name": "name", "type": "string", "optional": true, "description": "Name of the function. Not present for anonymous functions." },
+                    { "name": "displayName", "type": "string", "optional": true, "description": "Display name of the function(specified in 'displayName' property on the function object)." },
+                    { "name": "inferredName", "type": "string", "optional": true, "description": "Name of the function inferred from its initial assignment." },
+                    { "name": "scopeChain", "type": "array", "optional": true, "items": { "$ref": "Scope" }, "description": "Scope chain for this closure." }
+                ],
+                "description": "Information about the function."
+            },
+            {
+                "id": "CallFrame",
+                "type": "object",
+                "properties": [
+                    { "name": "callFrameId", "$ref": "CallFrameId", "description": "Call frame identifier. This identifier is only valid while the virtual machine is paused." },
+                    { "name": "functionName", "type": "string", "description": "Name of the JavaScript function called on this call frame." },
+                    { "name": "location", "$ref": "Location", "description": "Location in the source code." },
+                    { "name": "scopeChain", "type": "array", "items": { "$ref": "Scope" }, "description": "Scope chain for this call frame." },
+                    { "name": "this", "$ref": "Runtime.RemoteObject", "description": "<code>this</code> object for this call frame." }
+                ],
+                "description": "JavaScript call frame. Array of call frames form the call stack."
+            },
+            {
+                "id": "Scope",
+                "type": "object",
+                "properties": [
+                    { "name": "type", "type": "string", "enum": ["global", "local", "with", "closure", "catch"], "description": "Scope type." },
+                    { "name": "object", "$ref": "Runtime.RemoteObject", "description": "Object representing the scope. For <code>global</code> and <code>with</code> scopes it represents the actual object; for the rest of the scopes, it is artificial transient object enumerating scope variables as its properties." }
+                ],
+                "description": "Scope description."
+            },
+            {
+                "id": "SetScriptSourceError",
+                "type": "object",
+                "properties": [
+                    { "name": "compileError", "optional": true, "type": "object", "properties":
+                        [
+                            { "name": "message", "type": "string", "description": "Compiler error message" },
+                            { "name": "lineNumber", "type": "integer", "description": "Compile error line number (1-based)" },
+                            { "name": "columnNumber", "type": "integer", "description": "Compile error column number (1-based)" }
+                        ]
+                    }
+                ],
+                "description": "Error data for setScriptSource command. compileError is a case type for uncompilable script source error.",
+                "hidden": true
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables debugger for the given page. Clients should not assume that the debugging has been enabled until the result for this command is received."
+            },
+            {
+                "name": "disable",
+                "description": "Disables debugger for given page."
+            },
+            {
+                "name": "setBreakpointsActive",
+                "parameters": [
+                    { "name": "active", "type": "boolean", "description": "New value for breakpoints active state." }
+                ],
+                "description": "Activates / deactivates all breakpoints on the page."
+            },
+            {
+                "name": "setSkipAllPauses",
+                "hidden": true,
+                "parameters": [
+                    { "name": "skipped", "type": "boolean", "description": "New value for skip pauses state." },
+                    { "name": "untilReload", "type": "boolean", "optional": true, "description": "Whether page reload should set skipped to false." }
+                ],
+                "description": "Makes page not interrupt on any pauses (breakpoint, exception, dom exception etc)."
+            },
+            {
+                "name": "setBreakpointByUrl",
+                "parameters": [
+                    { "name": "lineNumber", "type": "integer", "description": "Line number to set breakpoint at." },
+                    { "name": "url", "type": "string", "optional": true, "description": "URL of the resources to set breakpoint on." },
+                    { "name": "urlRegex", "type": "string", "optional": true, "description": "Regex pattern for the URLs of the resources to set breakpoints on. Either <code>url</code> or <code>urlRegex</code> must be specified." },
+                    { "name": "columnNumber", "type": "integer", "optional": true, "description": "Offset in the line to set breakpoint at." },
+                    { "name": "condition", "type": "string", "optional": true, "description": "Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true." },
+                    { "name": "isAntibreakpoint", "type": "boolean", "optional": true, "hidden": true, "description": "Creates pseudo-breakpoint that prevents debugger from pausing on exception at this location." }
+                ],
+                "returns": [
+                    { "name": "breakpointId", "$ref": "BreakpointId", "description": "Id of the created breakpoint for further reference." },
+                    { "name": "locations", "type": "array", "items": { "$ref": "Location"}, "description": "List of the locations this breakpoint resolved into upon addition." }
+                ],
+                "description": "Sets JavaScript breakpoint at given location specified either by URL or URL regex. Once this command is issued, all existing parsed scripts will have breakpoints resolved and returned in <code>locations</code> property. Further matching script parsing will result in subsequent <code>breakpointResolved</code> events issued. This logical breakpoint will survive page reloads."
+            },
+            {
+                "name": "setBreakpoint",
+                "parameters": [
+                    { "name": "location", "$ref": "Location", "description": "Location to set breakpoint in." },
+                    { "name": "condition", "type": "string", "optional": true, "description": "Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true." }
+                ],
+                "returns": [
+                    { "name": "breakpointId", "$ref": "BreakpointId", "description": "Id of the created breakpoint for further reference." },
+                    { "name": "actualLocation", "$ref": "Location", "description": "Location this breakpoint resolved into." }
+                ],
+                "description": "Sets JavaScript breakpoint at a given location."
+            },
+            {
+                "name": "removeBreakpoint",
+                "parameters": [
+                    { "name": "breakpointId", "$ref": "BreakpointId" }
+                ],
+                "description": "Removes JavaScript breakpoint."
+            },
+            {
+                "name": "continueToLocation",
+                "parameters": [
+                    { "name": "location", "$ref": "Location", "description": "Location to continue to." },
+                    { "name": "interstatementLocation", "type": "boolean", "optional": true, "hidden": true, "description": "Allows breakpoints at the intemediate positions inside statements." }
+                ],
+                "description": "Continues execution until specific location is reached."
+            },
+            {
+                "name": "stepOver",
+                "description": "Steps over the statement."
+            },
+            {
+                "name": "stepInto",
+                "description": "Steps into the function call."
+            },
+            {
+                "name": "stepOut",
+                "description": "Steps out of the function call."
+            },
+            {
+                "name": "pause",
+                "description": "Stops on the next JavaScript statement."
+            },
+            {
+                "name": "resume",
+                "description": "Resumes JavaScript execution."
+            },
+            {
+                "name": "searchInContent",
+                "parameters": [
+                    { "name": "scriptId", "$ref": "ScriptId", "description": "Id of the script to search in." },
+                    { "name": "query", "type": "string", "description": "String to search for."  },
+                    { "name": "caseSensitive", "type": "boolean", "optional": true, "description": "If true, search is case sensitive." },
+                    { "name": "isRegex", "type": "boolean", "optional": true, "description": "If true, treats string parameter as regex." }
+                ],
+                "returns": [
+                    { "name": "result", "type": "array", "items": { "$ref": "Page.SearchMatch" }, "description": "List of search matches." }
+                ],
+                "description": "Searches for given string in script content."
+            },
+            {
+                "name": "canSetScriptSource",
+                "returns": [
+                    { "name": "result", "type": "boolean", "description": "True if <code>setScriptSource</code> is supported." }
+                ],
+                "description": "Always returns true."
+            },
+            {
+                "name": "setScriptSource",
+                "parameters": [
+                    { "name": "scriptId", "$ref": "ScriptId", "description": "Id of the script to edit." },
+                    { "name": "scriptSource", "type": "string", "description": "New content of the script." },
+                    { "name": "preview", "type": "boolean", "optional": true, "description": " If true the change will not actually be applied. Preview mode may be used to get result description without actually modifying the code.", "hidden": true }
+                ],
+                "returns": [
+                    { "name": "callFrames", "type": "array", "optional": true, "items": { "$ref": "CallFrame"}, "description": "New stack trace in case editing has happened while VM was stopped." },
+                    { "name": "result", "type": "object", "optional": true, "description": "VM-specific description of the changes applied.", "hidden": true }
+                ],
+                "error": {
+                    "$ref": "SetScriptSourceError"
+                },
+                "description": "Edits JavaScript source live."
+            },
+            {
+                "name": "restartFrame",
+                "parameters": [
+                    { "name": "callFrameId", "$ref": "CallFrameId", "description": "Call frame identifier to evaluate on." }
+                ],
+                "returns": [
+                    { "name": "callFrames", "type": "array", "items": { "$ref": "CallFrame"}, "description": "New stack trace." },
+                    { "name": "result", "type": "object", "description": "VM-specific description.", "hidden": true }
+                ],
+                "hidden": true,
+                "description": "Restarts particular call frame from the beginning."
+            },
+            {
+                "name": "getScriptSource",
+                "parameters": [
+                    { "name": "scriptId", "$ref": "ScriptId", "description": "Id of the script to get source for." }
+                ],
+                "returns": [
+                    { "name": "scriptSource", "type": "string", "description": "Script source." }
+                ],
+                "description": "Returns source for the script with given id."
+            },
+            {
+                "name": "getFunctionDetails",
+                "hidden": true,
+                "parameters": [
+                    { "name": "functionId", "$ref": "Runtime.RemoteObjectId", "description": "Id of the function to get location for." }
+                ],
+                "returns": [
+                    { "name": "details", "$ref": "FunctionDetails", "description": "Information about the function." }
+                ],
+                "description": "Returns detailed informtation on given function."
+            },
+            {
+                "name": "setPauseOnExceptions",
+                "parameters": [
+                    { "name": "state", "type": "string", "enum": ["none", "uncaught", "all"], "description": "Pause on exceptions mode." }
+                ],
+                "description": "Defines pause on exceptions state. Can be set to stop on all exceptions, uncaught exceptions or no exceptions. Initial pause on exceptions state is <code>none</code>."
+            },
+            {
+                "name": "evaluateOnCallFrame",
+                "parameters": [
+                    { "name": "callFrameId", "$ref": "CallFrameId", "description": "Call frame identifier to evaluate on." },
+                    { "name": "expression", "type": "string", "description": "Expression to evaluate." },
+                    { "name": "objectGroup", "type": "string", "optional": true, "description": "String object group name to put result into (allows rapid releasing resulting object handles using <code>releaseObjectGroup</code>)." },
+                    { "name": "includeCommandLineAPI", "type": "boolean", "optional": true, "description": "Specifies whether command line API should be available to the evaluated expression, defaults to false.", "hidden": true },
+                    { "name": "doNotPauseOnExceptionsAndMuteConsole", "type": "boolean", "optional": true, "description": "Specifies whether evaluation should stop on exceptions and mute console. Overrides setPauseOnException state.", "hidden": true },
+                    { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object that should be sent by value." },
+                    { "name": "generatePreview", "type": "boolean", "optional": true, "hidden": true, "description": "Whether preview should be generated for the result." }
+                ],
+                "returns": [
+                    { "name": "result", "$ref": "Runtime.RemoteObject", "description": "Object wrapper for the evaluation result." },
+                    { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." }
+                ],
+                "description": "Evaluates expression on a given call frame."
+            },
+            {
+                "name": "compileScript",
+                "hidden": true,
+                "parameters": [
+                    { "name": "expression", "type": "string", "description": "Expression to compile." },
+                    { "name": "sourceURL", "type": "string", "description": "Source url to be set for the script." }
+                ],
+                "returns": [
+                    { "name": "scriptId", "$ref": "ScriptId", "optional": true, "description": "Id of the script." },
+                    { "name": "syntaxErrorMessage", "type": "string", "optional": true, "description": "Syntax error message if compilation failed." }
+                ],
+                "description": "Compiles expression."
+            },
+            {
+                "name": "runScript",
+                "hidden": true,
+                "parameters": [
+                    { "name": "scriptId", "$ref": "ScriptId", "description": "Id of the script to run." },
+                    { "name": "contextId", "$ref": "Runtime.ExecutionContextId", "optional": true, "description": "Specifies in which isolated context to perform script run. Each content script lives in an isolated context and this parameter may be used to specify one of those contexts. If the parameter is omitted or 0 the evaluation will be performed in the context of the inspected page." },
+                    { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." },
+                    { "name": "doNotPauseOnExceptionsAndMuteConsole", "type": "boolean", "optional": true, "description": "Specifies whether script run should stop on exceptions and mute console. Overrides setPauseOnException state." }
+                ],
+                "returns": [
+                    { "name": "result", "$ref": "Runtime.RemoteObject", "description": "Run result." },
+                    { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the script run." }
+                ],
+                "description": "Runs script with given id in a given context."
+            },
+            {
+                "name": "setOverlayMessage",
+                "parameters": [
+                    { "name": "message", "type": "string", "optional": true, "description": "Overlay message to display when paused in debugger." }
+                ],
+                "hidden": true,
+                "description": "Sets overlay message."
+            },
+            {
+                "name": "setVariableValue",
+                "parameters": [
+                    { "name": "scopeNumber", "type": "integer", "description": "0-based number of scope as was listed in scope chain. Only 'local', 'closure' and 'catch' scope types are allowed. Other scopes could be manipulated manually." },
+                    { "name": "variableName", "type": "string", "description": "Variable name." },
+                    { "name": "newValue", "$ref": "Runtime.CallArgument", "description": "New variable value." },
+                    { "name": "callFrameId", "$ref": "CallFrameId", "optional": true, "description": "Id of callframe that holds variable." },
+                    { "name": "functionObjectId", "$ref": "Runtime.RemoteObjectId", "optional": true, "description": "Object id of closure (function) that holds variable." }
+                ],
+                "hidden": true,
+                "description": "Changes value of variable in a callframe or a closure. Either callframe or function must be specified. Object-based scopes are not supported and must be mutated manually."
+            },
+            {
+                "name": "getStepInPositions",
+                "parameters": [
+                    { "name": "callFrameId", "$ref": "CallFrameId", "description": "Id of a call frame where the current statement should be analized" }
+                ],
+                "returns": [
+                    { "name": "stepInPositions", "type": "array", "items": { "$ref": "Location" }, "optional": true, "description": "experimental" }
+                ],
+                "hidden": true,
+                "description": "Lists all positions where step-in is possible for a current statement in a specified call frame"
+            },
+            {
+                "name": "getBacktrace",
+                "returns": [
+                    { "name": "callFrames", "type": "array", "items": { "$ref": "CallFrame"}, "description": "Call stack the virtual machine stopped on." }
+                ],
+                "hidden": true,
+                "description": "Returns call stack including variables changed since VM was paused. VM must be paused."
+            },
+            {
+                "name": "skipStackFrames",
+                "parameters": [
+                    { "name": "script", "optional": true, "type": "string", "description": "Regular expression defining the scripts to ignore while stepping." }
+                ],
+                "hidden": true,
+                "description": "Makes backend skip steps in the sources with names matching given pattern. VM will try leave blacklisted scripts by performing 'step in' several times, finally resorting to 'step out' if unsuccessful."
+            }
+        ],
+        "events": [
+            {
+                "name": "globalObjectCleared",
+                "description": "Called when global has been cleared and debugger client should reset its state. Happens upon navigation or reload."
+            },
+            {
+                "name": "scriptParsed",
+                "parameters": [
+                    { "name": "scriptId", "$ref": "ScriptId", "description": "Identifier of the script parsed." },
+                    { "name": "url", "type": "string", "description": "URL or name of the script parsed (if any)." },
+                    { "name": "startLine", "type": "integer", "description": "Line offset of the script within the resource with given URL (for script tags)." },
+                    { "name": "startColumn", "type": "integer", "description": "Column offset of the script within the resource with given URL." },
+                    { "name": "endLine", "type": "integer", "description": "Last line of the script." },
+                    { "name": "endColumn", "type": "integer", "description": "Length of the last line of the script." },
+                    { "name": "isContentScript", "type": "boolean", "optional": true, "description": "Determines whether this script is a user extension script." },
+                    { "name": "sourceMapURL", "type": "string", "optional": true, "description": "URL of source map associated with script (if any)." },
+                    { "name": "hasSourceURL", "type": "boolean", "optional": true, "description": "True, if this script has sourceURL.", "hidden": true }
+                ],
+                "description": "Fired when virtual machine parses script. This event is also fired for all known and uncollected scripts upon enabling debugger."
+            },
+            {
+                "name": "scriptFailedToParse",
+                "parameters": [
+                    { "name": "scriptId", "$ref": "ScriptId", "description": "Identifier of the script parsed." },
+                    { "name": "url", "type": "string", "description": "URL or name of the script parsed (if any)." },
+                    { "name": "startLine", "type": "integer", "description": "Line offset of the script within the resource with given URL (for script tags)." },
+                    { "name": "startColumn", "type": "integer", "description": "Column offset of the script within the resource with given URL." },
+                    { "name": "endLine", "type": "integer", "description": "Last line of the script." },
+                    { "name": "endColumn", "type": "integer", "description": "Length of the last line of the script." },
+                    { "name": "isContentScript", "type": "boolean", "optional": true, "description": "Determines whether this script is a user extension script." },
+                    { "name": "sourceMapURL", "type": "string", "optional": true, "description": "URL of source map associated with script (if any)." },
+                    { "name": "hasSourceURL", "type": "boolean", "optional": true, "description": "True, if this script has sourceURL.", "hidden": true }
+                ],
+                "description": "Fired when virtual machine fails to parse the script."
+            },
+            {
+                "name": "breakpointResolved",
+                "parameters": [
+                    { "name": "breakpointId", "$ref": "BreakpointId", "description": "Breakpoint unique identifier." },
+                    { "name": "location", "$ref": "Location", "description": "Actual breakpoint location." }
+                ],
+                "description": "Fired when breakpoint is resolved to an actual script and location."
+            },
+            {
+                "name": "paused",
+                "parameters": [
+                    { "name": "callFrames", "type": "array", "items": { "$ref": "CallFrame" }, "description": "Call stack the virtual machine stopped on." },
+                    { "name": "reason", "type": "string", "enum": [ "XHR", "DOM", "EventListener", "exception", "assert", "CSPViolation", "debugCommand", "other" ], "description": "Pause reason." },
+                    { "name": "data", "type": "object", "optional": true, "description": "Object containing break-specific auxiliary properties." },
+                    { "name": "hitBreakpoints", "type": "array", "optional": true, "items": { "type": "string" }, "description": "Hit breakpoints IDs", "hidden": true }
+                ],
+                "description": "Fired when the virtual machine stopped on breakpoint or exception or any other stop criteria."
+            },
+            {
+                "name": "resumed",
+                "description": "Fired when the virtual machine resumed execution."
+            }
+        ]
+    },
+    {
+        "domain": "DOMDebugger",
+        "description": "DOM debugging allows setting breakpoints on particular DOM operations and events. JavaScript execution will stop on these operations as if there was a regular breakpoint set.",
+        "types": [
+            {
+                "id": "DOMBreakpointType",
+                "type": "string",
+                "enum": ["subtree-modified", "attribute-modified", "node-removed"],
+                "description": "DOM breakpoint type."
+            }
+        ],
+        "commands": [
+            {
+                "name": "setDOMBreakpoint",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId", "description": "Identifier of the node to set breakpoint on." },
+                    { "name": "type", "$ref": "DOMBreakpointType", "description": "Type of the operation to stop upon." }
+                ],
+                "description": "Sets breakpoint on particular operation with DOM."
+            },
+            {
+                "name": "removeDOMBreakpoint",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId", "description": "Identifier of the node to remove breakpoint from." },
+                    { "name": "type", "$ref": "DOMBreakpointType", "description": "Type of the breakpoint to remove." }
+                ],
+                "description": "Removes DOM breakpoint that was set using <code>setDOMBreakpoint</code>."
+            },
+            {
+                "name": "setEventListenerBreakpoint",
+                "parameters": [
+                    { "name": "eventName", "type": "string", "description": "DOM Event name to stop on (any DOM event will do)." }
+                ],
+                "description": "Sets breakpoint on particular DOM event."
+            },
+            {
+                "name": "removeEventListenerBreakpoint",
+                "parameters": [
+                    { "name": "eventName", "type": "string", "description": "Event name." }
+                ],
+                "description": "Removes breakpoint on particular DOM event."
+            },
+            {
+                "name": "setInstrumentationBreakpoint",
+                "parameters": [
+                    { "name": "eventName", "type": "string", "description": "Instrumentation name to stop on." }
+                ],
+                "description": "Sets breakpoint on particular native event.",
+                "hidden": true
+            },
+            {
+                "name": "removeInstrumentationBreakpoint",
+                "parameters": [
+                    { "name": "eventName", "type": "string", "description": "Instrumentation name to stop on." }
+                ],
+                "description": "Removes breakpoint on particular native event.",
+                "hidden": true
+            },
+            {
+                "name": "setXHRBreakpoint",
+                "parameters": [
+                    { "name": "url", "type": "string", "description": "Resource URL substring. All XHRs having this substring in the URL will get stopped upon." }
+                ],
+                "description": "Sets breakpoint on XMLHttpRequest."
+            },
+            {
+                "name": "removeXHRBreakpoint",
+                "parameters": [
+                    { "name": "url", "type": "string", "description": "Resource URL substring." }
+                ],
+                "description": "Removes breakpoint from XMLHttpRequest."
+            }
+        ]
+    },
+    {
+        "domain": "Profiler",
+        "hidden": true,
+        "types": [
+            {
+                "id": "ProfileHeader",
+                "type": "object",
+                "description": "Profile header.",
+                "properties": [
+                    { "name": "title", "type": "string", "description": "Profile title." },
+                    { "name": "uid", "type": "integer", "description": "Unique identifier of the profile." }
+                ]
+            },
+            {
+                "id": "CPUProfileNode",
+                "type": "object",
+                "description": "CPU Profile node. Holds callsite information, execution statistics and child nodes.",
+                "properties": [
+                    { "name": "functionName", "type": "string", "description": "Function name." },
+                    { "name": "scriptId", "$ref": "Debugger.ScriptId", "description": "Script identifier." },
+                    { "name": "url", "type": "string", "description": "URL." },
+                    { "name": "lineNumber", "type": "integer", "description": "Line number." },
+                    { "name": "hitCount", "type": "integer", "description": "Number of samples where this node was on top of the call stack." },
+                    { "name": "callUID", "type": "number", "description": "Call UID." },
+                    { "name": "children", "type": "array", "items": { "$ref": "CPUProfileNode" }, "description": "Child nodes." },
+                    { "name": "deoptReason", "type": "string", "description": "The reason of being not optimized. The function may be deoptimized or marked as don't optimize."},
+                    { "name": "id", "optional": true, "type": "integer", "description": "Unique id of the node." }
+                ]
+            },
+            {
+                "id": "CPUProfile",
+                "type": "object",
+                "description": "Profile.",
+                "properties": [
+                    { "name": "head", "$ref": "CPUProfileNode" },
+                    { "name": "startTime", "type": "number", "description": "Profiling start time in seconds." },
+                    { "name": "endTime", "type": "number", "description": "Profiling end time in seconds." },
+                    { "name": "samples", "optional": true, "type": "array", "items": { "type": "integer" }, "description": "Ids of samples top nodes." }
+                ]
+            },
+            {
+                "id": "HeapSnapshotObjectId",
+                "type": "string",
+                "description": "Heap snashot object id."
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable"
+            },
+            {
+                "name": "disable"
+            },
+            {
+                "name": "start"
+            },
+            {
+                "name": "stop",
+                "returns": [
+                    { "name": "header", "$ref": "ProfileHeader", "description": "The header of the recorded profile."}
+                ]
+            },
+            {
+                "name": "getProfileHeaders",
+                "returns": [
+                    { "name": "headers", "type": "array", "items": { "$ref": "ProfileHeader"} }
+                ]
+            },
+            {
+                "name": "getCPUProfile",
+                "parameters": [
+                    { "name": "uid", "type": "integer" }
+                ],
+                "returns": [
+                    { "name": "profile", "$ref": "CPUProfile" }
+                ]
+            },
+            {
+                "name": "removeProfile",
+                "parameters": [
+                    { "name": "type", "type": "string" },
+                    { "name": "uid", "type": "integer" }
+                ]
+            },
+            {
+                "name": "clearProfiles"
+            }
+        ],
+        "events": [
+            {
+                "name": "addProfileHeader",
+                "parameters": [
+                    { "name": "header", "$ref": "ProfileHeader" }
+                ]
+            },
+            {
+                "name": "setRecordingProfile",
+                "parameters": [
+                    { "name": "isProfiling", "type": "boolean" }
+                ]
+            },
+            {
+                "name": "resetProfiles"
+            }
+        ]
+    },
+    {
+        "domain": "HeapProfiler",
+        "hidden": true,
+        "types": [
+            {
+                "id": "ProfileHeader",
+                "type": "object",
+                "description": "Profile header.",
+                "properties": [
+                    { "name": "title", "type": "string", "description": "Profile title." },
+                    { "name": "uid", "type": "integer", "description": "Unique identifier of the profile." },
+                    { "name": "maxJSObjectId", "type": "integer", "optional": true, "description": "Last seen JS object Id." }
+                ]
+            },
+            {
+                "id": "HeapSnapshotObjectId",
+                "type": "string",
+                "description": "Heap snashot object id."
+            }
+        ],
+        "commands": [
+            {
+                "name": "getProfileHeaders",
+                "returns": [
+                    { "name": "headers", "type": "array", "items": { "$ref": "ProfileHeader"} }
+                ]
+            },
+            {
+                "name": "startTrackingHeapObjects"
+            },
+            {
+                "name": "stopTrackingHeapObjects"
+            },
+            {
+                "name": "getHeapSnapshot",
+                "parameters": [
+                    { "name": "uid", "type": "integer" }
+                ]
+            },
+            {
+                "name": "removeProfile",
+                "parameters": [
+                    { "name": "uid", "type": "integer" }
+                ]
+            },
+            {
+                "name": "clearProfiles"
+            },
+            {
+                "name": "takeHeapSnapshot",
+                "parameters": [
+                    { "name": "reportProgress", "type": "boolean", "optional": true, "description": "If true 'reportHeapSnapshotProgress' events will be generated while snapshot is being taken." }
+                ]
+            },
+            {
+                "name": "collectGarbage"
+            },
+            {
+                "name": "getObjectByHeapObjectId",
+                "parameters": [
+                    { "name": "objectId", "$ref": "HeapSnapshotObjectId" },
+                    { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." }
+                ],
+                "returns": [
+                    { "name": "result", "$ref": "Runtime.RemoteObject", "description": "Evaluation result." }
+                ]
+            },
+            {
+                "name": "getHeapObjectId",
+                "parameters": [
+                    { "name": "objectId", "$ref": "Runtime.RemoteObjectId", "description": "Identifier of the object to get heap object id for." }
+                ],
+                "returns": [
+                    { "name": "heapSnapshotObjectId", "$ref": "HeapSnapshotObjectId", "description": "Id of the heap snapshot object corresponding to the passed remote object id." }
+                ]
+            }
+        ],
+        "events": [
+            {
+                "name": "addProfileHeader",
+                "parameters": [
+                    { "name": "header", "$ref": "ProfileHeader" }
+                ]
+            },
+            {
+                "name": "addHeapSnapshotChunk",
+                "parameters": [
+                    { "name": "uid", "type": "integer" },
+                    { "name": "chunk", "type": "string" }
+                ]
+            },
+            {
+                "name": "finishHeapSnapshot",
+                "parameters": [
+                    { "name": "uid", "type": "integer" }
+                ]
+            },
+            {
+                "name": "resetProfiles"
+            },
+            {
+                "name": "reportHeapSnapshotProgress",
+                "parameters": [
+                    { "name": "done", "type": "integer" },
+                    { "name": "total", "type": "integer" }
+                ]
+            },
+            {
+                "name": "lastSeenObjectId",
+                "description": "If heap objects tracking has been started then backend regulary sends a current value for last seen object id and corresponding timestamp. If the were changes in the heap since last event then one or more heapStatsUpdate events will be sent before a new lastSeenObjectId event.",
+                "parameters": [
+                    { "name": "lastSeenObjectId", "type": "integer" },
+                    { "name": "timestamp", "type": "number" }
+                ]
+            },
+            {
+                "name": "heapStatsUpdate",
+                "description": "If heap objects tracking has been started then backend may send update for one or more fragments",
+                "parameters": [
+                    { "name": "statsUpdate", "type": "array", "items": { "type": "integer" }, "description": "An array of triplets. Each triplet describes a fragment. The first integer is the fragment index, the second integer is a total count of objects for the fragment, the third integer is a total size of the objects for the fragment."}
+                ]
+            }
+        ]
+    },
+    {
+        "domain": "Worker",
+        "hidden": true,
+        "types": [],
+        "commands": [
+            {
+                "name": "enable"
+            },
+            {
+                "name": "disable"
+            },
+            {
+                "name": "sendMessageToWorker",
+                "parameters": [
+                    { "name": "workerId", "type": "integer" },
+                    { "name": "message", "type": "object" }
+                ]
+            },
+            {
+                "name": "canInspectWorkers",
+                "description": "Tells whether browser supports workers inspection.",
+                "returns": [
+                    { "name": "result", "type": "boolean", "description": "True if browser has workers support." }
+                ]
+            },
+            {
+                "name": "connectToWorker",
+                "parameters": [
+                    { "name": "workerId", "type": "integer" }
+                ]
+            },
+            {
+                "name": "disconnectFromWorker",
+                "parameters": [
+                    { "name": "workerId", "type": "integer" }
+                ]
+            },
+            {
+                "name": "setAutoconnectToWorkers",
+                "parameters": [
+                    { "name": "value", "type": "boolean" }
+                ]
+            }
+        ],
+        "events": [
+            {
+                "name": "workerCreated",
+                "parameters": [
+                    { "name": "workerId", "type": "integer" },
+                    { "name": "url", "type": "string" },
+                    { "name": "inspectorConnected", "type": "boolean" }
+                ]
+            },
+            {
+                "name": "workerTerminated",
+                "parameters": [
+                    { "name": "workerId", "type": "integer" }
+                ]
+            },
+            {
+                "name": "dispatchMessageFromWorker",
+                "parameters": [
+                    { "name": "workerId", "type": "integer" },
+                    { "name": "message", "type": "object" }
+                ]
+            },
+            {
+                "name": "disconnectedFromWorker"
+            }
+        ]
+    },
+    {
+        "domain": "Canvas",
+        "hidden": true,
+        "types": [
+            {
+                "id": "ResourceId",
+                "type": "string",
+                "description": "Unique resource identifier."
+            },
+            {
+                "id": "ResourceStateDescriptor",
+                "type": "object",
+                "description": "Resource state descriptor.",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "State name." },
+                    { "name": "enumValueForName", "type": "string", "optional": true, "description": "String representation of the enum value, if <code>name</code> stands for an enum." },
+                    { "name": "value", "$ref": "CallArgument", "optional": true, "description": "The value associated with the particular state." },
+                    { "name": "values", "type": "array", "items": { "$ref": "ResourceStateDescriptor" }, "optional": true, "description": "Array of values associated with the particular state. Either <code>value</code> or <code>values</code> will be specified." },
+                    { "name": "isArray", "type": "boolean", "optional": true, "description": "True iff the given <code>values</code> items stand for an array rather than a list of grouped states." }
+                ]
+            },
+            {
+                "id": "ResourceState",
+                "type": "object",
+                "description": "Resource state.",
+                "properties": [
+                    { "name": "id", "$ref": "ResourceId" },
+                    { "name": "traceLogId", "$ref": "TraceLogId" },
+                    { "name": "descriptors", "type": "array", "items": { "$ref": "ResourceStateDescriptor" }, "optional": true, "description": "Describes current <code>Resource</code> state." },
+                    { "name": "imageURL", "type": "string", "optional": true, "description": "Screenshot image data URL." }
+                ]
+            },
+            {
+                "id": "CallArgument",
+                "type": "object",
+                "properties": [
+                    { "name": "description", "type": "string", "description": "String representation of the object." },
+                    { "name": "enumName", "type": "string", "optional": true, "description": "Enum name, if any, that stands for the value (for example, a WebGL enum name)." },
+                    { "name": "resourceId", "$ref": "ResourceId", "optional": true, "description": "Resource identifier. Specified for <code>Resource</code> objects only." },
+                    { "name": "type", "type": "string", "optional": true, "enum": ["object", "function", "undefined", "string", "number", "boolean"], "description": "Object type. Specified for non <code>Resource</code> objects only." },
+                    { "name": "subtype", "type": "string", "optional": true, "enum": ["array", "null", "node", "regexp", "date"], "description": "Object subtype hint. Specified for <code>object</code> type values only." },
+                    { "name": "remoteObject", "$ref": "Runtime.RemoteObject", "optional": true, "description": "The <code>RemoteObject</code>, if requested." }
+                ]
+            },
+            {
+                "id": "Call",
+                "type": "object",
+                "properties": [
+                    { "name": "contextId", "$ref": "ResourceId" },
+                    { "name": "functionName", "type": "string", "optional": true },
+                    { "name": "arguments", "type": "array", "items": { "$ref": "CallArgument" }, "optional": true },
+                    { "name": "result", "$ref": "CallArgument", "optional": true },
+                    { "name": "isDrawingCall", "type": "boolean", "optional": true },
+                    { "name": "isFrameEndCall", "type": "boolean", "optional": true },
+                    { "name": "property", "type": "string", "optional": true },
+                    { "name": "value", "$ref": "CallArgument", "optional": true },
+                    { "name": "sourceURL", "type": "string", "optional": true },
+                    { "name": "lineNumber", "type": "integer", "optional": true },
+                    { "name": "columnNumber", "type": "integer", "optional": true }
+                ]
+            },
+            {
+                "id": "TraceLogId",
+                "type": "string",
+                "description": "Unique trace log identifier."
+            },
+            {
+                "id": "TraceLog",
+                "type": "object",
+                "properties": [
+                    { "name": "id", "$ref": "TraceLogId" },
+                    { "name": "calls", "type": "array", "items": { "$ref": "Call" } },
+                    { "name": "contexts", "type": "array", "items": { "$ref": "CallArgument" } },
+                    { "name": "startOffset", "type": "integer" },
+                    { "name": "alive", "type": "boolean" },
+                    { "name": "totalAvailableCalls", "type": "number" }
+                ]
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables Canvas inspection."
+            },
+            {
+                "name": "disable",
+                "description": "Disables Canvas inspection."
+            },
+            {
+                "name": "dropTraceLog",
+                "parameters": [
+                    { "name": "traceLogId", "$ref": "TraceLogId" }
+                ]
+            },
+            {
+                "name": "hasUninstrumentedCanvases",
+                "returns": [
+                    { "name": "result", "type": "boolean" }
+                ],
+                "description": "Checks if there is any uninstrumented canvas in the inspected page."
+            },
+            {
+                "name": "captureFrame",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Page.FrameId", "optional": true, "description": "Identifier of the frame containing document whose canvases are to be captured. If omitted, main frame is assumed." }
+                ],
+                "returns": [
+                    { "name": "traceLogId", "$ref": "TraceLogId", "description": "Identifier of the trace log containing captured canvas calls." }
+                ],
+                "description": "Starts (or continues) a canvas frame capturing which will be stopped automatically after the next frame is prepared."
+            },
+            {
+                "name": "startCapturing",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Page.FrameId", "optional": true, "description": "Identifier of the frame containing document whose canvases are to be captured. If omitted, main frame is assumed." }
+                ],
+                "returns": [
+                    { "name": "traceLogId", "$ref": "TraceLogId", "description": "Identifier of the trace log containing captured canvas calls." }
+                ],
+                "description": "Starts (or continues) consecutive canvas frames capturing. The capturing is stopped by the corresponding stopCapturing command."
+            },
+            {
+                "name": "stopCapturing",
+                "parameters": [
+                    { "name": "traceLogId", "$ref": "TraceLogId" }
+                ]
+            },
+            {
+                "name": "getTraceLog",
+                "parameters": [
+                    { "name": "traceLogId", "$ref": "TraceLogId" },
+                    { "name": "startOffset", "type": "integer", "optional": true },
+                    { "name": "maxLength", "type": "integer", "optional": true }
+                ],
+                "returns": [
+                    { "name": "traceLog", "$ref": "TraceLog" }
+                ]
+            },
+            {
+                "name": "replayTraceLog",
+                "parameters": [
+                    { "name": "traceLogId", "$ref": "TraceLogId" },
+                    { "name": "stepNo", "type": "integer", "description": "Last call index in the trace log to replay (zero based)." }
+                ],
+                "returns": [
+                    { "name": "resourceState", "$ref": "ResourceState" },
+                    { "name": "replayTime", "type": "number", "description": "Replay time (in milliseconds)." }
+                ]
+            },
+            {
+                "name": "getResourceState",
+                "parameters": [
+                    { "name": "traceLogId", "$ref": "TraceLogId" },
+                    { "name": "resourceId", "$ref": "ResourceId" }
+                ],
+                "returns": [
+                    { "name": "resourceState", "$ref": "ResourceState" }
+                ]
+            },
+            {
+                "name": "evaluateTraceLogCallArgument",
+                "parameters": [
+                    { "name": "traceLogId", "$ref": "TraceLogId" },
+                    { "name": "callIndex", "type": "integer", "description": "Index of the call to evaluate on (zero based)." },
+                    { "name": "argumentIndex", "type": "integer", "description": "Index of the argument to evaluate (zero based). Provide <code>-1</code> to evaluate call result." },
+                    { "name": "objectGroup", "type": "string", "optional": true, "description": "String object group name to put result into (allows rapid releasing resulting object handles using <code>Runtime.releaseObjectGroup</code>)." }
+                ],
+                "returns": [
+                    { "name": "result", "$ref": "Runtime.RemoteObject", "optional": true, "description": "Object wrapper for the evaluation result." },
+                    { "name": "resourceState", "$ref": "ResourceState", "optional": true, "description": "State of the <code>Resource</code> object." }
+                ],
+                "description": "Evaluates a given trace call argument or its result."
+            }
+        ],
+        "events": [
+            {
+                "name": "contextCreated",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Page.FrameId", "description": "Identifier of the frame containing a canvas with a context." }
+                ],
+                "description": "Fired when a canvas context has been created in the given frame. The context may not be instrumented (see hasUninstrumentedCanvases command)."
+            },
+            {
+                "name": "traceLogsRemoved",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Page.FrameId", "optional": true, "description": "If given, trace logs from the given frame were removed." },
+                    { "name": "traceLogId", "$ref": "TraceLogId", "optional": true, "description": "If given, trace log with the given ID was removed." }
+                ],
+                "description": "Fired when a set of trace logs were removed from the backend. If no parameters are given, all trace logs were removed."
+            }
+        ]
+    },
+    {
+        "domain": "Input",
+        "types": [
+            {
+                "id": "TouchPoint",
+                "type": "object",
+                "hidden": true,
+                "properties": [
+                    { "name": "state", "type": "string", "enum": ["touchPressed", "touchReleased", "touchMoved", "touchStationary", "touchCancelled"], "description": "State of the touch point." },
+                    { "name": "x", "type": "integer", "description": "X coordinate of the event relative to the main frame's viewport."},
+                    { "name": "y", "type": "integer", "description": "Y coordinate of the event relative to the main frame's viewport. 0 refers to the top of the viewport and Y increases as it proceeds towards the bottom of the viewport."},
+                    { "name": "radiusX", "type": "integer", "optional": true, "description": "X radius of the touch area (default: 1)."},
+                    { "name": "radiusY", "type": "integer", "optional": true, "description": "Y radius of the touch area (default: 1)."},
+                    { "name": "rotationAngle", "type": "number", "optional": true, "description": "Rotation angle (default: 0.0)."},
+                    { "name": "force", "type": "number", "optional": true, "description": "Force (default: 1.0)."},
+                    { "name": "id", "type": "number", "optional": true, "description": "Identifier used to track touch sources between events, must be unique within an event."}
+                ]
+            }
+        ],
+        "commands": [
+            {
+                "name": "dispatchKeyEvent",
+                "parameters": [
+                    { "name": "type", "type": "string", "enum": ["keyDown", "keyUp", "rawKeyDown", "char"], "description": "Type of the key event." },
+                    { "name": "modifiers", "type": "integer", "optional": true, "description": "Bit field representing pressed modifier keys. Alt=1, Ctrl=2, Meta/Command=4, Shift=8 (default: 0)." },
+                    { "name": "timestamp", "type": "number", "optional": true, "description": "Time at which the event occurred. Measured in UTC time in seconds since January 1, 1970 (default: current time)." },
+                    { "name": "text", "type": "string", "optional": true, "description": "Text as generated by processing a virtual key code with a keyboard layout. Not needed for for <code>keyUp</code> and <code>rawKeyDown</code> events (default: \"\")" },
+                    { "name": "unmodifiedText", "type": "string", "optional": true, "description": "Text that would have been generated by the keyboard if no modifiers were pressed (except for shift). Useful for shortcut (accelerator) key handling (default: \"\")." },
+                    { "name": "keyIdentifier", "type": "string", "optional": true, "description": "Unique key identifier (e.g., 'U+0041') (default: \"\")." },
+                    { "name": "windowsVirtualKeyCode", "type": "integer", "optional": true, "description": "Windows virtual key code (default: 0)." },
+                    { "name": "nativeVirtualKeyCode", "type": "integer", "optional": true, "description": "Native virtual key code (default: 0)." },
+                    { "name": "autoRepeat", "type": "boolean", "optional": true, "description": "Whether the event was generated from auto repeat (default: false)." },
+                    { "name": "isKeypad", "type": "boolean", "optional": true, "description": "Whether the event was generated from the keypad (default: false)." },
+                    { "name": "isSystemKey", "type": "boolean", "optional": true, "description": "Whether the event was a system key event (default: false)." }
+                ],
+                "description": "Dispatches a key event to the page."
+            },
+            {
+                "name": "dispatchMouseEvent",
+                "parameters": [
+                    { "name": "type", "type": "string", "enum": ["mousePressed", "mouseReleased", "mouseMoved"], "description": "Type of the mouse event." },
+                    { "name": "x", "type": "integer", "description": "X coordinate of the event relative to the main frame's viewport."},
+                    { "name": "y", "type": "integer", "description": "Y coordinate of the event relative to the main frame's viewport. 0 refers to the top of the viewport and Y increases as it proceeds towards the bottom of the viewport."},
+                    { "name": "modifiers", "type": "integer", "optional": true, "description": "Bit field representing pressed modifier keys. Alt=1, Ctrl=2, Meta/Command=4, Shift=8 (default: 0)." },
+                    { "name": "timestamp", "type": "number", "optional": true, "description": "Time at which the event occurred. Measured in UTC time in seconds since January 1, 1970 (default: current time)." },
+                    { "name": "button", "type": "string", "enum": ["none", "left", "middle", "right"], "optional": true, "description": "Mouse button (default: \"none\")." },
+                    { "name": "clickCount", "type": "integer", "optional": true, "description": "Number of times the mouse button was clicked (default: 0)." },
+                    { "name": "deviceSpace", "type": "boolean", "optional": true, "hidden": true, "description": "If true, x and y are given in dip wrt current viewport." }
+                ],
+                "description": "Dispatches a mouse event to the page."
+            },
+            {
+                "name": "dispatchTouchEvent",
+                "hidden": true,
+                "parameters": [
+                    { "name": "type", "type": "string", "enum": ["touchStart", "touchEnd", "touchMove"], "description": "Type of the touch event." },
+                    { "name": "touchPoints", "type": "array", "items": { "$ref": "TouchPoint" }, "description": "Touch points." },
+                    { "name": "modifiers", "type": "integer", "optional": true, "description": "Bit field representing pressed modifier keys. Alt=1, Ctrl=2, Meta/Command=4, Shift=8 (default: 0)." },
+                    { "name": "timestamp", "type": "number", "optional": true, "description": "Time at which the event occurred. Measured in UTC time in seconds since January 1, 1970 (default: current time)." }
+                ],
+                "description": "Dispatches a touch event to the page."
+            },
+            {
+                "name": "dispatchGestureEvent",
+                "hidden": true,
+                "parameters": [
+                    { "name": "type", "type": "string", "enum": ["scrollBegin", "scrollEnd", "scrollUpdate", "tapDown", "tap", "pinchBegin", "pinchEnd", "pinchUpdate"], "description": "Type of the gesture event." },
+                    { "name": "x", "type": "integer", "description": "X coordinate relative to the screen's viewport."},
+                    { "name": "y", "type": "integer", "description": "Y coordinate relative to the screen's viewport."},
+                    { "name": "timestamp", "type": "number", "optional": true, "description": "Time at which the event occurred. Measured in UTC time in seconds since January 1, 1970 (default: current time)." },
+                    { "name": "deltaX", "type": "integer", "optional": true, "description": "Delta X where apllies."},
+                    { "name": "deltaY", "type": "integer", "optional": true, "description": "Delta Y where apllies."},
+                    { "name": "pinchScale", "type": "number", "optional": true, "description": "Pinch scale." }
+                ],
+                "description": "Dispatches a gesture event to the page."
+            }
+        ],
+        "events": []
+    },
+    {
+        "domain": "LayerTree",
+        "hidden": true,
+        "types": [
+            {
+                "id": "LayerId",
+                "type": "string",
+                "description": "Unique RenderLayer identifier."
+            },
+            {
+                "id": "Layer",
+                "type": "object",
+                "description": "Information about a compositing layer.",
+                "properties": [
+                    { "name": "layerId", "$ref": "LayerId", "description": "The unique id for this layer." },
+                    { "name": "parentLayerId", "$ref": "LayerId", "optional": true, "description": "The id of parent (not present for root)." },
+                    { "name": "nodeId", "$ref": "DOM.NodeId", "optional": true, "description": "The id for the node associated with this layer." },
+                    { "name": "offsetX", "type": "number", "description": "Offset from parent layer, X coordinate." },
+                    { "name": "offsetY", "type": "number", "description": "Offset from parent layer, X coordinate." },
+                    { "name": "width", "type": "number", "description": "Layer width." },
+                    { "name": "height", "type": "number", "description": "Layer height." },
+                    { "name": "transform", "type": "array", "items": { "type": "number" }, "minItems": 16, "maxItems": 16, "optional": true, "description": "Transformation matrix for layer, default is identity matrix" },
+                    { "name": "anchorX", "type": "number", "optional": true, "description": "Transform anchor point X, absent if no transform specified" },
+                    { "name": "anchorY", "type": "number", "optional": true, "description": "Transform anchor point Y, absent if no transform specified" },
+                    { "name": "anchorZ", "type": "number", "optional": true, "description": "Transform anchor point Z, absent if no transform specified" },
+                    { "name": "paintCount", "type": "integer", "description": "Indicates how many time this layer has painted." },
+                    { "name": "invisible", "type": "boolean", "optional": true, "description": "Set if layer is not visible." }
+                ]
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables compositing tree inspection."
+            },
+            {
+                "name": "disable",
+                "description": "Disables compositing tree inspection."
+            },
+            {
+                "name": "getLayers",
+                "parameters": [
+                    { "name": "nodeId", "optional": true, "$ref": "DOM.NodeId", "description": "Root of the subtree for which we want to gather layers (return entire tree if not specified)" }
+                ],
+                "description": "Returns the layer tree structure of the current page.",
+                "returns": [
+                    { "name": "layers", "type": "array", "items": { "$ref": "Layer" }, "description": "Child layers." }
+                ]
+            },
+            {
+                "name": "compositingReasons",
+                "parameters": [
+                    { "name": "layerId", "$ref": "LayerId", "description": "The id of the layer for which we want to get the reasons it was composited." }
+                ],
+                "description": "Provides the reasons why the given layer was composited.",
+                "returns": [
+                    { "name": "compositingReasons", "type": "array", "items": { "type": "string" }, "description": "A list of strings specifying reasons for the given layer to become composited." }
+                ]
+            }
+        ],
+        "events": [
+            {
+                "name": "layerTreeDidChange"
+            }
+        ]
+    },
+    {
+        "domain": "Tracing",
+        "hidden": true,
+        "commands": [
+            {
+                "name": "start",
+                "description": "Strart trace events collection.",
+                "parameters": [
+                    { "name": "categories", "type": "string", "description": "Category/tag filter" }
+                ]
+            },
+            {
+                "name": "end",
+                "description": "Stop trace events collection."
+            }
+        ],
+        "events": [
+            {
+                "name": "dataCollected",
+                "parameters": [
+                    { "name": "value", "type": "array", "items": { "type": "object" } }
+                ]
+            },
+            {
+                "name": "tracingComplete"
+            }
+        ]
+    }]
+}

--- a/source/ProtocolGenerator/Inspector-iOS-7.0.json
+++ b/source/ProtocolGenerator/Inspector-iOS-7.0.json
@@ -1,0 +1,2697 @@
+{
+    "domains": [{
+        "domain": "Inspector",
+        "types": [],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables inspector domain notifications."
+            },
+            {
+                "name": "disable",
+                "description": "Disables inspector domain notifications."
+            }
+        ],
+        "events": [
+            {
+                "name": "evaluateForTestInFrontend",
+                "parameters": [
+                    { "name": "testCallId", "type": "integer" },
+                    { "name": "script", "type": "string" }
+                ]
+            },
+            {
+                "name": "inspect",
+                "parameters": [
+                    { "name": "object", "$ref": "Runtime.RemoteObject" },
+                    { "name": "hints", "type": "object" }
+                ]
+            },
+            {
+                "name": "detached",
+                "description": "Fired when remote debugging connection is about to be terminated. Contains detach reason.",
+                "parameters": [
+                    { "name": "reason", "type": "string", "description": "The reason why connection has been terminated." }
+                ]
+            },
+            {
+                "name": "targetCrashed",
+                "description": "Fired when debugging target has crashed"
+            }
+        ]
+    },
+    {
+        "domain": "Page",
+        "description": "Actions and events related to the inspected page belong to the page domain.",
+        "types": [
+            {
+                "id": "ResourceType",
+                "type": "string",
+                "enum": ["Document", "Stylesheet", "Image", "Font", "Script", "XHR", "WebSocket", "Other"],
+                "description": "Resource type as it was perceived by the rendering engine."
+            },
+            {
+                "id": "Frame",
+                "type": "object",
+                "description": "Information about the Frame on the page.",
+                "properties": [
+                    { "name": "id", "type": "string", "description": "Frame unique identifier." },
+                    { "name": "parentId", "type": "string", "optional": true, "description": "Parent frame identifier." },
+                    { "name": "loaderId", "$ref": "Network.LoaderId", "description": "Identifier of the loader associated with this frame." },
+                    { "name": "name", "type": "string", "optional": true, "description": "Frame's name as specified in the tag." },
+                    { "name": "url", "type": "string", "description": "Frame document's URL." },
+                    { "name": "securityOrigin", "type": "string", "description": "Frame document's security origin." },
+                    { "name": "mimeType", "type": "string", "description": "Frame document's mimeType as determined by the browser." }
+                ]
+            },
+            {
+                "id": "FrameResource",
+                "type": "object",
+                "properties": [
+                    { "name": "url", "type": "string", "description": "Resource URL." },
+                    { "name": "type", "$ref": "ResourceType", "description": "Type of this resource." },
+                    { "name": "mimeType", "type": "string", "description": "Resource mimeType as determined by the browser." },
+                    { "name": "failed", "type": "boolean", "optional": true, "description": "True if the resource failed to load." },
+                    { "name": "canceled", "type": "boolean", "optional": true, "description": "True if the resource was canceled during loading." },
+                    { "name": "sourceMapURL", "type": "string", "optional": true, "description": "URL of source map associated with this resource (if any)." }
+                ]
+            },
+            {
+                "id": "FrameResourceTree",
+                "type": "object",
+                "description": "Information about the Frame hierarchy along with their cached resources.",
+                "properties": [
+                    { "name": "frame", "$ref": "Frame", "description": "Frame information for this tree item." },
+                    { "name": "childFrames", "type": "array", "optional": true, "items": { "$ref": "FrameResourceTree" }, "description": "Child frames." },
+                    { "name": "resources", "type": "array", "items": { "$ref": "FrameResource" }, "description": "Information about frame resources." }
+                ]
+            },
+            {
+                "id": "SearchMatch",
+                "type": "object",
+                "description": "Search match for resource.",
+                "properties": [
+                    { "name": "lineNumber", "type": "number", "description": "Line number in resource content." },
+                    { "name": "lineContent", "type": "string", "description": "Line with match content." }
+                ]
+            },
+            {
+                "id": "SearchResult",
+                "type": "object",
+                "description": "Search result for resource.",
+                "properties": [
+                    { "name": "url", "type": "string", "description": "Resource URL." },
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Resource frame id." },
+                    { "name": "matchesCount", "type": "number", "description": "Number of matches in the resource content." }
+                ]
+            },
+            {
+                "id": "Cookie",
+                "type": "object",
+                "description": "Cookie object",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "Cookie name." },
+                    { "name": "value", "type": "string", "description": "Cookie value." },
+                    { "name": "domain", "type": "string", "description": "Cookie domain." },
+                    { "name": "path", "type": "string", "description": "Cookie path." },
+                    { "name": "expires", "type": "number", "description": "Cookie expires." },
+                    { "name": "size", "type": "integer", "description": "Cookie size." },
+                    { "name": "httpOnly", "type": "boolean", "description": "True if cookie is http-only." },
+                    { "name": "secure", "type": "boolean", "description": "True if cookie is secure." },
+                    { "name": "session", "type": "boolean", "description": "True in case of session cookie." }
+                ]
+            },
+            {
+                "id": "ScriptIdentifier",
+                "type": "string",
+                "description": "Unique script identifier."
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables page domain notifications."
+            },
+            {
+                "name": "disable",
+                "description": "Disables page domain notifications."
+            },
+            {
+                "name": "addScriptToEvaluateOnLoad",
+                "parameters": [
+                    { "name": "scriptSource", "type": "string" }
+                ],
+                "returns": [
+                    { "name": "identifier", "$ref": "ScriptIdentifier", "description": "Identifier of the added script." }
+                ]
+            },
+            {
+                "name": "removeScriptToEvaluateOnLoad",
+                "parameters": [
+                    { "name": "identifier", "$ref": "ScriptIdentifier" }
+                ]
+            },
+            {
+                "name": "reload",
+                "parameters": [
+                    { "name": "ignoreCache", "type": "boolean", "optional": true, "description": "If true, browser cache is ignored (as if the user pressed Shift+refresh)." },
+                    { "name": "scriptToEvaluateOnLoad", "type": "string", "optional": true, "description": "If set, the script will be injected into all frames of the inspected page after reload." },
+                    { "name": "scriptPreprocessor", "type": "string", "optional": true, "description": "Script body that should evaluate to function that will preprocess all the scripts before their compilation." }
+                ],
+                "description": "Reloads given page optionally ignoring the cache."
+            },
+            {
+                "name": "navigate",
+                "parameters": [
+                    { "name": "url", "type": "string", "description": "URL to navigate the page to." }
+                ],
+                "description": "Navigates current page to the given URL."
+            },
+            {
+                "name": "getCookies",
+                "returns": [
+                    { "name": "cookies", "type": "array", "items": { "$ref": "Cookie"}, "description": "Array of cookie objects." },
+                    { "name": "cookiesString", "type": "string", "description": "document.cookie string representation of the cookies." }
+                ],
+                "description": "Returns all browser cookies. Depending on the backend support, will either return detailed cookie information in the <code>cookie</code> field or string cookie representation using <code>cookieString</code>."
+            },
+            {
+                "name": "deleteCookie",
+                "parameters": [
+                    { "name": "cookieName", "type": "string", "description": "Name of the cookie to remove." },
+                    { "name": "url", "type": "string", "description": "URL to match cooke domain and path." }
+                ],
+                "description": "Deletes browser cookie with given name, domain and path."
+            },
+            {
+                "name": "getResourceTree",
+                "description": "Returns present frame / resource tree structure.",
+                "returns": [
+                    { "name": "frameTree", "$ref": "FrameResourceTree", "description": "Present frame / resource tree structure." }
+                ]
+            },
+            {
+                "name": "getResourceContent",
+                "description": "Returns content of the given resource.",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Frame id to get resource for." },
+                    { "name": "url", "type": "string", "description": "URL of the resource to get content for." }
+                ],
+                "returns": [
+                    { "name": "content", "type": "string", "description": "Resource content." },
+                    { "name": "base64Encoded", "type": "boolean", "description": "True, if content was served as base64." }
+                ]
+            },
+            {
+                "name": "searchInResource",
+                "description": "Searches for given string in resource content.",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Frame id for resource to search in." },
+                    { "name": "url", "type": "string", "description": "URL of the resource to search in." },
+                    { "name": "query", "type": "string", "description": "String to search for."  },
+                    { "name": "caseSensitive", "type": "boolean", "optional": true, "description": "If true, search is case sensitive." },
+                    { "name": "isRegex", "type": "boolean", "optional": true, "description": "If true, treats string parameter as regex." }
+                ],
+                "returns": [
+                    { "name": "result", "type": "array", "items": { "$ref": "SearchMatch" }, "description": "List of search matches." }
+                ]
+            },
+            {
+                "name": "searchInResources",
+                "description": "Searches for given string in frame / resource tree structure.",
+                "parameters": [
+                    { "name": "text", "type": "string", "description": "String to search for."  },
+                    { "name": "caseSensitive", "type": "boolean", "optional": true, "description": "If true, search is case sensitive." },
+                    { "name": "isRegex", "type": "boolean", "optional": true, "description": "If true, treats string parameter as regex." }
+                ],
+                "returns": [
+                    { "name": "result", "type": "array", "items": { "$ref": "SearchResult" }, "description": "List of search results." }
+                ]
+            },
+            {
+                "name": "setDocumentContent",
+                "description": "Sets given markup as the document's HTML.",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Frame id to set HTML for." },
+                    { "name": "html", "type": "string", "description": "HTML content to set."  }
+                ]
+            },
+            {
+                "name": "getScriptExecutionStatus",
+                "description": "Determines if scripts can be executed in the page.",
+                "returns": [
+                    { "name": "result", "type": "string", "enum": ["allowed", "disabled", "forbidden"], "description": "Script execution status: \"allowed\" if scripts can be executed, \"disabled\" if script execution has been disabled through page settings, \"forbidden\" if script execution for the given page is not possible for other reasons." }
+                ]
+            },
+            {
+                "name": "setScriptExecutionDisabled",
+                "description": "Switches script execution in the page.",
+                "parameters": [
+                    { "name": "value", "type": "boolean", "description": "Whether script execution should be disabled in the page." }
+                ]
+            },
+            {
+                "name": "setTouchEmulationEnabled",
+                "parameters": [
+                    { "name": "enabled", "type": "boolean", "description": "Whether the touch event emulation should be enabled." }
+                ],
+                "description": "Toggles mouse event-based touch event emulation."
+            },
+            {
+                "name": "setEmulatedMedia",
+                "parameters": [
+                    { "name": "media", "type": "string", "description": "Media type to emulate. Empty string disables the override." }
+                ],
+                "description": "Emulates the given media for CSS media queries."
+            },
+            {
+                "name": "getCompositingBordersVisible",
+                "description": "Indicates the visibility of compositing borders.",
+                "returns": [
+                    { "name": "result", "type": "boolean", "description": "If true, compositing borders are visible." }
+                ]
+            },
+            {
+                "name": "setCompositingBordersVisible",
+                "description": "Controls the visibility of compositing borders.",
+                "parameters": [
+                    { "name": "visible", "type": "boolean", "description": "True for showing compositing borders." }
+                ]
+            },
+            {
+                "name": "handleJavaScriptDialog",
+                "description": "Accepts or dismisses a JavaScript initiated dialog (alert, confirm, prompt, or onbeforeunload).",
+                "parameters": [
+                    { "name": "accept", "type": "boolean", "description": "Whether to accept or dismiss the dialog." },
+                    { "name": "promptText", "type": "string", "optional": true, "description": "The text to enter into the dialog prompt before accepting. Used only if this is a prompt dialog." }
+                ]
+            }
+        ],
+        "events": [
+            {
+                "name": "domContentEventFired",
+                "parameters": [
+                    { "name": "timestamp", "type": "number" }
+                ]
+            },
+            {
+                "name": "loadEventFired",
+                "parameters": [
+                    { "name": "timestamp", "type": "number" }
+                ]
+            },
+            {
+                "name": "frameNavigated",
+                "description": "Fired once navigation of the frame has completed. Frame is now associated with the new loader.",
+                "parameters": [
+                    { "name": "frame", "$ref": "Frame", "description": "Frame object." }
+                ]
+            },
+            {
+                "name": "frameDetached",
+                "description": "Fired when frame has been detached from its parent.",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Id of the frame that has been detached." }
+                ]
+            },
+            {
+                "name": "frameStartedLoading",
+                "description": "Fired when frame has started loading.",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Id of the frame that has started loading." }
+                ]
+            },
+            {
+                "name": "frameStoppedLoading",
+                "description": "Fired when frame has stopped loading.",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Id of the frame that has stopped loading." }
+                ]
+            },
+            {
+                "name": "frameScheduledNavigation",
+                "description": "Fired when frame schedules a potential navigation.",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Id of the frame that has scheduled a navigation." },
+                    { "name": "delay", "type": "number", "description": "Delay (in seconds) until the navigation is scheduled to begin. The navigation is not guaranteed to start." }
+                ]
+            },
+            {
+                "name": "frameClearedScheduledNavigation",
+                "description": "Fired when frame no longer has a scheduled navigation.",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Id of the frame that has cleared its scheduled navigation." }
+                ]
+            },
+            {
+                "name": "javascriptDialogOpening",
+                "description": "Fired when a JavaScript initiated dialog (alert, confirm, prompt, or onbeforeunload) is about to open.",
+                "parameters": [
+                    { "name": "message", "type": "string", "description": "Message that will be displayed by the dialog." }
+                ]
+            },
+            {
+                "name": "javascriptDialogClosed",
+                "description": "Fired when a JavaScript initiated dialog (alert, confirm, prompt, or onbeforeunload) has been closed."
+            },
+            {
+                "name": "scriptsEnabled",
+                "description": "Fired when the JavaScript is enabled/disabled on the page",
+                "parameters": [
+                    { "name": "isEnabled", "type": "boolean", "description": "Whether script execution is enabled or disabled on the page." }
+                ]
+            }
+        ]
+    },
+    {
+        "domain": "Runtime",
+        "description": "Runtime domain exposes JavaScript runtime by means of remote evaluation and mirror objects. Evaluation results are returned as mirror object that expose object type, string representation and unique identifier that can be used for further object reference. Original objects are maintained in memory unless they are either explicitly released or are released along with the other objects in their object group.",
+        "types": [
+            {
+                "id": "RemoteObjectId",
+                "type": "string",
+                "description": "Unique object identifier."
+            },
+            {
+                "id": "RemoteObject",
+                "type": "object",
+                "description": "Mirror object referencing original JavaScript object.",
+                "properties": [
+                    { "name": "type", "type": "string", "enum": ["object", "function", "undefined", "string", "number", "boolean"], "description": "Object type." },
+                    { "name": "subtype", "type": "string", "optional": true, "enum": ["array", "null", "node", "regexp", "date"], "description": "Object subtype hint. Specified for <code>object</code> type values only." },
+                    { "name": "className", "type": "string", "optional": true, "description": "Object class (constructor) name. Specified for <code>object</code> type values only." },
+                    { "name": "value", "type": "any", "optional": true, "description": "Remote object value (in case of primitive values or JSON values if it was requested)." },
+                    { "name": "description", "type": "string", "optional": true, "description": "String representation of the object." },
+                    { "name": "objectId", "$ref": "RemoteObjectId", "optional": true, "description": "Unique object identifier (for non-primitive values)." },
+                    { "name": "preview", "$ref": "ObjectPreview", "optional": true, "description": "Preview containsing abbreviated property values." }
+                ]
+            },
+            {
+                "id": "ObjectPreview",
+                "type": "object",
+                "description": "Object containing abbreviated remote object value.",
+                "properties": [
+                    { "name": "lossless", "type": "boolean", "description": "Determines whether preview is lossless (contains all information of the original object)." },
+                    { "name": "overflow", "type": "boolean", "description": "True iff some of the properties of the original did not fit." },
+                    { "name": "properties", "type": "array", "items": { "$ref": "PropertyPreview" }, "description": "List of the properties." }
+                ]
+            },
+            {
+                "id": "PropertyPreview",
+                "type": "object",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "Property name." },
+	                { "name": "type", "type": "string", "enum": ["object", "function", "undefined", "string", "number", "boolean"], "description": "Object type." },
+	                { "name": "value", "type": "string", "optional": true, "description": "User-friendly property value string." },
+	                { "name": "valuePreview", "$ref": "ObjectPreview", "optional": true, "description": "Nested value preview." },
+	                { "name": "subtype", "type": "string", "optional": true, "enum": ["array", "null", "node", "regexp", "date"], "description": "Object subtype hint. Specified for <code>object</code> type values only." }
+                ]
+            },
+            {
+                "id": "PropertyDescriptor",
+                "type": "object",
+                "description": "Object property descriptor.",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "Property name." },
+                    { "name": "value", "$ref": "RemoteObject", "optional": true, "description": "The value associated with the property." },
+                    { "name": "writable", "type": "boolean", "optional": true, "description": "True if the value associated with the property may be changed (data descriptors only)." },
+                    { "name": "get", "$ref": "RemoteObject", "optional": true, "description": "A function which serves as a getter for the property, or <code>undefined</code> if there is no getter (accessor descriptors only)." },
+                    { "name": "set", "$ref": "RemoteObject", "optional": true, "description": "A function which serves as a setter for the property, or <code>undefined</code> if there is no setter (accessor descriptors only)." },
+                    { "name": "configurable", "type": "boolean", "description": "True if the type of this property descriptor may be changed and if the property may be deleted from the corresponding object." },
+                    { "name": "enumerable", "type": "boolean", "description": "True if this property shows up during enumeration of the properties on the corresponding object." },
+                    { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." },
+                    { "name": "isOwn", "optional": true, "type": "boolean", "description": "True if the property is owned for the object." }
+                ]
+            },
+            {
+                "id": "InternalPropertyDescriptor",
+                "type": "object",
+                "description": "Object internal property descriptor. This property isn't normally visible in JavaScript code.",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "Conventional property name." },
+                    { "name": "value", "$ref": "RemoteObject", "optional": true, "description": "The value associated with the property." }
+                ]
+            },
+            {
+                "id": "CallArgument",
+                "type": "object",
+                "description": "Represents function call argument. Either remote object id <code>objectId</code> or primitive <code>value</code> or neither of (for undefined) them should be specified.",
+                "properties": [
+                    { "name": "value", "type": "any", "optional": true, "description": "Primitive value." },
+                    { "name": "objectId", "$ref": "RemoteObjectId", "optional": true, "description": "Remote object handle." }
+                ]
+            },
+            {
+                "id": "ExecutionContextId",
+                "type": "integer",
+                "description": "Id of an execution context."
+            },
+            {
+                "id": "ExecutionContextDescription",
+                "type": "object",
+                "description": "Description of an isolated world.",
+                "properties": [
+                    { "name": "id", "$ref": "ExecutionContextId", "description": "Unique id of the execution context. It can be used to specify in which execution context script evaluation should be performed." },
+                    { "name": "isPageContext", "type": "boolean", "description": "True if this is a context where inpspected web page scripts run. False if it is a content script isolated context." },
+                    { "name": "name", "type": "string", "description": "Human readable name describing given context."},
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Id of the owning frame." }
+                ]
+            },
+            {
+                "id": "SyntaxErrorType",
+                "type": "string",
+                "enum": ["none", "irrecoverable", "unterminated-literal", "recoverable"],
+                "description": "Syntax error type: \"none\" for no error, \"irrecoverable\" for unrecoverable errors, \"unterminated-literal\" for when there is an unterminated literal, \"recoverable\" for when the expression is unfinished but valid so far."
+            },
+            {
+                "id": "ErrorRange",
+                "type": "object",
+                "description": "Range of an error in source code.",
+                "properties": [
+                    { "name": "startOffset", "type": "integer", "description": "Start offset of range (inclusive)." },
+                    { "name": "endOffset", "type": "integer", "description": "End offset of range (exclusive)." }
+                ]
+            }
+        ],
+        "commands": [
+            {
+                "name": "parse",
+                "parameters": [
+                    { "name": "source", "type": "string", "description": "Source code to parse." }
+                ],
+                "returns": [
+                    { "name": "result", "$ref": "SyntaxErrorType", "description": "Parse result." },
+                    { "name": "message", "type": "string", "optional": true, "description": "Parse error message." },
+                    { "name": "range", "$ref": "ErrorRange", "optional": true, "description": "Range in the source where the error occurred." }
+                ],
+                "description": "Parses JavaScript source code for errors."
+            },
+            {
+                "name": "evaluate",
+                "parameters": [
+                    { "name": "expression", "type": "string", "description": "Expression to evaluate." },
+                    { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." },
+                    { "name": "includeCommandLineAPI", "type": "boolean", "optional": true, "description": "Determines whether Command Line API should be available during the evaluation." },
+                    { "name": "doNotPauseOnExceptionsAndMuteConsole", "type": "boolean", "optional": true, "description": "Specifies whether evaluation should stop on exceptions and mute console. Overrides setPauseOnException state." },
+                    { "name": "contextId", "$ref": "Runtime.ExecutionContextId", "optional": true, "description": "Specifies in which isolated context to perform evaluation. Each content script lives in an isolated context and this parameter may be used to specify one of those contexts. If the parameter is omitted or 0 the evaluation will be performed in the context of the inspected page." },
+                    { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object that should be sent by value." },
+                    { "name": "generatePreview", "type": "boolean", "optional": true,  "description": "Whether preview should be generated for the result." }
+                ],
+                "returns": [
+                    { "name": "result", "$ref": "RemoteObject", "description": "Evaluation result." },
+                    { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." }
+                ],
+                "description": "Evaluates expression on global object."
+            },
+            {
+                "name": "callFunctionOn",
+                "parameters": [
+                    { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to call function on." },
+                    { "name": "functionDeclaration", "type": "string", "description": "Declaration of the function to call." },
+                    { "name": "arguments", "type": "array", "items": { "$ref": "CallArgument", "description": "Call argument." }, "optional": true, "description": "Call arguments. All call arguments must belong to the same JavaScript world as the target object." },
+                    { "name": "doNotPauseOnExceptionsAndMuteConsole", "type": "boolean", "optional": true, "description": "Specifies whether function call should stop on exceptions and mute console. Overrides setPauseOnException state." },
+                    { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object which should be sent by value." },
+                    { "name": "generatePreview", "type": "boolean", "optional": true,  "description": "Whether preview should be generated for the result." }
+                ],
+                "returns": [
+                    { "name": "result", "$ref": "RemoteObject", "description": "Call result." },
+                    { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." }
+                ],
+                "description": "Calls function with given declaration on the given object. Object group of the result is inherited from the target object."
+            },
+            {
+                "name": "getProperties",
+                "parameters": [
+                    { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to return properties for." },
+                    { "name": "ownProperties", "optional": true, "type": "boolean", "description": "If true, returns properties belonging only to the element itself, not to its prototype chain." }
+                ],
+                "returns": [
+                    { "name": "result", "type": "array", "items": { "$ref": "PropertyDescriptor"}, "description": "Object properties." },
+                    { "name": "internalProperties", "optional": true, "type": "array", "items": { "$ref": "InternalPropertyDescriptor"}, "description": "Internal object properties." }
+                ],
+                "description": "Returns properties of a given object. Object group of the result is inherited from the target object."
+            },
+            {
+                "name": "releaseObject",
+                "parameters": [
+                    { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to release." }
+                ],
+                "description": "Releases remote object with given id."
+            },
+            {
+                "name": "releaseObjectGroup",
+                "parameters": [
+                    { "name": "objectGroup", "type": "string", "description": "Symbolic object group name." }
+                ],
+                "description": "Releases all remote objects that belong to a given group."
+            },
+            {
+                "name": "enable",
+                "description": "Enables reporting of execution contexts creation by means of <code>executionContextCreated</code> event. When the reporting gets enabled the event will be sent immediately for each existing execution context."
+            },
+            {
+                "name": "disable",
+                "description": "Disables reporting of execution contexts creation."
+            }
+        ],
+        "events": [
+            {
+                "name": "executionContextCreated",
+                "parameters": [
+                    { "name": "context", "$ref": "ExecutionContextDescription", "description": "A newly created execution contex." }
+                ],
+                "description": "Issued when new execution context is created."
+            }
+        ]
+    },
+    {
+        "domain": "Console",
+        "description": "Console domain defines methods and events for interaction with the JavaScript console. Console collects messages created by means of the <a href='http://getfirebug.com/wiki/index.php/Console_API'>JavaScript Console API</a>. One needs to enable this domain using <code>enable</code> command in order to start receiving the console messages. Browser collects messages issued while console domain is not enabled as well and reports them using <code>messageAdded</code> notification upon enabling.",
+        "types": [
+            {
+                "id": "ConsoleMessage",
+                "type": "object",
+                "description": "Console message.",
+                "properties": [
+                    { "name": "source", "type": "string", "enum": ["xml", "javascript", "network", "console-api", "storage", "appcache", "rendering", "css", "security", "other"], "description": "Message source." },
+                    { "name": "level", "type": "string", "enum": ["log", "warning", "error", "debug"], "description": "Message severity." },
+                    { "name": "text", "type": "string", "description": "Message text." },
+                    { "name": "type", "type": "string", "optional": true, "enum": ["log", "dir", "dirxml", "table", "trace", "clear", "startGroup", "startGroupCollapsed", "endGroup", "assert", "timing", "profile", "profileEnd"], "description": "Console message type." },
+                    { "name": "url", "type": "string", "optional": true, "description": "URL of the message origin." },
+                    { "name": "line", "type": "integer", "optional": true, "description": "Line number in the resource that generated this message." },
+                    { "name": "column", "type": "integer", "optional": true, "description": "Column number on the line in the resource that generated this message." },
+                    { "name": "repeatCount", "type": "integer", "optional": true, "description": "Repeat count for repeated messages." },
+                    { "name": "parameters", "type": "array", "items": { "$ref": "Runtime.RemoteObject" }, "optional": true, "description": "Message parameters in case of the formatted message." },
+                    { "name": "stackTrace", "$ref": "StackTrace", "optional": true, "description": "JavaScript stack trace for assertions and error messages." },
+                    { "name": "networkRequestId", "$ref": "Network.RequestId", "optional": true, "description": "Identifier of the network request associated with this message." }
+                ]
+            },
+            {
+                "id": "CallFrame",
+                "type": "object",
+                "description": "Stack entry for console errors and assertions.",
+                "properties": [
+                    { "name": "functionName", "type": "string", "description": "JavaScript function name." },
+                    { "name": "url", "type": "string", "description": "JavaScript script name or url." },
+                    { "name": "lineNumber", "type": "integer", "description": "JavaScript script line number." },
+                    { "name": "columnNumber", "type": "integer", "description": "JavaScript script column number." }
+                ]
+            },
+            {
+                "id": "StackTrace",
+                "type": "array",
+                "items": { "$ref": "CallFrame" },
+                "description": "Call frames for assertions or error messages."
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables console domain, sends the messages collected so far to the client by means of the <code>messageAdded</code> notification."
+            },
+            {
+                "name": "disable",
+                "description": "Disables console domain, prevents further console messages from being reported to the client."
+            },
+            {
+                "name": "clearMessages",
+                "description": "Clears console messages collected in the browser."
+            },
+            {
+                "name": "setMonitoringXHREnabled",
+                "parameters": [
+                    { "name": "enabled", "type": "boolean", "description": "Monitoring enabled state." }
+                ],
+                "description": "Toggles monitoring of XMLHttpRequest. If <code>true</code>, console will receive messages upon each XHR issued."
+            },
+            {
+                "name": "addInspectedNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId", "description": "DOM node id to be accessible by means of $x command line API." }
+                ],
+                "description": "Enables console to refer to the node with given id via $x (see Command Line API for more details $x functions)."
+            }
+        ],
+        "events": [
+            {
+                "name": "messageAdded",
+                "parameters": [
+                    { "name": "message", "$ref": "ConsoleMessage", "description": "Console message that has been added." }
+                ],
+                "description": "Issued when new console message is added."
+            },
+            {
+                "name": "messageRepeatCountUpdated",
+                "parameters": [
+                    { "name": "count", "type": "integer", "description": "New repeat count value." }
+                ],
+                "description": "Issued when subsequent message(s) are equal to the previous one(s)."
+            },
+            {
+                "name": "messagesCleared",
+                "description": "Issued when console is cleared. This happens either upon <code>clearMessages</code> command or after page navigation."
+            }
+        ]
+    },
+    {
+        "domain": "Network",
+        "description": "Network domain allows tracking network activities of the page. It exposes information about http, file, data and other requests and responses, their headers, bodies, timing, etc.",
+        "types": [
+            {
+                "id": "LoaderId",
+                "type": "string",
+                "description": "Unique loader identifier."
+            },
+            {
+                "id": "FrameId",
+                "type": "string",
+                "description": "Unique frame identifier."
+            },
+            {
+                "id": "RequestId",
+                "type": "string",
+                "description": "Unique request identifier."
+            },
+            {
+                "id": "Timestamp",
+                "type": "number",
+                "description": "Number of seconds since epoch."
+            },
+            {
+                "id": "Headers",
+                "type": "object",
+                "description": "Request / response headers as keys / values of JSON object."
+            },
+            {
+                "id": "ResourceTiming",
+                "type": "object",
+                "description": "Timing information for the request.",
+                "properties": [
+                    { "name": "requestTime", "type": "number", "description": "Timing's requestTime is a baseline in seconds, while the other numbers are ticks in milliseconds relatively to this requestTime." },
+                    { "name": "proxyStart", "type": "number", "description": "Started resolving proxy." },
+                    { "name": "proxyEnd", "type": "number", "description": "Finished resolving proxy." },
+                    { "name": "dnsStart", "type": "number", "description": "Started DNS address resolve." },
+                    { "name": "dnsEnd", "type": "number", "description": "Finished DNS address resolve." },
+                    { "name": "connectStart", "type": "number", "description": "Started connecting to the remote host." },
+                    { "name": "connectEnd", "type": "number", "description": "Connected to the remote host." },
+                    { "name": "sslStart", "type": "number", "description": "Started SSL handshake." },
+                    { "name": "sslEnd", "type": "number", "description": "Finished SSL handshake." },
+                    { "name": "sendStart", "type": "number", "description": "Started sending request." },
+                    { "name": "sendEnd", "type": "number", "description": "Finished sending request." },
+                    { "name": "receiveHeadersEnd", "type": "number", "description": "Finished receiving response headers." }
+                ]
+            },
+            {
+                "id": "Request",
+                "type": "object",
+                "description": "HTTP request data.",
+                "properties": [
+                    { "name": "url", "type": "string", "description": "Request URL." },
+                    { "name": "method", "type": "string", "description": "HTTP request method." },
+                    { "name": "headers", "$ref": "Headers", "description": "HTTP request headers." },
+                    { "name": "postData", "type": "string", "optional": true, "description": "HTTP POST request data." }
+                ]
+            },
+            {
+                "id": "Response",
+                "type": "object",
+                "description": "HTTP response data.",
+                "properties": [
+                    { "name": "url", "type": "string", "description": "Response URL. This URL can be different from CachedResource.url in case of redirect." },
+                    { "name": "status", "type": "number", "description": "HTTP response status code." },
+                    { "name": "statusText", "type": "string", "description": "HTTP response status text." },
+                    { "name": "headers", "$ref": "Headers", "description": "HTTP response headers." },
+                    { "name": "headersText", "type": "string", "optional": true, "description": "HTTP response headers text." },
+                    { "name": "mimeType", "type": "string", "description": "Resource mimeType as determined by the browser." },
+                    { "name": "requestHeaders", "$ref": "Headers", "optional": true, "description": "Refined HTTP request headers that were actually transmitted over the network." },
+                    { "name": "requestHeadersText", "type": "string", "optional": true, "description": "HTTP request headers text." },
+                    { "name": "connectionReused", "type": "boolean", "description": "Specifies whether physical connection was actually reused for this request." },
+                    { "name": "connectionId", "type": "number", "description": "Physical connection id that was actually used for this request." },
+                    { "name": "fromDiskCache", "type": "boolean", "optional": true, "description": "Specifies that the request was served from the disk cache." },
+                    { "name": "timing", "$ref": "ResourceTiming", "optional": true, "description": "Timing information for the given request." }
+                ]
+            },
+            {
+                "id": "WebSocketRequest",
+                "type": "object",
+                "description": "WebSocket request data.",
+                "properties": [
+                    { "name": "headers", "$ref": "Headers", "description": "HTTP response headers." }
+                ]
+            },
+            {
+                "id": "WebSocketResponse",
+                "type": "object",
+                "description": "WebSocket response data.",
+                "properties": [
+                    { "name": "status", "type": "number", "description": "HTTP response status code." },
+                    { "name": "statusText", "type": "string", "description": "HTTP response status text." },
+                    { "name": "headers", "$ref": "Headers", "description": "HTTP response headers." }
+                ]
+            },
+            {
+                "id": "WebSocketFrame",
+                "type": "object",
+                "description": "WebSocket frame data.",
+                "properties": [
+                    { "name": "opcode", "type": "number", "description": "WebSocket frame opcode." },
+                    { "name": "mask", "type": "boolean", "description": "WebSocket frame mask." },
+                    { "name": "payloadData", "type": "string", "description": "WebSocket frame payload data." }
+                ]
+            },
+            {
+                "id": "CachedResource",
+                "type": "object",
+                "description": "Information about the cached resource.",
+                "properties": [
+                    { "name": "url", "type": "string", "description": "Resource URL. This is the url of the original network request." },
+                    { "name": "type", "$ref": "Page.ResourceType", "description": "Type of this resource." },
+                    { "name": "response", "$ref": "Response", "optional": true, "description": "Cached response data." },
+                    { "name": "bodySize", "type": "number", "description": "Cached response body size." },
+                    { "name": "sourceMapURL", "type": "string", "optional": true, "description": "URL of source map associated with this resource (if any)." }
+                ]
+            },
+            {
+                "id": "Initiator",
+                "type": "object",
+                "description": "Information about the request initiator.",
+                "properties": [
+                    { "name": "type", "type": "string", "enum": ["parser", "script", "other"], "description": "Type of this initiator." },
+                    { "name": "stackTrace", "$ref": "Console.StackTrace", "optional": true, "description": "Initiator JavaScript stack trace, set for Script only." },
+                    { "name": "url", "type": "string", "optional": true, "description": "Initiator URL, set for Parser type only." },
+                    { "name": "lineNumber", "type": "number", "optional": true, "description": "Initiator line number, set for Parser type only." }
+                ]
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables network tracking, network events will now be delivered to the client."
+            },
+            {
+                "name": "disable",
+                "description": "Disables network tracking, prevents network events from being sent to the client."
+            },
+            {
+                "name": "setExtraHTTPHeaders",
+                "description": "Specifies whether to always send extra HTTP headers with the requests from this page.",
+                "parameters": [
+                    { "name": "headers", "$ref": "Headers", "description": "Map with extra HTTP headers." }
+                ]
+            },
+            {
+                "name": "getResponseBody",
+                "description": "Returns content served for the given request.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Identifier of the network request to get content for." }
+                ],
+                "returns": [
+                    { "name": "body", "type": "string", "description": "Response body." },
+                    { "name": "base64Encoded", "type": "boolean", "description": "True, if content was sent as base64." }
+                ]
+            },
+            {
+                "name": "setCacheDisabled",
+                "parameters": [
+                    { "name": "cacheDisabled", "type": "boolean", "description": "Cache disabled state." }
+                ],
+                "description": "Toggles ignoring cache for each request. If <code>true</code>, cache will not be used."
+            }
+        ],
+        "events": [
+            {
+                "name": "requestWillBeSent",
+                "description": "Fired when page is about to send HTTP request.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "frameId", "$ref": "FrameId", "description": "Frame identifier." },
+                    { "name": "loaderId", "$ref": "LoaderId", "description": "Loader identifier." },
+                    { "name": "documentURL", "type": "string", "description": "URL of the document this request is loaded for." },
+                    { "name": "request", "$ref": "Request", "description": "Request data." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "initiator", "$ref": "Initiator", "description": "Request initiator." },
+                    { "name": "redirectResponse", "optional": true, "$ref": "Response", "description": "Redirect response data." },
+                    { "name": "type", "$ref": "Page.ResourceType", "optional": true, "description": "Resource type." }
+                ]
+            },
+            {
+                "name": "requestServedFromCache",
+                "description": "Fired if request ended up loading from cache.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." }
+                ]
+            },
+            {
+                "name": "responseReceived",
+                "description": "Fired when HTTP response is available.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "frameId", "$ref": "FrameId", "description": "Frame identifier." },
+                    { "name": "loaderId", "$ref": "LoaderId", "description": "Loader identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "type", "$ref": "Page.ResourceType", "description": "Resource type." },
+                    { "name": "response", "$ref": "Response", "description": "Response data." }
+                ]
+            },
+            {
+                "name": "dataReceived",
+                "description": "Fired when data chunk was received over the network.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "dataLength", "type": "integer", "description": "Data chunk length." },
+                    { "name": "encodedDataLength", "type": "integer", "description": "Actual bytes received (might be less than dataLength for compressed encodings)." }
+                ]
+            },
+            {
+                "name": "loadingFinished",
+                "description": "Fired when HTTP request has finished loading.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "sourceMapURL", "type": "string", "optional": true, "description": "URL of source map associated with this resource (if any)." }
+                ]
+            },
+            {
+                "name": "loadingFailed",
+                "description": "Fired when HTTP request has failed to load.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "errorText", "type": "string", "description": "User friendly error message." },
+                    { "name": "canceled", "type": "boolean", "optional": true, "description": "True if loading was canceled." }
+                ]
+            },
+            {
+                "name": "requestServedFromMemoryCache",
+                "description": "Fired when HTTP request has been served from memory cache.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "frameId", "$ref": "FrameId", "description": "Frame identifier." },
+                    { "name": "loaderId", "$ref": "LoaderId", "description": "Loader identifier." },
+                    { "name": "documentURL", "type": "string", "description": "URL of the document this request is loaded for." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "initiator", "$ref": "Initiator", "description": "Request initiator." },
+                    { "name": "resource", "$ref": "CachedResource", "description": "Cached resource data." }
+                ]
+            },
+            {
+                "name": "webSocketWillSendHandshakeRequest",
+                "description": "Fired when WebSocket is about to initiate handshake.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "request", "$ref": "WebSocketRequest", "description": "WebSocket request data." }
+                ]
+            },
+            {
+                "name": "webSocketHandshakeResponseReceived",
+                "description": "Fired when WebSocket handshake response becomes available.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "response", "$ref": "WebSocketResponse", "description": "WebSocket response data." }
+                ]
+            },
+            {
+                "name": "webSocketCreated",
+                "description": "Fired upon WebSocket creation.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "url", "type": "string", "description": "WebSocket request URL." }
+                ]
+            },
+            {
+                "name": "webSocketClosed",
+                "description": "Fired when WebSocket is closed.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." }
+                ]
+            },
+            {
+                "name": "webSocketFrameReceived",
+                "description": "Fired when WebSocket frame is received.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "response", "$ref": "WebSocketFrame", "description": "WebSocket response data." }
+                ]
+            },
+            {
+                "name": "webSocketFrameError",
+                "description": "Fired when WebSocket frame error occurs.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "errorMessage", "type": "string", "description": "WebSocket frame error message." }
+                ]
+            },
+            {
+                "name": "webSocketFrameSent",
+                "description": "Fired when WebSocket frame is sent.",
+                "parameters": [
+                    { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                    { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                    { "name": "response", "$ref": "WebSocketFrame", "description": "WebSocket response data." }
+                ]
+            }
+        ]
+    },
+    {
+        "domain": "Database",
+        "types": [
+            {
+                "id": "DatabaseId",
+                "type": "string",
+                "description": "Unique identifier of Database object."
+            },
+            {
+                "id": "Database",
+                "type": "object",
+                "description": "Database object.",
+                "properties": [
+                    { "name": "id", "$ref": "DatabaseId", "description": "Database ID." },
+                    { "name": "domain", "type": "string", "description": "Database domain." },
+                    { "name": "name", "type": "string", "description": "Database name." },
+                    { "name": "version", "type": "string", "description": "Database version." }
+                ]
+            },
+            {
+                "id": "Error",
+                "type": "object",
+                "description": "Database error.",
+                "properties": [
+                    { "name": "message", "type": "string", "description": "Error message." },
+                    { "name": "code", "type": "integer", "description": "Error code." }
+                ]
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables database tracking, database events will now be delivered to the client."
+            },
+            {
+                "name": "disable",
+                "description": "Disables database tracking, prevents database events from being sent to the client."
+            },
+            {
+                "name": "getDatabaseTableNames",
+                "parameters": [
+                    { "name": "databaseId", "$ref": "DatabaseId" }
+                ],
+                "returns": [
+                    { "name": "tableNames", "type": "array", "items": { "type": "string" } }
+                ]
+            },
+            {
+                "name": "executeSQL",
+                "async": true,
+                "parameters": [
+                    { "name": "databaseId", "$ref": "DatabaseId" },
+                    { "name": "query", "type": "string" }
+                ],
+                "returns": [
+                    { "name": "columnNames", "type": "array", "optional": true, "items": { "type": "string" } },
+                    { "name": "values", "type": "array", "optional": true, "items": { "type": "any" }},
+                    { "name": "sqlError", "$ref": "Error", "optional": true }
+                ]
+            }
+        ],
+        "events": [
+            {
+                "name": "addDatabase",
+                "parameters": [
+                    { "name": "database", "$ref": "Database" }
+                ]
+            }
+        ]
+    },
+    {
+        "domain": "DOMStorage",
+        "description": "Query and modify DOM storage.",
+        "types": [
+            {
+                "id": "StorageId",
+                "type": "object",
+                "description": "DOM Storage identifier.",
+                "properties": [
+                    { "name": "securityOrigin", "type": "string", "description": "Security origin for the storage." },
+                    { "name": "isLocalStorage", "type": "boolean", "description": "Whether the storage is local storage (not session storage)." }
+                ]
+            },
+            {
+                "id": "Item",
+                "type": "array",
+                "description": "DOM Storage item.",
+                "items": { "type": "string" }
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables storage tracking, storage events will now be delivered to the client."
+            },
+            {
+                "name": "disable",
+                "description": "Disables storage tracking, prevents storage events from being sent to the client."
+            },
+            {
+                "name": "getDOMStorageItems",
+                "parameters": [
+                    { "name": "storageId", "$ref": "StorageId" }
+                ],
+                "returns": [
+                    { "name": "entries", "type": "array", "items": { "$ref": "Item" } }
+                ]
+            },
+            {
+                "name": "setDOMStorageItem",
+                "parameters": [
+                    { "name": "storageId", "$ref": "StorageId" },
+                    { "name": "key", "type": "string" },
+                    { "name": "value", "type": "string" }
+                ]
+            },
+            {
+                "name": "removeDOMStorageItem",
+                "parameters": [
+                    { "name": "storageId", "$ref": "StorageId" },
+                    { "name": "key", "type": "string" }
+                ]
+            }
+        ],
+        "events": [
+            {
+                "name": "domStorageItemsCleared",
+                "parameters": [
+                    { "name": "storageId",  "$ref": "StorageId" }
+                ]
+            },
+            {
+                "name": "domStorageItemRemoved",
+                "parameters": [
+                    { "name": "storageId",  "$ref": "StorageId" },
+                    { "name": "key", "type": "string" }
+                ]
+            },
+            {
+                "name": "domStorageItemAdded",
+                "parameters": [
+                    { "name": "storageId",  "$ref": "StorageId" },
+                    { "name": "key", "type": "string" },
+                    { "name": "newValue", "type": "string" }
+                ]
+            },
+            {
+                "name": "domStorageItemUpdated",
+                "parameters": [
+                    { "name": "storageId",  "$ref": "StorageId" },
+                    { "name": "key", "type": "string" },
+                    { "name": "oldValue", "type": "string" },
+                    { "name": "newValue", "type": "string" }
+                ]
+            }
+        ]
+    },
+    {
+        "domain": "ApplicationCache",
+        "types": [
+            {
+                "id": "ApplicationCacheResource",
+                "type": "object",
+                "description": "Detailed application cache resource information.",
+                "properties": [
+                    { "name": "url", "type": "string", "description": "Resource url." },
+                    { "name": "size", "type": "integer", "description": "Resource size." },
+                    { "name": "type", "type": "string", "description": "Resource type." }
+                ]
+            },
+            {
+                "id": "ApplicationCache",
+                "type": "object",
+                "description": "Detailed application cache information.",
+                "properties": [
+                    { "name": "manifestURL", "type": "string", "description": "Manifest URL." },
+                    { "name": "size", "type": "number", "description": "Application cache size." },
+                    { "name": "creationTime", "type": "number", "description": "Application cache creation time." },
+                    { "name": "updateTime", "type": "number", "description": "Application cache update time." },
+                    { "name": "resources", "type": "array", "items": { "$ref": "ApplicationCacheResource" }, "description": "Application cache resources." }
+                ]
+            },
+            {
+                "id": "FrameWithManifest",
+                "type": "object",
+                "description": "Frame identifier - manifest URL pair.",
+                "properties": [
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Frame identifier." },
+                    { "name": "manifestURL", "type": "string", "description": "Manifest URL." },
+                    { "name": "status", "type": "integer", "description": "Application cache status." }
+                ]
+            }
+        ],
+        "commands": [
+            {
+                "name": "getFramesWithManifests",
+                "returns": [
+                    { "name": "frameIds", "type": "array", "items": { "$ref": "FrameWithManifest" }, "description": "Array of frame identifiers with manifest urls for each frame containing a document associated with some application cache." }
+                ],
+                "description": "Returns array of frame identifiers with manifest urls for each frame containing a document associated with some application cache."
+            },
+            {
+                "name": "enable",
+                "description": "Enables application cache domain notifications."
+            },
+            {
+                "name": "getManifestForFrame",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Identifier of the frame containing document whose manifest is retrieved." }
+                ],
+                "returns": [
+                    { "name": "manifestURL", "type": "string", "description": "Manifest URL for document in the given frame." }
+                ],
+                "description": "Returns manifest URL for document in the given frame."
+            },
+            {
+                "name": "getApplicationCacheForFrame",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Identifier of the frame containing document whose application cache is retrieved." }
+                ],
+                "returns": [
+                    { "name": "applicationCache", "$ref": "ApplicationCache", "description": "Relevant application cache data for the document in given frame." }
+                ],
+                "description": "Returns relevant application cache data for the document in given frame."
+            }
+        ],
+        "events": [
+            {
+                "name": "applicationCacheStatusUpdated",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Identifier of the frame containing document whose application cache updated status." },
+                    { "name": "manifestURL", "type": "string", "description": "Manifest URL." },
+                    { "name": "status", "type": "integer", "description": "Updated application cache status." }
+                ]
+            },
+            {
+                "name": "networkStateUpdated",
+                "parameters": [
+                    { "name": "isNowOnline", "type": "boolean" }
+                ]
+            }
+        ]
+    },
+    {
+        "domain": "DOM",
+        "description": "This domain exposes DOM read/write operations. Each DOM Node is represented with its mirror object that has an <code>id</code>. This <code>id</code> can be used to get additional information on the Node, resolve it into the JavaScript object wrapper, etc. It is important that client receives DOM events only for the nodes that are known to the client. Backend keeps track of the nodes that were sent to the client and never sends the same node twice. It is client's responsibility to collect information about the nodes that were sent to the client.<p>Note that <code>iframe</code> owner elements will return corresponding document elements as their child nodes.</p>",
+        "types": [
+            {
+                "id": "NodeId",
+                "type": "integer",
+                "description": "Unique DOM node identifier."
+            },
+            {
+                "id": "BackendNodeId",
+                "type": "integer",
+                "description": "Unique DOM node identifier used to reference a node that may not have been pushed to the front-end."
+            },
+            {
+                "id": "Node",
+                "type": "object",
+                "properties": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Node identifier that is passed into the rest of the DOM messages as the <code>nodeId</code>. Backend will only push node with given <code>id</code> once. It is aware of all requested nodes and will only fire DOM events for nodes known to the client." },
+                    { "name": "nodeType", "type": "integer", "description": "<code>Node</code>'s nodeType." },
+                    { "name": "nodeName", "type": "string", "description": "<code>Node</code>'s nodeName." },
+                    { "name": "localName", "type": "string", "description": "<code>Node</code>'s localName." },
+                    { "name": "nodeValue", "type": "string", "description": "<code>Node</code>'s nodeValue." },
+                    { "name": "childNodeCount", "type": "integer", "optional": true, "description": "Child count for <code>Container</code> nodes." },
+                    { "name": "children", "type": "array", "optional": true, "items": { "$ref": "Node" }, "description": "Child nodes of this node when requested with children." },
+                    { "name": "attributes", "type": "array", "optional": true, "items": { "type": "string" }, "description": "Attributes of the <code>Element</code> node in the form of flat array <code>[name1, value1, name2, value2]</code>." },
+                    { "name": "documentURL", "type": "string", "optional": true, "description": "Document URL that <code>Document</code> or <code>FrameOwner</code> node points to." },
+                    { "name": "baseURL", "type": "string", "optional": true, "description": "Base URL that <code>Document</code> or <code>FrameOwner</code> node uses for URL completion." },
+                    { "name": "publicId", "type": "string", "optional": true, "description": "<code>DocumentType</code>'s publicId." },
+                    { "name": "systemId", "type": "string", "optional": true, "description": "<code>DocumentType</code>'s systemId." },
+                    { "name": "internalSubset", "type": "string", "optional": true, "description": "<code>DocumentType</code>'s internalSubset." },
+                    { "name": "xmlVersion", "type": "string", "optional": true, "description": "<code>Document</code>'s XML version in case of XML documents." },
+                    { "name": "name", "type": "string", "optional": true, "description": "<code>Attr</code>'s name." },
+                    { "name": "value", "type": "string", "optional": true, "description": "<code>Attr</code>'s value." },
+                    { "name": "frameId", "$ref": "Network.FrameId", "optional": true, "description": "Frame ID for frame owner elements." },
+                    { "name": "contentDocument", "$ref": "Node", "optional": true, "description": "Content document for frame owner elements." },
+                    { "name": "shadowRoots", "type": "array", "optional": true, "items": { "$ref": "Node" }, "description": "Shadow root list for given element host." },
+                    { "name": "templateContent", "$ref": "Node", "optional": true, "description": "Content document fragment for template elements" }
+                ],
+                "description": "DOM interaction is implemented in terms of mirror objects that represent the actual DOM nodes. DOMNode is a base node mirror type."
+            },
+            {
+                "id": "EventListener",
+                "type": "object",
+                "properties": [
+                    { "name": "type", "type": "string", "description": "<code>EventListener</code>'s type." },
+                    { "name": "useCapture", "type": "boolean", "description": "<code>EventListener</code>'s useCapture." },
+                    { "name": "isAttribute", "type": "boolean", "description": "<code>EventListener</code>'s isAttribute." },
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Target <code>DOMNode</code> id." },
+                    { "name": "handlerBody", "type": "string", "description": "Event handler function body." },
+                    { "name": "location", "$ref": "Debugger.Location", "optional": true, "description": "Handler code location." },
+                    { "name": "sourceName", "type": "string", "optional": true, "description": "Source script URL." },
+                    { "name": "handler", "$ref": "Runtime.RemoteObject", "optional": true, "description": "Event handler function value." }
+                ],
+                "description": "DOM interaction is implemented in terms of mirror objects that represent the actual DOM nodes. DOMNode is a base node mirror type."
+            },
+            {
+                "id": "RGBAColor",
+                "type": "object",
+                "properties": [
+                    { "name": "r", "type": "integer", "description": "The red component, in the [0-255] range." },
+                    { "name": "g", "type": "integer", "description": "The green component, in the [0-255] range." },
+                    { "name": "b", "type": "integer", "description": "The blue component, in the [0-255] range." },
+                    { "name": "a", "type": "number", "optional": true, "description": "The alpha component, in the [0-1] range (default: 1)." }
+                ],
+                "description": "A structure holding an RGBA color."
+            },
+            {
+                "id": "Quad",
+                "type": "array",
+                "items": { "type": "number" },
+                "minItems": 8,
+                "maxItems": 8,
+                "description": "An array of quad vertices, x immediately followed by y for each point, points clock-wise."
+            },
+            {
+                "id": "HighlightConfig",
+                "type": "object",
+                "properties": [
+                    { "name": "showInfo", "type": "boolean", "optional": true, "description": "Whether the node info tooltip should be shown (default: false)." },
+                    { "name": "contentColor", "$ref": "RGBAColor", "optional": true, "description": "The content box highlight fill color (default: transparent)." },
+                    { "name": "paddingColor", "$ref": "RGBAColor", "optional": true, "description": "The padding highlight fill color (default: transparent)." },
+                    { "name": "borderColor", "$ref": "RGBAColor", "optional": true, "description": "The border highlight fill color (default: transparent)." },
+                    { "name": "marginColor", "$ref": "RGBAColor", "optional": true, "description": "The margin highlight fill color (default: transparent)." }
+                ],
+                "description": "Configuration data for the highlighting of page elements."
+            }
+        ],
+        "commands": [
+            {
+                "name": "getDocument",
+                "returns": [
+                    { "name": "root", "$ref": "Node", "description": "Resulting node." }
+                ],
+                "description": "Returns the root DOM node to the caller."
+            },
+            {
+                "name": "requestChildNodes",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to get children for." },
+                    { "name": "depth", "type": "integer", "optional": true, "description": "The maximum depth at which children should be retrieved, defaults to 1. Use -1 for the entire subtree or provide an integer larger than 0." }
+                ],
+                "description": "Requests that children of the node with given id are returned to the caller in form of <code>setChildNodes</code> events where not only immediate children are retrieved, but all children down to the specified depth."
+            },
+            {
+                "name": "querySelector",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to query upon." },
+                    { "name": "selector", "type": "string", "description": "Selector string." }
+                ],
+                "returns": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Query selector result." }
+                ],
+                "description": "Executes <code>querySelector</code> on a given node."
+            },
+            {
+                "name": "querySelectorAll",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to query upon." },
+                    { "name": "selector", "type": "string", "description": "Selector string." }
+                ],
+                "returns": [
+                    { "name": "nodeIds", "type": "array", "items": { "$ref": "NodeId" }, "description": "Query selector result." }
+                ],
+                "description": "Executes <code>querySelectorAll</code> on a given node."
+            },
+            {
+                "name": "setNodeName",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to set name for." },
+                    { "name": "name", "type": "string", "description": "New node's name." }
+                ],
+                "returns": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "New node's id." }
+                ],
+                "description": "Sets node name for a node with given id."
+            },
+            {
+                "name": "setNodeValue",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to set value for." },
+                    { "name": "value", "type": "string", "description": "New node's value." }
+                ],
+                "description": "Sets node value for a node with given id."
+            },
+            {
+                "name": "removeNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to remove." }
+                ],
+                "description": "Removes node with given id."
+            },
+            {
+                "name": "setAttributeValue",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the element to set attribute for." },
+                    { "name": "name", "type": "string", "description": "Attribute name." },
+                    { "name": "value", "type": "string", "description": "Attribute value." }
+                ],
+                "description": "Sets attribute for an element with given id."
+            },
+            {
+                "name": "setAttributesAsText",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the element to set attributes for." },
+                    { "name": "text", "type": "string", "description": "Text with a number of attributes. Will parse this text using HTML parser." },
+                    { "name": "name", "type": "string", "optional": true, "description": "Attribute name to replace with new attributes derived from text in case text parsed successfully." }
+                ],
+                "description": "Sets attributes on element with given id. This method is useful when user edits some existing attribute value and types in several attribute name/value pairs."
+            },
+            {
+                "name": "removeAttribute",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the element to remove attribute from." },
+                    { "name": "name", "type": "string", "description": "Name of the attribute to remove." }
+                ],
+                "description": "Removes attribute with given name from an element with given id."
+            },
+            {
+                "name": "getEventListenersForNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to get listeners for." },
+                    { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name for handler value. Handler value is not returned without this parameter specified." }
+                ],
+                "returns": [
+                    { "name": "listeners", "type": "array", "items": { "$ref": "EventListener"}, "description": "Array of relevant listeners." }
+                ],
+                "description": "Returns event listeners relevant to the node."
+            },
+            {
+                "name": "getOuterHTML",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to get markup for." }
+                ],
+                "returns": [
+                    { "name": "outerHTML", "type": "string", "description": "Outer HTML markup." }
+                ],
+                "description": "Returns node's HTML markup."
+            },
+            {
+                "name": "setOuterHTML",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to set markup for." },
+                    { "name": "outerHTML", "type": "string", "description": "Outer HTML markup to set." }
+                ],
+                "description": "Sets node HTML markup, returns new node id."
+            },
+            {
+                "name": "performSearch",
+                "parameters": [
+                    { "name": "query", "type": "string", "description": "Plain text or query selector or XPath search query." }
+                ],
+                "returns": [
+                    { "name": "searchId", "type": "string", "description": "Unique search session identifier." },
+                    { "name": "resultCount", "type": "integer", "description": "Number of search results." }
+                ],
+                "description": "Searches for a given string in the DOM tree. Use <code>getSearchResults</code> to access search results or <code>cancelSearch</code> to end this search session."
+            },
+            {
+                "name": "getSearchResults",
+                "parameters": [
+                    { "name": "searchId", "type": "string", "description": "Unique search session identifier." },
+                    { "name": "fromIndex", "type": "integer", "description": "Start index of the search result to be returned." },
+                    { "name": "toIndex", "type": "integer", "description": "End index of the search result to be returned." }
+                ],
+                "returns": [
+                    { "name": "nodeIds", "type": "array", "items": { "$ref": "NodeId" }, "description": "Ids of the search result nodes." }
+                ],
+                "description": "Returns search results from given <code>fromIndex</code> to given <code>toIndex</code> from the sarch with the given identifier."
+            },
+            {
+                "name": "discardSearchResults",
+                "parameters": [
+                    { "name": "searchId", "type": "string", "description": "Unique search session identifier." }
+                ],
+                "description": "Discards search results from the session with the given id. <code>getSearchResults</code> should no longer be called for that search."
+            },
+            {
+                "name": "requestNode",
+                "parameters": [
+                    { "name": "objectId", "$ref": "Runtime.RemoteObjectId", "description": "JavaScript object id to convert into node." }
+                ],
+                "returns": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Node id for given object." }
+                ],
+                "description": "Requests that the node is sent to the caller given the JavaScript node object reference. All nodes that form the path from the node to the root are also sent to the client as a series of <code>setChildNodes</code> notifications."
+            },
+            {
+                "name": "setInspectModeEnabled",
+                "parameters": [
+                    { "name": "enabled", "type": "boolean", "description": "True to enable inspection mode, false to disable it." },
+                    { "name": "highlightConfig", "$ref": "HighlightConfig", "optional": true, "description": "A descriptor for the highlight appearance of hovered-over nodes. May be omitted if <code>enabled == false</code>." }
+                ],
+                "description": "Enters the 'inspect' mode. In this mode, elements that user is hovering over are highlighted. Backend then generates 'inspect' command upon element selection."
+            },
+            {
+                "name": "highlightRect",
+                "parameters": [
+                    { "name": "x", "type": "integer", "description": "X coordinate" },
+                    { "name": "y", "type": "integer", "description": "Y coordinate" },
+                    { "name": "width", "type": "integer", "description": "Rectangle width" },
+                    { "name": "height", "type": "integer", "description": "Rectangle height" },
+                    { "name": "color", "$ref": "RGBAColor", "optional": true, "description": "The highlight fill color (default: transparent)." },
+                    { "name": "outlineColor", "$ref": "RGBAColor", "optional": true, "description": "The highlight outline color (default: transparent)." },
+                    { "name": "usePageCoordinates", "type": "boolean", "optional": true, "description": "Indicates whether the provided parameters are in page coordinates or in viewport coordinates (the default)." }
+                ],
+                "description": "Highlights given rectangle. Coordinates are absolute with respect to the main frame viewport."
+            },
+            {
+                "name": "highlightQuad",
+                "parameters": [
+                    { "name": "quad", "$ref": "Quad", "description": "Quad to highlight" },
+                    { "name": "color", "$ref": "RGBAColor", "optional": true, "description": "The highlight fill color (default: transparent)." },
+                    { "name": "outlineColor", "$ref": "RGBAColor", "optional": true, "description": "The highlight outline color (default: transparent)." },
+                    { "name": "usePageCoordinates", "type": "boolean", "optional": true, "description": "Indicates whether the provided parameters are in page coordinates or in viewport coordinates (the default)." }
+                ],
+                "description": "Highlights given quad. Coordinates are absolute with respect to the main frame viewport."
+            },
+            {
+                "name": "highlightNode",
+                "parameters": [
+                    { "name": "highlightConfig", "$ref": "HighlightConfig",  "description": "A descriptor for the highlight appearance." },
+                    { "name": "nodeId", "$ref": "NodeId", "optional": true, "description": "Identifier of the node to highlight." },
+                    { "name": "objectId", "$ref": "Runtime.RemoteObjectId", "optional": true, "description": "JavaScript object id of the node to be highlighted." }
+                ],
+                "description": "Highlights DOM node with given id or with the given JavaScript object wrapper. Either nodeId or objectId must be specified."
+            },
+            {
+                "name": "hideHighlight",
+                "description": "Hides DOM node highlight."
+            },
+            {
+                "name": "highlightFrame",
+                "parameters": [
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Identifier of the frame to highlight." },
+                    { "name": "contentColor", "$ref": "RGBAColor", "optional": true, "description": "The content box highlight fill color (default: transparent)." },
+                    { "name": "contentOutlineColor", "$ref": "RGBAColor", "optional": true, "description": "The content box highlight outline color (default: transparent)." }
+                ],
+                "description": "Highlights owner element of the frame with given id."
+            },
+            {
+                "name": "pushNodeByPathToFrontend",
+                "parameters": [
+                    { "name": "path", "type": "string", "description": "Path to node in the proprietary format." }
+                ],
+                "returns": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node for given path." }
+                ],
+                "description": "Requests that the node is sent to the caller given its path. // FIXME, use XPath"
+            },
+            {
+                "name": "pushNodeByBackendIdToFrontend",
+                "parameters": [
+                    { "name": "backendNodeId", "$ref": "BackendNodeId", "description": "The backend node id of the node." }
+                ],
+                "returns": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "The pushed node's id." }
+                ],
+                "description": "Requests that the node is sent to the caller given its backend node id."
+            },
+            {
+                "name": "releaseBackendNodeIds",
+                "parameters": [
+                    { "name": "nodeGroup", "type": "string", "description": "The backend node ids group name." }
+                ],
+                "description": "Requests that group of <code>BackendNodeIds</code> is released."
+            },
+            {
+                "name": "resolveNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to resolve." },
+                    { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." }
+                ],
+                "returns": [
+                    { "name": "object", "$ref": "Runtime.RemoteObject", "description": "JavaScript object wrapper for given node." }
+                ],
+                "description": "Resolves JavaScript node object for given node id."
+            },
+            {
+                "name": "getAttributes",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to retrieve attibutes for." }
+                ],
+                "returns": [
+                    { "name": "attributes", "type": "array", "items": { "type": "string" }, "description": "An interleaved array of node attribute names and values." }
+                ],
+                "description": "Returns attributes for the specified node."
+            },
+            {
+                "name": "moveTo",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to drop." },
+                    { "name": "targetNodeId", "$ref": "NodeId", "description": "Id of the element to drop into." },
+                    { "name": "insertBeforeNodeId", "$ref": "NodeId", "optional": true, "description": "Drop node before given one." }
+                ],
+                "returns": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "New id of the moved node." }
+                ],
+                "description": "Moves node into the new container, places it before the given anchor."
+            },
+            {
+                "name": "undo",
+                "description": "Undoes the last performed action."
+            },
+            {
+                "name": "redo",
+                "description": "Re-does the last undone action."
+            },
+            {
+                "name": "markUndoableState",
+                "description": "Marks last undoable state."
+            },
+            {
+                "name": "focus",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to focus." }
+                ],
+                "description": "Focuses the given element."
+            }
+        ],
+        "events": [
+            {
+                "name": "documentUpdated",
+                "description": "Fired when <code>Document</code> has been totally updated. Node ids are no longer valid."
+            },
+            {
+                "name": "setChildNodes",
+                "parameters": [
+                    { "name": "parentId", "$ref": "NodeId", "description": "Parent node id to populate with children." },
+                    { "name": "nodes", "type": "array", "items": { "$ref": "Node"}, "description": "Child nodes array." }
+                ],
+                "description": "Fired when backend wants to provide client with the missing DOM structure. This happens upon most of the calls requesting node ids."
+            },
+            {
+                "name": "attributeModified",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                    { "name": "name", "type": "string", "description": "Attribute name." },
+                    { "name": "value", "type": "string", "description": "Attribute value." }
+                ],
+                "description": "Fired when <code>Element</code>'s attribute is modified."
+            },
+            {
+                "name": "attributeRemoved",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                    { "name": "name", "type": "string", "description": "A ttribute name." }
+                ],
+                "description": "Fired when <code>Element</code>'s attribute is removed."
+            },
+            {
+                "name": "inlineStyleInvalidated",
+                "parameters": [
+                    { "name": "nodeIds", "type": "array", "items": { "$ref": "NodeId" }, "description": "Ids of the nodes for which the inline styles have been invalidated." }
+                ],
+                "description": "Fired when <code>Element</code>'s inline style is modified via a CSS property modification."
+            },
+            {
+                "name": "characterDataModified",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                    { "name": "characterData", "type": "string", "description": "New text value." }
+                ],
+                "description": "Mirrors <code>DOMCharacterDataModified</code> event."
+            },
+            {
+                "name": "childNodeCountUpdated",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                    { "name": "childNodeCount", "type": "integer", "description": "New node count." }
+                ],
+                "description": "Fired when <code>Container</code>'s child node count has changed."
+            },
+            {
+                "name": "childNodeInserted",
+                "parameters": [
+                    { "name": "parentNodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                    { "name": "previousNodeId", "$ref": "NodeId", "description": "If of the previous siblint." },
+                    { "name": "node", "$ref": "Node", "description": "Inserted node data." }
+                ],
+                "description": "Mirrors <code>DOMNodeInserted</code> event."
+            },
+            {
+                "name": "childNodeRemoved",
+                "parameters": [
+                    { "name": "parentNodeId", "$ref": "NodeId", "description": "Parent id." },
+                    { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has been removed." }
+                ],
+                "description": "Mirrors <code>DOMNodeRemoved</code> event."
+            },
+            {
+                "name": "shadowRootPushed",
+                "parameters": [
+                    { "name": "hostId", "$ref": "NodeId", "description": "Host element id." },
+                    { "name": "root", "$ref": "Node", "description": "Shadow root." }
+                ],
+                "description": "Called when shadow root is pushed into the element."
+            },
+            {
+                "name": "shadowRootPopped",
+                "parameters": [
+                    { "name": "hostId", "$ref": "NodeId", "description": "Host element id." },
+                    { "name": "rootId", "$ref": "NodeId", "description": "Shadow root id." }
+                ],
+                "description": "Called when shadow root is popped from the element."
+            }
+        ]
+    },
+    {
+        "domain": "CSS",
+        "description": "This domain exposes CSS read/write operations. All CSS objects, like stylesheets, rules, and styles, have an associated <code>id</code> used in subsequent operations on the related object. Each object type has a specific <code>id</code> structure, and those are not interchangeable between objects of different kinds. CSS objects can be loaded using the <code>get*ForNode()</code> calls (which accept a DOM node id). Alternatively, a client can discover all the existing stylesheets with the <code>getAllStyleSheets()</code> method and subsequently load the required stylesheet contents using the <code>getStyleSheet[Text]()</code> methods.",
+        "types": [
+            {
+                "id": "StyleSheetId",
+                "type": "string"
+            },
+            {
+                "id": "CSSStyleId",
+                "type": "object",
+                "properties": [
+                    { "name": "styleSheetId", "$ref": "StyleSheetId", "description": "Enclosing stylesheet identifier." },
+                    { "name": "ordinal", "type": "integer", "description": "The style ordinal within the stylesheet." }
+                ],
+                "description": "This object identifies a CSS style in a unique way."
+            },
+            {
+                "id": "StyleSheetOrigin",
+                "type": "string",
+                "enum": ["user", "user-agent", "inspector", "regular"],
+                "description": "Stylesheet type: \"user\" for user stylesheets, \"user-agent\" for user-agent stylesheets, \"inspector\" for stylesheets created by the inspector (i.e. those holding the \"via inspector\" rules), \"regular\" for regular stylesheets."
+            },
+            {
+                "id": "CSSRuleId",
+                "type": "object",
+                "properties": [
+                    { "name": "styleSheetId", "$ref": "StyleSheetId", "description": "Enclosing stylesheet identifier." },
+                    { "name": "ordinal", "type": "integer", "description": "The rule ordinal within the stylesheet." }
+                ],
+                "description": "This object identifies a CSS rule in a unique way."
+            },
+            {
+                "id": "PseudoIdMatches",
+                "type": "object",
+                "properties": [
+                    { "name": "pseudoId", "type": "integer", "description": "Pseudo style identifier (see <code>enum PseudoId</code> in <code>RenderStyleConstants.h</code>)."},
+                    { "name": "matches", "type": "array", "items": { "$ref": "RuleMatch" }, "description": "Matches of CSS rules applicable to the pseudo style."}
+                ],
+                "description": "CSS rule collection for a single pseudo style."
+            },
+            {
+                "id": "InheritedStyleEntry",
+                "type": "object",
+                "properties": [
+                    { "name": "inlineStyle", "$ref": "CSSStyle", "optional": true, "description": "The ancestor node's inline style, if any, in the style inheritance chain." },
+                    { "name": "matchedCSSRules", "type": "array", "items": { "$ref": "RuleMatch" }, "description": "Matches of CSS rules matching the ancestor node in the style inheritance chain." }
+                ],
+                "description": "CSS rule collection for a single pseudo style."
+            },
+            {
+                "id": "RuleMatch",
+                "type": "object",
+                "properties": [
+                    { "name": "rule", "$ref": "CSSRule", "description": "CSS rule in the match." },
+                    { "name": "matchingSelectors", "type": "array", "items": { "type": "integer" }, "description": "Matching selector indices in the rule's selectorList selectors (0-based)." }
+                ],
+                "description": "Match data for a CSS rule."
+            },
+            {
+                "id": "SelectorList",
+                "type": "object",
+                "properties": [
+                    { "name": "selectors", "type": "array", "items": { "type": "string" }, "description": "Selectors in the list." },
+                    { "name": "text", "type": "string", "description": "Rule selector text." },
+                    { "name": "range", "$ref": "SourceRange", "optional": true, "description": "Rule selector range in the underlying resource (if available)." }
+                ],
+                "description": "Selector list data."
+            },
+            {
+                "id": "CSSStyleAttribute",
+                "type": "object",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "DOM attribute name (e.g. \"width\")."},
+                    { "name": "style", "$ref": "CSSStyle", "description": "CSS style generated by the respective DOM attribute."}
+                ],
+                "description": "CSS style information for a DOM style attribute."
+            },
+            {
+                "id": "CSSStyleSheetHeader",
+                "type": "object",
+                "properties": [
+                    { "name": "styleSheetId", "$ref": "StyleSheetId", "description": "The stylesheet identifier."},
+                    { "name": "frameId", "$ref": "Network.FrameId", "description": "Owner frame identifier."},
+                    { "name": "sourceURL", "type": "string", "description": "Stylesheet resource URL."},
+                    { "name": "origin", "$ref": "StyleSheetOrigin", "description": "Stylesheet origin."},
+                    { "name": "title", "type": "string", "description": "Stylesheet title."},
+                    { "name": "disabled", "type": "boolean", "description": "Denotes whether the stylesheet is disabled."}
+                ],
+                "description": "CSS stylesheet metainformation."
+            },
+            {
+                "id": "CSSStyleSheetBody",
+                "type": "object",
+                "properties": [
+                    { "name": "styleSheetId", "$ref": "StyleSheetId", "description": "The stylesheet identifier."},
+                    { "name": "rules", "type": "array", "items": { "$ref": "CSSRule" }, "description": "Stylesheet resource URL."},
+                    { "name": "text", "type": "string", "optional": true, "description": "Stylesheet resource contents (if available)."}
+                ],
+                "description": "CSS stylesheet contents."
+            },
+            {
+                "id": "CSSRule",
+                "type": "object",
+                "properties": [
+                    { "name": "ruleId", "$ref": "CSSRuleId", "optional": true, "description": "The CSS rule identifier (absent for user agent stylesheet and user-specified stylesheet rules)."},
+                    { "name": "selectorList", "$ref": "SelectorList", "description": "Rule selector data." },
+                    { "name": "sourceURL", "type": "string", "optional": true, "description": "Parent stylesheet resource URL (for regular rules)."},
+                    { "name": "sourceLine", "type": "integer", "description": "Line ordinal of the rule selector start character in the resource."},
+                    { "name": "origin", "$ref": "StyleSheetOrigin", "description": "Parent stylesheet's origin."},
+                    { "name": "style", "$ref": "CSSStyle", "description": "Associated style declaration." },
+                    { "name": "media", "type": "array", "items": { "$ref": "CSSMedia" }, "optional": true, "description": "Media list array (for rules involving media queries). The array enumerates media queries starting with the innermost one, going outwards." }
+                ],
+                "description": "CSS rule representation."
+            },
+            {
+                "id": "SourceRange",
+                "type": "object",
+                "properties": [
+                    { "name": "startLine", "type": "integer", "description": "Start line of range." },
+                    { "name": "startColumn", "type": "integer", "description": "Start column of range (inclusive)." },
+                    { "name": "endLine", "type": "integer", "description": "End line of range" },
+                    { "name": "endColumn", "type": "integer", "description": "End column of range (exclusive)." }
+                ],
+                "description": "Text range within a resource."
+            },
+            {
+                "id": "ShorthandEntry",
+                "type": "object",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "Shorthand name." },
+                    { "name": "value", "type": "string", "description": "Shorthand value." }
+                ]
+            },
+            {
+                "id": "CSSPropertyInfo",
+                "type": "object",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "Property name." },
+                    { "name": "longhands", "type": "array", "optional": true, "items": { "type": "string" }, "description": "Longhand property names." }
+                ]
+            },
+            {
+                "id": "CSSComputedStyleProperty",
+                "type": "object",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "Computed style property name." },
+                    { "name": "value", "type": "string", "description": "Computed style property value." }
+                ]
+            },
+            {
+                "id": "CSSStyle",
+                "type": "object",
+                "properties": [
+                    { "name": "styleId", "$ref": "CSSStyleId", "optional": true, "description": "The CSS style identifier (absent for attribute styles)." },
+                    { "name": "cssProperties", "type": "array", "items": { "$ref": "CSSProperty" }, "description": "CSS properties in the style." },
+                    { "name": "shorthandEntries", "type": "array", "items": { "$ref": "ShorthandEntry" }, "description": "Computed values for all shorthands found in the style." },
+                    { "name": "cssText", "type": "string", "optional": true, "description": "Style declaration text (if available)." },
+                    { "name": "range", "$ref": "SourceRange", "optional": true, "description": "Style declaration range in the enclosing stylesheet (if available)." },
+                    { "name": "width", "type": "string", "optional": true, "description": "The effective \"width\" property value from this style." },
+                    { "name": "height", "type": "string", "optional": true, "description": "The effective \"height\" property value from this style." }
+                ],
+                "description": "CSS style representation."
+            },
+            {
+                "id": "CSSPropertyStatus",
+                "type": "string",
+                "enum": ["active", "inactive", "disabled", "style"],
+                "description": "The property status: \"active\" (implied if absent) if the property is effective in the style, \"inactive\" if the property is overridden by a same-named property in this style later on, \"disabled\" if the property is disabled by the user, \"style\" if the property is reported by the browser rather than by the CSS source parser."
+            },
+            {
+                "id": "CSSProperty",
+                "type": "object",
+                "properties": [
+                    { "name": "name", "type": "string", "description": "The property name." },
+                    { "name": "value", "type": "string", "description": "The property value." },
+                    { "name": "priority", "type": "string", "optional": true, "description": "The property priority (implies \"\" if absent)." },
+                    { "name": "implicit", "type": "boolean", "optional": true, "description": "Whether the property is implicit (implies <code>false</code> if absent)." },
+                    { "name": "text", "type": "string", "optional": true, "description": "The full property text as specified in the style." },
+                    { "name": "parsedOk", "type": "boolean", "optional": true, "description": "Whether the property is understood by the browser (implies <code>true</code> if absent)." },
+                    { "name": "status", "$ref": "CSSPropertyStatus", "optional": true, "description": "Whether the property is active or disabled." },
+                    { "name": "range", "$ref": "SourceRange", "optional": true, "description": "The entire property range in the enclosing style declaration (if available)." }
+                ],
+                "description": "CSS style effective visual dimensions and source offsets."
+            },
+            {
+                "id": "CSSMedia",
+                "type": "object",
+                "properties": [
+                    { "name": "text", "type": "string", "description": "Media query text." },
+                    { "name": "source", "type": "string", "enum": ["mediaRule", "importRule", "linkedSheet", "inlineSheet"], "description": "Source of the media query: \"mediaRule\" if specified by a @media rule, \"importRule\" if specified by an @import rule, \"linkedSheet\" if specified by a \"media\" attribute in a linked stylesheet's LINK tag, \"inlineSheet\" if specified by a \"media\" attribute in an inline stylesheet's STYLE tag." },
+                    { "name": "sourceURL", "type": "string", "optional": true, "description": "URL of the document containing the media query description." },
+                    { "name": "sourceLine", "type": "integer", "optional": true, "description": "Line in the document containing the media query (not defined for the \"stylesheet\" source)." }
+                ],
+                "description": "CSS media query descriptor."
+            },
+            {
+                "id": "SelectorProfileEntry",
+                "type": "object",
+                "properties": [
+                    { "name": "selector", "type": "string", "description": "CSS selector of the corresponding rule." },
+                    { "name": "url", "type": "string", "description": "URL of the resource containing the corresponding rule." },
+                    { "name": "lineNumber", "type": "integer", "description": "Selector line number in the resource for the corresponding rule." },
+                    { "name": "time", "type": "number", "description": "Total time this rule handling contributed to the browser running time during profiling (in milliseconds.)" },
+                    { "name": "hitCount", "type": "integer", "description": "Number of times this rule was considered a candidate for matching against DOM elements." },
+                    { "name": "matchCount", "type": "integer", "description": "Number of times this rule actually matched a DOM element." }
+                ],
+                "description": "CSS selector profile entry."
+            },
+            {
+                "id": "SelectorProfile",
+                "type": "object",
+                "properties": [
+                    { "name": "totalTime", "type": "number", "description": "Total processing time for all selectors in the profile (in milliseconds.)" },
+                    { "name": "data", "type": "array", "items": { "$ref": "SelectorProfileEntry" }, "description": "CSS selector profile entries." }
+                ]
+            },
+            {
+                "id": "Region",
+                "type": "object",
+                "properties": [
+                    { "name": "regionOverset", "type": "string", "enum": ["overset", "fit", "empty"], "description": "The \"overset\" attribute of a Named Flow." },
+                    { "name": "nodeId", "$ref": "DOM.NodeId", "description": "The corresponding DOM node id." }
+                ],
+                "description": "This object represents a region that flows from a Named Flow."
+            },
+            {
+                "id": "NamedFlow",
+                "type": "object",
+                "properties": [
+                    { "name": "documentNodeId", "$ref": "DOM.NodeId", "description": "The document node id." },
+                    { "name": "name", "type": "string", "description": "Named Flow identifier." },
+                    { "name": "overset", "type": "boolean", "description": "The \"overset\" attribute of a Named Flow." },
+                    { "name": "content", "type": "array", "items": { "$ref": "DOM.NodeId" }, "description": "An array of nodes that flow into the Named Flow." },
+                    { "name": "regions", "type": "array", "items": { "$ref": "Region" }, "description": "An array of regions associated with the Named Flow." }
+                ],
+                "description": "This object represents a Named Flow."
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables the CSS agent for the given page. Clients should not assume that the CSS agent has been enabled until the result of this command is received."
+            },
+            {
+                "name": "disable",
+                "description": "Disables the CSS agent for the given page."
+            },
+            {
+                "name": "getMatchedStylesForNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId" },
+                    { "name": "includePseudo", "type": "boolean", "optional": true, "description": "Whether to include pseudo styles (default: true)." },
+                    { "name": "includeInherited", "type": "boolean", "optional": true, "description": "Whether to include inherited styles (default: true)." }
+                ],
+                "returns": [
+                    { "name": "matchedCSSRules", "type": "array", "items": { "$ref": "RuleMatch" }, "optional": true, "description": "CSS rules matching this node, from all applicable stylesheets." },
+                    { "name": "pseudoElements", "type": "array", "items": { "$ref": "PseudoIdMatches" }, "optional": true, "description": "Pseudo style matches for this node." },
+                    { "name": "inherited", "type": "array", "items": { "$ref": "InheritedStyleEntry" }, "optional": true, "description": "A chain of inherited styles (from the immediate node parent up to the DOM tree root)." }
+                ],
+                "description": "Returns requested styles for a DOM node identified by <code>nodeId</code>."
+            },
+            {
+                "name": "getInlineStylesForNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId" }
+                ],
+                "returns": [
+                    { "name": "inlineStyle", "$ref": "CSSStyle", "optional": true, "description": "Inline style for the specified DOM node." },
+                    { "name": "attributesStyle", "$ref": "CSSStyle", "optional": true, "description": "Attribute-defined element style (e.g. resulting from \"width=20 height=100%\")."}
+                ],
+                "description": "Returns the styles defined inline (explicitly in the \"style\" attribute and implicitly, using DOM attributes) for a DOM node identified by <code>nodeId</code>."
+            },
+            {
+                "name": "getComputedStyleForNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId" }
+                ],
+                "returns": [
+                    { "name": "computedStyle", "type": "array", "items": { "$ref": "CSSComputedStyleProperty" }, "description": "Computed style for the specified DOM node." }
+                ],
+                "description": "Returns the computed style for a DOM node identified by <code>nodeId</code>."
+            },
+            {
+                "name": "getAllStyleSheets",
+                "returns": [
+                    { "name": "headers", "type": "array", "items": { "$ref": "CSSStyleSheetHeader" }, "description": "Descriptor entries for all available stylesheets." }
+                ],
+                "description": "Returns metainfo entries for all known stylesheets."
+            },
+            {
+                "name": "getStyleSheet",
+                "parameters": [
+                    { "name": "styleSheetId", "$ref": "StyleSheetId" }
+                ],
+                "returns": [
+                    { "name": "styleSheet", "$ref": "CSSStyleSheetBody", "description": "Stylesheet contents for the specified <code>styleSheetId</code>." }
+                ],
+                "description": "Returns stylesheet data for the specified <code>styleSheetId</code>."
+            },
+            {
+                "name": "getStyleSheetText",
+                "parameters": [
+                    { "name": "styleSheetId", "$ref": "StyleSheetId" }
+                ],
+                "returns": [
+                    { "name": "text", "type": "string", "description": "The stylesheet text." }
+                ],
+                "description": "Returns the current textual content and the URL for a stylesheet."
+            },
+            {
+                "name": "setStyleSheetText",
+                "parameters": [
+                    { "name": "styleSheetId", "$ref": "StyleSheetId" },
+                    { "name": "text", "type": "string" }
+                ],
+                "description": "Sets the new stylesheet text, thereby invalidating all existing <code>CSSStyleId</code>'s and <code>CSSRuleId</code>'s contained by this stylesheet."
+            },
+            {
+                "name": "setStyleText",
+                "parameters": [
+                    { "name": "styleId", "$ref": "CSSStyleId" },
+                    { "name": "text", "type": "string" }
+                ],
+                "returns": [
+                    { "name": "style", "$ref": "CSSStyle", "description": "The resulting style after the text modification." }
+                ],
+                "description": "Sets the new <code>text</code> for the respective style."
+            },
+            {
+                "name": "setRuleSelector",
+                "parameters": [
+                    { "name": "ruleId", "$ref": "CSSRuleId" },
+                    { "name": "selector", "type": "string" }
+                ],
+                "returns": [
+                    { "name": "rule", "$ref": "CSSRule", "description": "The resulting rule after the selector modification." }
+                ],
+                "description": "Modifies the rule selector."
+            },
+            {
+                "name": "addRule",
+                "parameters": [
+                    { "name": "contextNodeId", "$ref": "DOM.NodeId" },
+                    { "name": "selector", "type": "string" }
+                ],
+                "returns": [
+                    { "name": "rule", "$ref": "CSSRule", "description": "The newly created rule." }
+                ],
+                "description": "Creates a new empty rule with the given <code>selector</code> in a special \"inspector\" stylesheet in the owner document of the context node."
+            },
+            {
+                "name": "getSupportedCSSProperties",
+                "returns": [
+                    { "name": "cssProperties", "type": "array", "items": { "$ref": "CSSPropertyInfo" }, "description": "Supported property metainfo." }
+                ],
+                "description": "Returns all supported CSS property names."
+            },
+            {
+                "name": "forcePseudoState",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId", "description": "The element id for which to force the pseudo state." },
+                    { "name": "forcedPseudoClasses", "type": "array", "items": { "type": "string", "enum": ["active", "focus", "hover", "visited"] }, "description": "Element pseudo classes to force when computing the element's style." }
+                ],
+                "description": "Ensures that the given node will have specified pseudo-classes whenever its style is computed by the browser."
+            },
+            {
+                "name": "startSelectorProfiler"
+            },
+            {
+                "name": "stopSelectorProfiler",
+                "returns": [
+                    { "name": "profile", "$ref": "SelectorProfile" }
+                ]
+            },
+            {
+                "name": "getNamedFlowCollection",
+                "parameters": [
+                    { "name": "documentNodeId", "$ref": "DOM.NodeId", "description": "The document node id for which to get the Named Flow Collection." }
+                ],
+                "returns": [
+                    { "name": "namedFlows", "type": "array", "items": { "$ref": "NamedFlow" }, "description": "An array containing the Named Flows in the document." }
+                ],
+                "description": "Returns the Named Flows from the document."
+            }
+        ],
+        "events": [
+            {
+                "name": "mediaQueryResultChanged",
+                "description": "Fires whenever a MediaQuery result changes (for example, after a browser window has been resized.) The current implementation considers only viewport-dependent media features."
+            },
+            {
+                "name": "styleSheetChanged",
+                "parameters": [
+                    { "name": "styleSheetId", "$ref": "StyleSheetId" }
+                ],
+                "description": "Fired whenever a stylesheet is changed as a result of the client operation."
+            },
+            {
+                "name": "namedFlowCreated",
+                "parameters": [
+                    { "name": "namedFlow", "$ref": "NamedFlow", "description": "The new Named Flow." }
+                ],
+                "description": "Fires when a Named Flow is created."
+            },
+            {
+                "name": "namedFlowRemoved",
+                "parameters": [
+                    { "name": "documentNodeId", "$ref": "DOM.NodeId", "description": "The document node id." },
+                    { "name": "flowName", "type": "string", "description": "Identifier of the removed Named Flow." }
+                ],
+                "description": "Fires when a Named Flow is removed: has no associated content nodes and regions."
+            },
+            {
+                "name": "regionLayoutUpdated",
+                "parameters": [
+                    { "name": "namedFlow", "$ref": "NamedFlow", "description": "The Named Flow whose layout may have changed." }
+                ],
+                "description": "Fires when a Named Flow's layout may have changed."
+            }
+        ]
+    },
+    {
+        "domain": "Timeline",
+        "description": "Timeline provides its clients with instrumentation records that are generated during the page runtime. Timeline instrumentation can be started and stopped using corresponding commands. While timeline is started, it is generating timeline event records.",
+        "types": [
+            {
+                "id": "EventType",
+                "type": "string",
+                "enum": ["EventDispatch", "ScheduleStyleRecalculation", "RecalculateStyles", "InvalidateLayout", "Layout", "Paint", "ResizeImage", "ParseHTML", "TimerInstall", "TimerRemove", "TimerFire", "EvaluateScript", "MarkLoad", "MarkDOMContent", "TimeStamp", "Time", "TimeEnd", "ScheduleResourceRequest", "ResourceSendRequest", "ResourceReceiveResponse", "ResourceReceivedData", "ResourceFinish", "XHRReadyStateChange", "XHRLoad", "FunctionCall", "RequestAnimationFrame", "CancelAnimationFrame", "FireAnimationFrame", "WebSocketCreate", "WebSocketSendHandshakeRequest", "WebSocketReceiveHandshakeResponse", "WebSocketDestroy"],
+                "description": "Timeline record type."
+            },
+            {
+                "id": "TimelineEvent",
+                "type": "object",
+                "properties": [
+                    { "name": "type", "type": "string", "description": "Event type." },
+                    { "name": "data", "type": "object", "description": "Event data." },
+                    { "name": "children", "type": "array", "optional": true, "items": { "$ref": "TimelineEvent" }, "description": "Nested records." }
+                ],
+                "description": "Timeline record contains information about the recorded activity."
+            }
+        ],
+        "commands": [
+            {
+                "name": "start",
+                "parameters": [
+                    { "name": "maxCallStackDepth", "optional": true, "type": "integer", "description": "Samples JavaScript stack traces up to <code>maxCallStackDepth</code>, defaults to 5." }
+                ],
+                "description": "Starts capturing instrumentation events."
+            },
+            {
+                "name": "stop",
+                "description": "Stops capturing instrumentation events."
+            }
+        ],
+        "events": [
+            {
+                "name": "eventRecorded",
+                "parameters": [
+                    { "name": "record", "$ref": "TimelineEvent", "description": "Timeline event record data." }
+                ],
+                "description": "Fired for every instrumentation event while timeline is started."
+            }
+        ]
+    },
+    {
+        "domain": "Debugger",
+        "description": "Debugger domain exposes JavaScript debugging capabilities. It allows setting and removing breakpoints, stepping through execution, exploring stack traces, etc.",
+        "types": [
+            {
+                "id": "BreakpointId",
+                "type": "string",
+                "description": "Breakpoint identifier."
+            },
+            {
+                "id": "ScriptId",
+                "type": "string",
+                "description": "Unique script identifier."
+            },
+            {
+                "id": "CallFrameId",
+                "type": "string",
+                "description": "Call frame identifier."
+            },
+            {
+                "id": "Location",
+                "type": "object",
+                "properties": [
+                    { "name": "scriptId", "$ref": "ScriptId", "description": "Script identifier as reported in the <code>Debugger.scriptParsed</code>." },
+                    { "name": "lineNumber", "type": "integer", "description": "Line number in the script." },
+                    { "name": "columnNumber", "type": "integer", "optional": true, "description": "Column number in the script." }
+                ],
+                "description": "Location in the source code."
+            },
+            {
+                "id": "FunctionDetails",
+                "type": "object",
+                "properties": [
+                    { "name": "location", "$ref": "Location", "description": "Location of the function." },
+                    { "name": "name", "type": "string", "optional": true, "description": "Name of the function. Not present for anonymous functions." },
+                    { "name": "displayName", "type": "string", "optional": true, "description": "Display name of the function(specified in 'displayName' property on the function object)." },
+                    { "name": "inferredName", "type": "string", "optional": true, "description": "Name of the function inferred from its initial assignment." },
+                    { "name": "scopeChain", "type": "array", "optional": true, "items": { "$ref": "Scope" }, "description": "Scope chain for this closure." }
+                ],
+                "description": "Information about the function."
+            },
+            {
+                "id": "CallFrame",
+                "type": "object",
+                "properties": [
+                    { "name": "callFrameId", "$ref": "CallFrameId", "description": "Call frame identifier. This identifier is only valid while the virtual machine is paused." },
+                    { "name": "functionName", "type": "string", "description": "Name of the JavaScript function called on this call frame." },
+                    { "name": "location", "$ref": "Location", "description": "Location in the source code." },
+                    { "name": "scopeChain", "type": "array", "items": { "$ref": "Scope" }, "description": "Scope chain for this call frame." },
+                    { "name": "this", "$ref": "Runtime.RemoteObject", "description": "<code>this</code> object for this call frame." }
+                ],
+                "description": "JavaScript call frame. Array of call frames form the call stack."
+            },
+            {
+                "id": "Scope",
+                "type": "object",
+                "properties": [
+                    { "name": "type", "type": "string", "enum": ["global", "local", "with", "closure", "catch"], "description": "Scope type." },
+                    { "name": "object", "$ref": "Runtime.RemoteObject", "description": "Object representing the scope. For <code>global</code> and <code>with</code> scopes it represents the actual object; for the rest of the scopes, it is artificial transient object enumerating scope variables as its properties." }
+                ],
+                "description": "Scope description."
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables debugger for the given page. Clients should not assume that the debugging has been enabled until the result for this command is received."
+            },
+            {
+                "name": "disable",
+                "description": "Disables debugger for given page."
+            },
+            {
+                "name": "setBreakpointsActive",
+                "parameters": [
+                    { "name": "active", "type": "boolean", "description": "New value for breakpoints active state." }
+                ],
+                "description": "Activates / deactivates all breakpoints on the page."
+            },
+            {
+                "name": "setBreakpointByUrl",
+                "parameters": [
+                    { "name": "lineNumber", "type": "integer", "description": "Line number to set breakpoint at." },
+                    { "name": "url", "type": "string", "optional": true, "description": "URL of the resources to set breakpoint on." },
+                    { "name": "urlRegex", "type": "string", "optional": true, "description": "Regex pattern for the URLs of the resources to set breakpoints on. Either <code>url</code> or <code>urlRegex</code> must be specified." },
+                    { "name": "columnNumber", "type": "integer", "optional": true, "description": "Offset in the line to set breakpoint at." },
+                    { "name": "condition", "type": "string", "optional": true, "description": "Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true." }
+                ],
+                "returns": [
+                    { "name": "breakpointId", "$ref": "BreakpointId", "description": "Id of the created breakpoint for further reference." },
+                    { "name": "locations", "type": "array", "items": { "$ref": "Location"}, "description": "List of the locations this breakpoint resolved into upon addition." }
+                ],
+                "description": "Sets JavaScript breakpoint at given location specified either by URL or URL regex. Once this command is issued, all existing parsed scripts will have breakpoints resolved and returned in <code>locations</code> property. Further matching script parsing will result in subsequent <code>breakpointResolved</code> events issued. This logical breakpoint will survive page reloads."
+            },
+            {
+                "name": "setBreakpoint",
+                "parameters": [
+                    { "name": "location", "$ref": "Location", "description": "Location to set breakpoint in." },
+                    { "name": "condition", "type": "string", "optional": true, "description": "Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true." }
+                ],
+                "returns": [
+                    { "name": "breakpointId", "$ref": "BreakpointId", "description": "Id of the created breakpoint for further reference." },
+                    { "name": "actualLocation", "$ref": "Location", "description": "Location this breakpoint resolved into." }
+                ],
+                "description": "Sets JavaScript breakpoint at a given location."
+            },
+            {
+                "name": "removeBreakpoint",
+                "parameters": [
+                    { "name": "breakpointId", "$ref": "BreakpointId" }
+                ],
+                "description": "Removes JavaScript breakpoint."
+            },
+            {
+                "name": "continueToLocation",
+                "parameters": [
+                    { "name": "location", "$ref": "Location", "description": "Location to continue to." }
+                ],
+                "description": "Continues execution until specific location is reached."
+            },
+            {
+                "name": "stepOver",
+                "description": "Steps over the statement."
+            },
+            {
+                "name": "stepInto",
+                "description": "Steps into the function call."
+            },
+            {
+                "name": "stepOut",
+                "description": "Steps out of the function call."
+            },
+            {
+                "name": "pause",
+                "description": "Stops on the next JavaScript statement."
+            },
+            {
+                "name": "resume",
+                "description": "Resumes JavaScript execution."
+            },
+            {
+                "name": "searchInContent",
+                "parameters": [
+                    { "name": "scriptId", "$ref": "ScriptId", "description": "Id of the script to search in." },
+                    { "name": "query", "type": "string", "description": "String to search for."  },
+                    { "name": "caseSensitive", "type": "boolean", "optional": true, "description": "If true, search is case sensitive." },
+                    { "name": "isRegex", "type": "boolean", "optional": true, "description": "If true, treats string parameter as regex." }
+                ],
+                "returns": [
+                    { "name": "result", "type": "array", "items": { "$ref": "Page.SearchMatch" }, "description": "List of search matches." }
+                ],
+                "description": "Searches for given string in script content."
+            },
+            {
+                "name": "restartFrame",
+                "parameters": [
+                    { "name": "callFrameId", "$ref": "CallFrameId", "description": "Call frame identifier to evaluate on." }
+                ],
+                "returns": [
+                    { "name": "callFrames", "type": "array", "items": { "$ref": "CallFrame"}, "description": "New stack trace." },
+                    { "name": "result", "type": "object", "description": "VM-specific description." }
+                ],
+                "description": "Restarts particular call frame from the beginning."
+            },
+            {
+                "name": "getScriptSource",
+                "parameters": [
+                    { "name": "scriptId", "$ref": "ScriptId", "description": "Id of the script to get source for." }
+                ],
+                "returns": [
+                    { "name": "scriptSource", "type": "string", "description": "Script source." }
+                ],
+                "description": "Returns source for the script with given id."
+            },
+            {
+                "name": "getFunctionDetails",
+                "parameters": [
+                    { "name": "functionId", "$ref": "Runtime.RemoteObjectId", "description": "Id of the function to get location for." }
+                ],
+                "returns": [
+                    { "name": "details", "$ref": "FunctionDetails", "description": "Information about the function." }
+                ],
+                "description": "Returns detailed informtation on given function."
+            },
+            {
+                "name": "setPauseOnExceptions",
+                "parameters": [
+                    { "name": "state", "type": "string", "enum": ["none", "uncaught", "all"], "description": "Pause on exceptions mode." }
+                ],
+                "description": "Defines pause on exceptions state. Can be set to stop on all exceptions, uncaught exceptions or no exceptions. Initial pause on exceptions state is <code>none</code>."
+            },
+            {
+                "name": "evaluateOnCallFrame",
+                "parameters": [
+                    { "name": "callFrameId", "$ref": "CallFrameId", "description": "Call frame identifier to evaluate on." },
+                    { "name": "expression", "type": "string", "description": "Expression to evaluate." },
+                    { "name": "objectGroup", "type": "string", "optional": true, "description": "String object group name to put result into (allows rapid releasing resulting object handles using <code>releaseObjectGroup</code>)." },
+                    { "name": "includeCommandLineAPI", "type": "boolean", "optional": true, "description": "Specifies whether command line API should be available to the evaluated expression, defaults to false." },
+                    { "name": "doNotPauseOnExceptionsAndMuteConsole", "type": "boolean", "optional": true, "description": "Specifies whether evaluation should stop on exceptions and mute console. Overrides setPauseOnException state." },
+                    { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object that should be sent by value." },
+                    { "name": "generatePreview", "type": "boolean", "optional": true,  "description": "Whether preview should be generated for the result." }
+                ],
+                "returns": [
+                    { "name": "result", "$ref": "Runtime.RemoteObject", "description": "Object wrapper for the evaluation result." },
+                    { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." }
+                ],
+                "description": "Evaluates expression on a given call frame."
+            },
+            {
+                "name": "setOverlayMessage",
+                "parameters": [
+                    { "name": "message", "type": "string", "optional": true, "description": "Overlay message to display when paused in debugger." }
+                ],
+                "description": "Sets overlay message."
+            },
+            {
+                "name": "setVariableValue",
+                "parameters": [
+                    { "name": "scopeNumber", "type": "integer", "description": "0-based number of scope as was listed in scope chain. Only 'local', 'closure' and 'catch' scope types are allowed. Other scopes could be manipulated manually." },
+                    { "name": "variableName", "type": "string", "description": "Variable name." },
+                    { "name": "newValue", "$ref": "Runtime.CallArgument", "description": "New variable value." },
+                    { "name": "callFrameId", "$ref": "CallFrameId", "optional": true, "description": "Id of callframe that holds variable." },
+                    { "name": "functionObjectId", "$ref": "Runtime.RemoteObjectId", "optional": true, "description": "Object id of closure (function) that holds variable." }
+                ],
+                "description": "Changes value of variable in a callframe or a closure. Either callframe or function must be specified. Object-based scopes are not supported and must be mutated manually."
+            }
+        ],
+        "events": [
+            {
+                "name": "globalObjectCleared",
+                "description": "Called when global has been cleared and debugger client should reset its state. Happens upon navigation or reload."
+            },
+            {
+                "name": "scriptParsed",
+                "parameters": [
+                    { "name": "scriptId", "$ref": "ScriptId", "description": "Identifier of the script parsed." },
+                    { "name": "url", "type": "string", "description": "URL or name of the script parsed (if any)." },
+                    { "name": "startLine", "type": "integer", "description": "Line offset of the script within the resource with given URL (for script tags)." },
+                    { "name": "startColumn", "type": "integer", "description": "Column offset of the script within the resource with given URL." },
+                    { "name": "endLine", "type": "integer", "description": "Last line of the script." },
+                    { "name": "endColumn", "type": "integer", "description": "Length of the last line of the script." },
+                    { "name": "isContentScript", "type": "boolean", "optional": true, "description": "Determines whether this script is a user extension script." },
+                    { "name": "sourceMapURL", "type": "string", "optional": true, "description": "URL of source map associated with script (if any)." },
+                    { "name": "hasSourceURL", "type": "boolean", "optional": true, "description": "True, if this script has sourceURL." }
+                ],
+                "description": "Fired when virtual machine parses script. This event is also fired for all known and uncollected scripts upon enabling debugger."
+            },
+            {
+                "name": "scriptFailedToParse",
+                "parameters": [
+                    { "name": "url", "type": "string", "description": "URL of the script that failed to parse." },
+                    { "name": "scriptSource", "type": "string", "description": "Source text of the script that failed to parse." },
+                    { "name": "startLine", "type": "integer", "description": "Line offset of the script within the resource." },
+                    { "name": "errorLine", "type": "integer", "description": "Line with error." },
+                    { "name": "errorMessage", "type": "string", "description": "Parse error message." }
+                ],
+                "description": "Fired when virtual machine fails to parse the script."
+            },
+            {
+                "name": "breakpointResolved",
+                "parameters": [
+                    { "name": "breakpointId", "$ref": "BreakpointId", "description": "Breakpoint unique identifier." },
+                    { "name": "location", "$ref": "Location", "description": "Actual breakpoint location." }
+                ],
+                "description": "Fired when breakpoint is resolved to an actual script and location."
+            },
+            {
+                "name": "paused",
+                "parameters": [
+                    { "name": "callFrames", "type": "array", "items": { "$ref": "CallFrame" }, "description": "Call stack the virtual machine stopped on." },
+                    { "name": "reason", "type": "string", "enum": [ "XHR", "DOM", "EventListener", "exception", "assert", "CSPViolation", "other" ], "description": "Pause reason." },
+                    { "name": "data", "type": "object", "optional": true, "description": "Object containing break-specific auxiliary properties." }
+                ],
+                "description": "Fired when the virtual machine stopped on breakpoint or exception or any other stop criteria."
+            },
+            {
+                "name": "resumed",
+                "description": "Fired when the virtual machine resumed execution."
+            }
+        ]
+    },
+    {
+        "domain": "DOMDebugger",
+        "description": "DOM debugging allows setting breakpoints on particular DOM operations and events. JavaScript execution will stop on these operations as if there was a regular breakpoint set.",
+        "types": [
+            {
+                "id": "DOMBreakpointType",
+                "type": "string",
+                "enum": ["subtree-modified", "attribute-modified", "node-removed"],
+                "description": "DOM breakpoint type."
+            }
+        ],
+        "commands": [
+            {
+                "name": "setDOMBreakpoint",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId", "description": "Identifier of the node to set breakpoint on." },
+                    { "name": "type", "$ref": "DOMBreakpointType", "description": "Type of the operation to stop upon." }
+                ],
+                "description": "Sets breakpoint on particular operation with DOM."
+            },
+            {
+                "name": "removeDOMBreakpoint",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId", "description": "Identifier of the node to remove breakpoint from." },
+                    { "name": "type", "$ref": "DOMBreakpointType", "description": "Type of the breakpoint to remove." }
+                ],
+                "description": "Removes DOM breakpoint that was set using <code>setDOMBreakpoint</code>."
+            },
+            {
+                "name": "setEventListenerBreakpoint",
+                "parameters": [
+                    { "name": "eventName", "type": "string", "description": "DOM Event name to stop on (any DOM event will do)." }
+                ],
+                "description": "Sets breakpoint on particular DOM event."
+            },
+            {
+                "name": "removeEventListenerBreakpoint",
+                "parameters": [
+                    { "name": "eventName", "type": "string", "description": "Event name." }
+                ],
+                "description": "Removes breakpoint on particular DOM event."
+            },
+            {
+                "name": "setInstrumentationBreakpoint",
+                "parameters": [
+                    { "name": "eventName", "type": "string", "description": "Instrumentation name to stop on." }
+                ],
+                "description": "Sets breakpoint on particular native event."
+            },
+            {
+                "name": "removeInstrumentationBreakpoint",
+                "parameters": [
+                    { "name": "eventName", "type": "string", "description": "Instrumentation name to stop on." }
+                ],
+                "description": "Sets breakpoint on particular native event."
+            },
+            {
+                "name": "setXHRBreakpoint",
+                "parameters": [
+                    { "name": "url", "type": "string", "description": "Resource URL substring. All XHRs having this substring in the URL will get stopped upon." }
+                ],
+                "description": "Sets breakpoint on XMLHttpRequest."
+            },
+            {
+                "name": "removeXHRBreakpoint",
+                "parameters": [
+                    { "name": "url", "type": "string", "description": "Resource URL substring." }
+                ],
+                "description": "Removes breakpoint from XMLHttpRequest."
+            }
+        ]
+    },
+    {
+        "domain": "Profiler",
+        "types": [
+            {
+                "id": "ProfileHeader",
+                "type": "object",
+                "description": "Profile header.",
+                "properties": [
+                    { "name": "typeId", "type": "string", "enum": ["CPU", "CSS"], "description": "Profile type name." },
+                    { "name": "title", "type": "string", "description": "Profile title." },
+                    { "name": "uid", "type": "integer", "description": "Unique identifier of the profile." }
+                ]
+            },
+            {
+                "id": "CPUProfileNode",
+                "type": "object",
+                "description": "CPU Profile node. Holds callsite information, execution statistics and child nodes.",
+                "properties": [
+                    { "name": "functionName", "type": "string", "description": "Function name." },
+                    { "name": "url", "type": "string", "description": "URL." },
+                    { "name": "lineNumber", "type": "integer", "description": "Line number." },
+                    { "name": "totalTime", "type": "number", "description": "Total execution time." },
+                    { "name": "selfTime", "type": "number", "description": "Self time." },
+                    { "name": "numberOfCalls", "type": "integer", "description": "Number of calls." },
+                    { "name": "callUID", "type": "number", "description": "Call UID." },
+                    { "name": "children", "type": "array", "items": { "$ref": "CPUProfileNode" }, "description": "Child nodes." },
+                    { "name": "id", "optional": true, "type": "integer", "description": "Unique id of the node." }
+                ]
+            },
+            {
+                "id": "CPUProfile",
+                "type": "object",
+                "description": "Profile.",
+                "properties": [
+                    { "name": "head", "$ref": "CPUProfileNode", "optional": true },
+                    { "name": "idleTime", "type": "number", "optional": true }
+                ]
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable"
+            },
+            {
+                "name": "disable"
+            },
+            {
+                "name": "start"
+            },
+            {
+                "name": "stop"
+            },
+            {
+                "name": "getProfileHeaders",
+                "returns": [
+                    { "name": "headers", "type": "array", "items": { "$ref": "ProfileHeader"} }
+                ]
+            },
+            {
+                "name": "getCPUProfile",
+                "parameters": [
+                    { "name": "uid", "type": "integer" }
+                ],
+                "returns": [
+                    { "name": "profile", "$ref": "CPUProfile" }
+                ]
+            },
+            {
+                "name": "removeProfile",
+                "parameters": [
+                    { "name": "type", "type": "string" },
+                    { "name": "uid", "type": "integer" }
+                ]
+            },
+            {
+                "name": "clearProfiles"
+            }
+        ],
+        "events": [
+            {
+                "name": "addProfileHeader",
+                "parameters": [
+                    { "name": "header", "$ref": "ProfileHeader" }
+                ]
+            },
+            {
+                "name": "setRecordingProfile",
+                "parameters": [
+                    { "name": "isProfiling", "type": "boolean" }
+                ]
+            },
+            {
+                "name": "resetProfiles"
+            }
+        ]
+    },
+    {
+        "domain": "LayerTree",
+        "types": [
+            {
+                "id": "LayerId",
+                "type": "string",
+                "description": "Unique RenderLayer identifier."
+            },
+            {
+                "id": "PseudoElementId",
+                "type": "string",
+                "description": "Unique PseudoElement identifier."
+            },
+            {
+                "id": "IntRect",
+                "type": "object",
+                "description": "A rectangle.",
+                "properties": [
+                    { "name": "x", "type": "integer", "description": "The x position." },
+                    { "name": "y", "type": "integer", "description": "The y position." },
+                    { "name": "width", "type": "integer", "description": "The width metric." },
+                    { "name": "height", "type": "integer", "description": "The height metric." }
+                ]
+            },
+            {
+                "id": "Layer",
+                "type": "object",
+                "description": "Information about a compositing layer.",
+                "properties": [
+                    { "name": "layerId", "$ref": "LayerId", "description": "The unique id for this layer." },
+                    { "name": "nodeId", "$ref": "DOM.NodeId", "description": "The id for the node associated with this layer." },
+                    { "name": "bounds", "$ref": "IntRect", "description": "Bounds of the layer in absolute page coordinates." },
+                    { "name": "paintCount", "type": "integer", "description": "Indicates how many time this layer has painted." },
+                    { "name": "memory", "type": "integer", "description": "Estimated memory used by this layer." },
+                    { "name": "compositedBounds", "$ref": "IntRect", "description": "The bounds of the composited layer." },
+                    { "name": "isInShadowTree", "type": "boolean", "optional": true, "description": "Indicates whether this layer is associated with an element hosted in a shadow tree." },
+                    { "name": "isReflection", "type": "boolean", "optional": true, "description": "Indicates whether this layer was used to provide a reflection for the element." },
+                    { "name": "isGeneratedContent", "type": "boolean", "optional": true, "description": "Indicates whether the layer is attached to a pseudo element that is CSS generated content." },
+                    { "name": "isAnonymous", "type": "boolean", "optional": true, "description": "Indicates whether the layer was created for a CSS anonymous block or box." },
+                    { "name": "pseudoElementId", "$ref": "PseudoElementId", "optional": true, "description": "The id for the pseudo element associated with this layer." },
+                    { "name": "pseudoElement", "type": "string", "optional": true, "description": "The name of the CSS pseudo-element that prompted the layer to be generated." }
+                ]
+            },
+            {
+                "id": "CompositingReasons",
+                "type": "object",
+                "description": "An object containing the reasons why the layer was composited as properties.",
+                "properties": [
+                    { "name": "transform3D", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a CSS 3D transform." },
+                    { "name": "video", "type": "boolean", "optional": true, "description": "Composition due to association with a <video> element." },
+                    { "name": "canvas", "type": "boolean", "optional": true, "description": "Composition due to the element being a <canvas> element." },
+                    { "name": "plugin", "type": "boolean", "optional": true, "description": "Composition due to association with a plugin." },
+                    { "name": "iFrame", "type": "boolean", "optional": true, "description": "Composition due to association with an <iframe> element." },
+                    { "name": "backfaceVisibilityHidden", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a \"backface-visibility: hidden\" style." },
+                    { "name": "clipsCompositingDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with an element clipping compositing descendants." },
+                    { "name": "animation", "type": "boolean", "optional": true, "description": "Composition due to association with an animated element." },
+                    { "name": "filters", "type": "boolean", "optional": true, "description": "Composition due to association with an element with CSS filters applied." },
+                    { "name": "positionFixed", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a \"position: fixed\" style." },
+                    { "name": "positionSticky", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a \"position: sticky\" style." },
+                    { "name": "overflowScrollingTouch", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a \"overflow-scrolling: touch\" style." },
+                    { "name": "stacking", "type": "boolean", "optional": true, "description": "Composition due to association with an element establishing a stacking context." },
+                    { "name": "overlap", "type": "boolean", "optional": true, "description": "Composition due to association with an element overlapping other composited elements." },
+                    { "name": "negativeZIndexChildren", "type": "boolean", "optional": true, "description": "Composition due to association with an element with descendants that have a negative z-index." },
+                    { "name": "transformWithCompositedDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with an element with composited descendants." },
+                    { "name": "opacityWithCompositedDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with an element with opacity applied and composited descendants." },
+                    { "name": "maskWithCompositedDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with a masked element and composited descendants." },
+                    { "name": "reflectionWithCompositedDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a reflection and composited descendants." },
+                    { "name": "filterWithCompositedDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with an element with CSS filters applied and composited descendants." },
+                    { "name": "blendingWithCompositedDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with an element with CSS blending applied and composited descendants." },
+                    { "name": "perspective", "type": "boolean", "optional": true, "description": "Composition due to association with an element with perspective applied." },
+                    { "name": "preserve3D", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a \"transform-style: preserve-3d\" style." },
+                    { "name": "root", "type": "boolean", "optional": true, "description": "Composition due to association with the root element." }
+                ]
+            }
+        ],
+        "commands": [
+            {
+                "name": "enable",
+                "description": "Enables compositing tree inspection."
+            },
+            {
+                "name": "disable",
+                "description": "Disables compositing tree inspection."
+            },
+            {
+                "name": "layersForNode",
+                "parameters": [
+                    { "name": "nodeId", "$ref": "DOM.NodeId", "description": "Root of the subtree for which we want to gather layers." }                ],
+                "description": "Returns the layer tree structure of the current page.",
+                "returns": [
+                    { "name": "layers", "type": "array", "items": { "$ref": "Layer" }, "description": "Child layers." }
+                ]
+            },
+            {
+                "name": "reasonsForCompositingLayer",
+                "parameters": [
+                    { "name": "layerId", "$ref": "LayerId", "description": "The id of the layer for which we want to get the reasons it was composited." }
+                ],
+                "description": "Provides the reasons why the given layer was composited.",
+                "returns": [
+                    { "name": "compositingReasons", "$ref": "CompositingReasons", "description": "An object containing the reasons why the layer was composited as properties." }
+                ]
+            }
+        ],
+        "events": [
+            {
+                "name": "layerTreeDidChange"
+            }
+        ]
+    }]
+}

--- a/source/ProtocolGenerator/Inspector-iOS-8.0.json
+++ b/source/ProtocolGenerator/Inspector-iOS-8.0.json
@@ -1,0 +1,3014 @@
+{"domains":[
+{
+    "domain": "Console",
+    "description": "Console domain defines methods and events for interaction with the JavaScript console. Console collects messages created by means of the <a href='http://getfirebug.com/wiki/index.php/Console_API'>JavaScript Console API</a>. One needs to enable this domain using <code>enable</code> command in order to start receiving the console messages. Browser collects messages issued while console domain is not enabled as well and reports them using <code>messageAdded</code> notification upon enabling.",
+    "types": [
+        {
+            "id": "ConsoleNetworkRequestId",
+            "type": "string",
+            "description": "Unique request identifier. FIXME: Duplicate of Network.RequestId <https://webkit.org/b/125664> Web Inspector: FIX Type Dependency Issues"
+        },
+        {
+            "id": "ConsoleDOMNodeId",
+            "type": "integer",
+            "description": "Unique DOM node identifier. FIXME: Duplicate of DOM.NodeId <https://webkit.org/b/125664> Web Inspector: FIX Type Dependency Issues"
+        },
+        {
+            "id": "ConsoleMessage",
+            "type": "object",
+            "description": "Console message.",
+            "properties": [
+                { "name": "source", "type": "string", "enum": ["xml", "javascript", "network", "console-api", "storage", "appcache", "rendering", "css", "security", "other"], "description": "Message source." },
+                { "name": "level", "type": "string", "enum": ["log", "warning", "error", "debug"], "description": "Message severity." },
+                { "name": "text", "type": "string", "description": "Message text." },
+                { "name": "type", "type": "string", "optional": true, "enum": ["log", "dir", "dirxml", "table", "trace", "clear", "startGroup", "startGroupCollapsed", "endGroup", "assert", "timing", "profile", "profileEnd"], "description": "Console message type." },
+                { "name": "url", "type": "string", "optional": true, "description": "URL of the message origin." },
+                { "name": "line", "type": "integer", "optional": true, "description": "Line number in the resource that generated this message." },
+                { "name": "column", "type": "integer", "optional": true, "description": "Column number on the line in the resource that generated this message." },
+                { "name": "repeatCount", "type": "integer", "optional": true, "description": "Repeat count for repeated messages." },
+                { "name": "parameters", "type": "array", "items": { "$ref": "Runtime.RemoteObject" }, "optional": true, "description": "Message parameters in case of the formatted message." },
+                { "name": "stackTrace", "$ref": "StackTrace", "optional": true, "description": "JavaScript stack trace for assertions and error messages." },
+                { "name": "networkRequestId", "$ref": "ConsoleNetworkRequestId", "optional": true, "description": "Identifier of the network request associated with this message." }
+            ]
+        },
+        {
+            "id": "CallFrame",
+            "type": "object",
+            "description": "Stack entry for console errors and assertions.",
+            "properties": [
+                { "name": "functionName", "type": "string", "description": "JavaScript function name." },
+                { "name": "url", "type": "string", "description": "JavaScript script name or url." },
+                { "name": "lineNumber", "type": "integer", "description": "JavaScript script line number." },
+                { "name": "columnNumber", "type": "integer", "description": "JavaScript script column number." }
+            ]
+        },
+        {
+            "id": "StackTrace",
+            "type": "array",
+            "items": { "$ref": "CallFrame" },
+            "description": "Call frames for assertions or error messages."
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables console domain, sends the messages collected so far to the client by means of the <code>messageAdded</code> notification."
+        },
+        {
+            "name": "disable",
+            "description": "Disables console domain, prevents further console messages from being reported to the client."
+        },
+        {
+            "name": "clearMessages",
+            "description": "Clears console messages collected in the browser."
+        },
+        {
+            "name": "setMonitoringXHREnabled",
+            "parameters": [
+                { "name": "enabled", "type": "boolean", "description": "Monitoring enabled state." }
+            ],
+            "description": "Toggles monitoring of XMLHttpRequest. If <code>true</code>, console will receive messages upon each XHR issued."
+        },
+        {
+            "name": "addInspectedNode",
+            "parameters": [
+                { "name": "nodeId", "$ref": "ConsoleDOMNodeId", "description": "DOM node id to be accessible by means of $x command line API." }
+            ],
+            "description": "Enables console to refer to the node with given id via $x (see Command Line API for more details $x functions)."
+        }
+    ],
+    "events": [
+        {
+            "name": "messageAdded",
+            "parameters": [
+                { "name": "message", "$ref": "ConsoleMessage", "description": "Console message that has been added." }
+            ],
+            "description": "Issued when new console message is added."
+        },
+        {
+            "name": "messageRepeatCountUpdated",
+            "parameters": [
+                { "name": "count", "type": "integer", "description": "New repeat count value." }
+            ],
+            "description": "Issued when subsequent message(s) are equal to the previous one(s)."
+        },
+        {
+            "name": "messagesCleared",
+            "description": "Issued when console is cleared. This happens either upon <code>clearMessages</code> command or after page navigation."
+        }
+    ]
+}
+,
+{
+    "domain": "Debugger",
+    "description": "Debugger domain exposes JavaScript debugging capabilities. It allows setting and removing breakpoints, stepping through execution, exploring stack traces, etc.",
+    "types": [
+        {
+            "id": "BreakpointId",
+            "type": "string",
+            "description": "Breakpoint identifier."
+        },
+        {
+            "id": "BreakpointActionIdentifier",
+            "type": "integer",
+            "description": "Breakpoint action identifier."
+        },
+        {
+            "id": "ScriptId",
+            "type": "string",
+            "description": "Unique script identifier."
+        },
+        {
+            "id": "CallFrameId",
+            "type": "string",
+            "description": "Call frame identifier."
+        },
+        {
+            "id": "Location",
+            "type": "object",
+            "properties": [
+                { "name": "scriptId", "$ref": "ScriptId", "description": "Script identifier as reported in the <code>Debugger.scriptParsed</code>." },
+                { "name": "lineNumber", "type": "integer", "description": "Line number in the script." },
+                { "name": "columnNumber", "type": "integer", "optional": true, "description": "Column number in the script." }
+            ],
+            "description": "Location in the source code."
+        },
+        {
+            "id": "BreakpointAction",
+            "type": "object",
+            "properties": [
+                { "name": "type", "type": "string", "enum": ["log", "evaluate", "sound", "probe"], "description": "Different kinds of breakpoint actions." },
+                { "name": "data", "type": "string", "optional": true, "description": "Data associated with this breakpoint type (e.g. for type \"eval\" this is the JavaScript string to evalulate)." },
+                { "name": "id", "$ref": "BreakpointActionIdentifier", "optional": true, "description": "A frontend-assigned identifier for this breakpoint action." }
+            ],
+            "description": "Action to perform when a breakpoint is triggered."
+        },
+        {
+            "id": "BreakpointOptions",
+            "type": "object",
+            "properties": [
+                { "name": "condition", "type": "string", "optional": true, "description": "Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true." },
+                { "name": "actions", "type": "array", "optional": true, "items": { "$ref": "BreakpointAction" }, "description": "Actions to perform automatically when the breakpoint is triggered." },
+                { "name": "autoContinue", "type": "boolean", "optional": true, "description": "Automatically continue after hitting this breakpoint and running actions." }
+            ],
+            "description": "Extra options that modify breakpoint behavior."
+        },
+        {
+            "id": "FunctionDetails",
+            "type": "object",
+            "properties": [
+                { "name": "location", "$ref": "Location", "description": "Location of the function." },
+                { "name": "name", "type": "string", "optional": true, "description": "Name of the function. Not present for anonymous functions." },
+                { "name": "displayName", "type": "string", "optional": true, "description": "Display name of the function(specified in 'displayName' property on the function object)." },
+                { "name": "inferredName", "type": "string", "optional": true, "description": "Name of the function inferred from its initial assignment." },
+                { "name": "scopeChain", "type": "array", "optional": true, "items": { "$ref": "Scope" }, "description": "Scope chain for this closure." }
+            ],
+            "description": "Information about the function."
+        },
+        {
+            "id": "CallFrame",
+            "type": "object",
+            "properties": [
+                { "name": "callFrameId", "$ref": "CallFrameId", "description": "Call frame identifier. This identifier is only valid while the virtual machine is paused." },
+                { "name": "functionName", "type": "string", "description": "Name of the JavaScript function called on this call frame." },
+                { "name": "location", "$ref": "Location", "description": "Location in the source code." },
+                { "name": "scopeChain", "type": "array", "items": { "$ref": "Scope" }, "description": "Scope chain for this call frame." },
+                { "name": "this", "$ref": "Runtime.RemoteObject", "description": "<code>this</code> object for this call frame." }
+            ],
+            "description": "JavaScript call frame. Array of call frames form the call stack."
+        },
+        {
+            "id": "Scope",
+            "type": "object",
+            "properties": [
+                { "name": "type", "type": "string", "enum": ["global", "local", "with", "closure", "catch"], "description": "Scope type." },
+                { "name": "object", "$ref": "Runtime.RemoteObject", "description": "Object representing the scope. For <code>global</code> and <code>with</code> scopes it represents the actual object; for the rest of the scopes, it is artificial transient object enumerating scope variables as its properties." }
+            ],
+            "description": "Scope description."
+        },
+        {
+            "id": "ProbeSample",
+            "description": "A sample collected by evaluating a probe breakpoint action.",
+            "type": "object",
+            "properties": [
+                { "name": "probeId", "$ref": "BreakpointActionIdentifier", "description": "Identifier of the probe breakpoint action that created the sample." },
+                { "name": "sampleId", "type": "integer", "description": "Unique identifier for this sample." },
+                { "name": "batchId", "type": "integer", "description": "A batch identifier which is the same for all samples taken at the same breakpoint hit." },
+                { "name": "timestamp", "type": "number", "description": "Timestamp of when the sample was taken." },
+                { "name": "payload", "$ref": "Runtime.RemoteObject", "description": "Contents of the sample." }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables debugger for the given page. Clients should not assume that the debugging has been enabled until the result for this command is received."
+        },
+        {
+            "name": "disable",
+            "description": "Disables debugger for given page."
+        },
+        {
+            "name": "setBreakpointsActive",
+            "parameters": [
+                { "name": "active", "type": "boolean", "description": "New value for breakpoints active state." }
+            ],
+            "description": "Activates / deactivates all breakpoints on the page."
+        },
+        {
+            "name": "setBreakpointByUrl",
+            "parameters": [
+                { "name": "lineNumber", "type": "integer", "description": "Line number to set breakpoint at." },
+                { "name": "url", "type": "string", "optional": true, "description": "URL of the resources to set breakpoint on." },
+                { "name": "urlRegex", "type": "string", "optional": true, "description": "Regex pattern for the URLs of the resources to set breakpoints on. Either <code>url</code> or <code>urlRegex</code> must be specified." },
+                { "name": "columnNumber", "type": "integer", "optional": true, "description": "Offset in the line to set breakpoint at." },
+                { "name": "options", "$ref": "BreakpointOptions", "optional": true, "description": "Options to apply to this breakpoint to modify its behavior." }
+            ],
+            "returns": [
+                { "name": "breakpointId", "$ref": "BreakpointId", "description": "Id of the created breakpoint for further reference." },
+                { "name": "locations", "type": "array", "items": { "$ref": "Location"}, "description": "List of the locations this breakpoint resolved into upon addition." }
+            ],
+            "description": "Sets JavaScript breakpoint at given location specified either by URL or URL regex. Once this command is issued, all existing parsed scripts will have breakpoints resolved and returned in <code>locations</code> property. Further matching script parsing will result in subsequent <code>breakpointResolved</code> events issued. This logical breakpoint will survive page reloads."
+        },
+        {
+            "name": "setBreakpoint",
+            "parameters": [
+                { "name": "location", "$ref": "Location", "description": "Location to set breakpoint in." },
+                { "name": "options", "$ref": "BreakpointOptions", "optional": true, "description": "Options to apply to this breakpoint to modify its behavior." }
+            ],
+            "returns": [
+                { "name": "breakpointId", "$ref": "BreakpointId", "description": "Id of the created breakpoint for further reference." },
+                { "name": "actualLocation", "$ref": "Location", "description": "Location this breakpoint resolved into." }
+            ],
+            "description": "Sets JavaScript breakpoint at a given location."
+        },
+        {
+            "name": "removeBreakpoint",
+            "parameters": [
+                { "name": "breakpointId", "$ref": "BreakpointId" }
+            ],
+            "description": "Removes JavaScript breakpoint."
+        },
+        {
+            "name": "continueToLocation",
+            "parameters": [
+                { "name": "location", "$ref": "Location", "description": "Location to continue to." }
+            ],
+            "description": "Continues execution until specific location is reached."
+        },
+        {
+            "name": "stepOver",
+            "description": "Steps over the statement."
+        },
+        {
+            "name": "stepInto",
+            "description": "Steps into the function call."
+        },
+        {
+            "name": "stepOut",
+            "description": "Steps out of the function call."
+        },
+        {
+            "name": "pause",
+            "description": "Stops on the next JavaScript statement."
+        },
+        {
+            "name": "resume",
+            "description": "Resumes JavaScript execution."
+        },
+        {
+            "name": "searchInContent",
+            "parameters": [
+                { "name": "scriptId", "$ref": "ScriptId", "description": "Id of the script to search in." },
+                { "name": "query", "type": "string", "description": "String to search for."  },
+                { "name": "caseSensitive", "type": "boolean", "optional": true, "description": "If true, search is case sensitive." },
+                { "name": "isRegex", "type": "boolean", "optional": true, "description": "If true, treats string parameter as regex." }
+            ],
+            "returns": [
+                { "name": "result", "type": "array", "items": { "$ref": "GenericTypes.SearchMatch" }, "description": "List of search matches." }
+            ],
+            "description": "Searches for given string in script content."
+        },
+        {
+            "name": "getScriptSource",
+            "parameters": [
+                { "name": "scriptId", "$ref": "ScriptId", "description": "Id of the script to get source for." }
+            ],
+            "returns": [
+                { "name": "scriptSource", "type": "string", "description": "Script source." }
+            ],
+            "description": "Returns source for the script with given id."
+        },
+        {
+            "name": "getFunctionDetails",
+            "parameters": [
+                { "name": "functionId", "$ref": "Runtime.RemoteObjectId", "description": "Id of the function to get location for." }
+            ],
+            "returns": [
+                { "name": "details", "$ref": "FunctionDetails", "description": "Information about the function." }
+            ],
+            "description": "Returns detailed informtation on given function."
+        },
+        {
+            "name": "setPauseOnExceptions",
+            "parameters": [
+                { "name": "state", "type": "string", "enum": ["none", "uncaught", "all"], "description": "Pause on exceptions mode." }
+            ],
+            "description": "Defines pause on exceptions state. Can be set to stop on all exceptions, uncaught exceptions or no exceptions. Initial pause on exceptions state is <code>none</code>."
+        },
+        {
+            "name": "evaluateOnCallFrame",
+            "parameters": [
+                { "name": "callFrameId", "$ref": "CallFrameId", "description": "Call frame identifier to evaluate on." },
+                { "name": "expression", "type": "string", "description": "Expression to evaluate." },
+                { "name": "objectGroup", "type": "string", "optional": true, "description": "String object group name to put result into (allows rapid releasing resulting object handles using <code>releaseObjectGroup</code>)." },
+                { "name": "includeCommandLineAPI", "type": "boolean", "optional": true, "description": "Specifies whether command line API should be available to the evaluated expression, defaults to false." },
+                { "name": "doNotPauseOnExceptionsAndMuteConsole", "type": "boolean", "optional": true, "description": "Specifies whether evaluation should stop on exceptions and mute console. Overrides setPauseOnException state." },
+                { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object that should be sent by value." },
+                { "name": "generatePreview", "type": "boolean", "optional": true, "description": "Whether preview should be generated for the result." }
+            ],
+            "returns": [
+                { "name": "result", "$ref": "Runtime.RemoteObject", "description": "Object wrapper for the evaluation result." },
+                { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." }
+            ],
+            "description": "Evaluates expression on a given call frame."
+        },
+        {
+            "name": "setOverlayMessage",
+            "parameters": [
+                { "name": "message", "type": "string", "optional": true, "description": "Overlay message to display when paused in debugger." }
+            ],
+            "description": "Sets overlay message."
+        }
+    ],
+    "events": [
+        {
+            "name": "globalObjectCleared",
+            "description": "Called when global has been cleared and debugger client should reset its state. Happens upon navigation or reload."
+        },
+        {
+            "name": "scriptParsed",
+            "parameters": [
+                { "name": "scriptId", "$ref": "ScriptId", "description": "Identifier of the script parsed." },
+                { "name": "url", "type": "string", "description": "URL or name of the script parsed (if any)." },
+                { "name": "startLine", "type": "integer", "description": "Line offset of the script within the resource with given URL (for script tags)." },
+                { "name": "startColumn", "type": "integer", "description": "Column offset of the script within the resource with given URL." },
+                { "name": "endLine", "type": "integer", "description": "Last line of the script." },
+                { "name": "endColumn", "type": "integer", "description": "Length of the last line of the script." },
+                { "name": "isContentScript", "type": "boolean", "optional": true, "description": "Determines whether this script is a user extension script." },
+                { "name": "sourceMapURL", "type": "string", "optional": true, "description": "URL of source map associated with script (if any)." },
+                { "name": "hasSourceURL", "type": "boolean", "optional": true, "description": "True, if this script has sourceURL." }
+            ],
+            "description": "Fired when virtual machine parses script. This event is also fired for all known and uncollected scripts upon enabling debugger."
+        },
+        {
+            "name": "scriptFailedToParse",
+            "parameters": [
+                { "name": "url", "type": "string", "description": "URL of the script that failed to parse." },
+                { "name": "scriptSource", "type": "string", "description": "Source text of the script that failed to parse." },
+                { "name": "startLine", "type": "integer", "description": "Line offset of the script within the resource." },
+                { "name": "errorLine", "type": "integer", "description": "Line with error." },
+                { "name": "errorMessage", "type": "string", "description": "Parse error message." }
+            ],
+            "description": "Fired when virtual machine fails to parse the script."
+        },
+        {
+            "name": "breakpointResolved",
+            "parameters": [
+                { "name": "breakpointId", "$ref": "BreakpointId", "description": "Breakpoint unique identifier." },
+                { "name": "location", "$ref": "Location", "description": "Actual breakpoint location." }
+            ],
+            "description": "Fired when breakpoint is resolved to an actual script and location."
+        },
+        {
+            "name": "paused",
+            "parameters": [
+                { "name": "callFrames", "type": "array", "items": { "$ref": "CallFrame" }, "description": "Call stack the virtual machine stopped on." },
+                { "name": "reason", "type": "string", "enum": [ "XHR", "DOM", "EventListener", "exception", "assert", "CSPViolation", "other" ], "description": "Pause reason." },
+                { "name": "data", "type": "object", "optional": true, "description": "Object containing break-specific auxiliary properties." }
+            ],
+            "description": "Fired when the virtual machine stopped on breakpoint or exception or any other stop criteria."
+        },
+        {
+            "name": "resumed",
+            "description": "Fired when the virtual machine resumed execution."
+        },
+        {
+            "name": "didSampleProbe",
+            "description": "Fires when a new probe sample is collected.",
+            "parameters": [
+                { "name": "sample", "$ref": "ProbeSample", "description": "A collected probe sample." }
+            ]
+        },
+        {
+            "name": "playBreakpointActionSound",
+            "description": "Fired when a \"sound\" breakpoint action is triggered on a breakpoint.",
+            "parameters": [
+                { "name": "breakpointActionId", "$ref": "BreakpointActionIdentifier", "description": "Breakpoint action identifier." }
+            ]
+        }
+    ]
+}
+,
+{
+    "domain": "GenericTypes",
+    "description": "Exposes generic types to be used by any domain.",
+    "types": [
+        {
+            "id": "SearchMatch",
+            "type": "object",
+            "description": "Search match in a resource.",
+            "properties": [
+                { "name": "lineNumber", "type": "number", "description": "Line number in resource content." },
+                { "name": "lineContent", "type": "string", "description": "Line with match content." }
+            ]
+        }
+    ]
+}
+,
+{
+    "domain": "Inspector",
+    "types": [],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables inspector domain notifications."
+        },
+        {
+            "name": "disable",
+            "description": "Disables inspector domain notifications."
+        }
+    ],
+    "events": [
+        {
+            "name": "evaluateForTestInFrontend",
+            "parameters": [
+                { "name": "script", "type": "string" }
+            ]
+        },
+        {
+            "name": "inspect",
+            "parameters": [
+                { "name": "object", "$ref": "Runtime.RemoteObject" },
+                { "name": "hints", "type": "object" }
+            ]
+        },
+        {
+            "name": "detached",
+            "description": "Fired when remote debugging connection is about to be terminated. Contains detach reason.",
+            "parameters": [
+                { "name": "reason", "type": "string", "description": "The reason why connection has been terminated." }
+            ]
+        },
+        {
+            "name": "targetCrashed",
+            "description": "Fired when debugging target has crashed"
+        }
+    ]
+}
+,
+{
+    "domain": "Profiler",
+    "types": [
+        {
+            "id": "ProfileHeader",
+            "type": "object",
+            "description": "Profile header.",
+            "properties": [
+                { "name": "typeId", "type": "string", "enum": ["CPU"], "description": "Profile type name." },
+                { "name": "title", "type": "string", "description": "Profile title." },
+                { "name": "uid", "type": "integer", "description": "Unique identifier of the profile." }
+            ]
+        },
+        {
+            "id": "CPUProfileNodeCall",
+            "type": "object",
+            "description": "CPU Profile call info. Holds time information for a specific call that happened on a node.",
+            "properties": [
+                { "name": "startTime", "type": "number", "description": "Start time for the call." },
+                { "name": "totalTime", "type": "number", "description": "Total execution time for the call." }
+            ]
+        },
+        {
+            "id": "CPUProfileNode",
+            "type": "object",
+            "description": "CPU Profile node. Holds callsite information, execution statistics and child nodes.",
+            "properties": [
+                { "name": "id", "type": "integer", "description": "Unique identifier for this call site." },
+                { "name": "calls", "type": "array", "items": { "$ref": "CPUProfileNodeCall" }, "description": "Calls making up this node." },
+                { "name": "functionName", "type": "string", "optional": true, "description": "Function name." },
+                { "name": "url", "type": "string", "optional": true, "description": "URL." },
+                { "name": "lineNumber", "type": "integer", "optional": true, "description": "Line number." },
+                { "name": "columnNumber", "type": "integer", "optional": true, "description": "Column number." },
+                { "name": "children", "type": "array", "items": { "$ref": "CPUProfileNode" }, "optional": true, "description": "Child nodes." }
+            ]
+        },
+        {
+            "id": "CPUProfile",
+            "type": "object",
+            "description": "Profile.",
+            "properties": [
+                { "name": "rootNodes", "type": "array", "items": { "$ref": "CPUProfileNode" }, "description": "Top level nodes in the stack." },
+                { "name": "idleTime", "type": "number", "optional": true }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable"
+        },
+        {
+            "name": "disable"
+        },
+        {
+            "name": "start"
+        },
+        {
+            "name": "stop"
+        },
+        {
+            "name": "getProfileHeaders",
+            "returns": [
+                { "name": "headers", "type": "array", "items": { "$ref": "ProfileHeader"} }
+            ]
+        },
+        {
+            "name": "getCPUProfile",
+            "parameters": [
+                { "name": "uid", "type": "integer" }
+            ],
+            "returns": [
+                { "name": "profile", "$ref": "CPUProfile" }
+            ]
+        },
+        {
+            "name": "removeProfile",
+            "parameters": [
+                { "name": "type", "type": "string" },
+                { "name": "uid", "type": "integer" }
+            ]
+        },
+        {
+            "name": "clearProfiles"
+        }
+    ],
+    "events": [
+        {
+            "name": "addProfileHeader",
+            "parameters": [
+                { "name": "header", "$ref": "ProfileHeader" }
+            ]
+        },
+        {
+            "name": "setRecordingProfile",
+            "parameters": [
+                { "name": "isProfiling", "type": "boolean" }
+            ]
+        },
+        {
+            "name": "resetProfiles"
+        }
+    ]
+}
+,
+{
+    "domain": "Runtime",
+    "description": "Runtime domain exposes JavaScript runtime by means of remote evaluation and mirror objects. Evaluation results are returned as mirror object that expose object type, string representation and unique identifier that can be used for further object reference. Original objects are maintained in memory unless they are either explicitly released or are released along with the other objects in their object group.",
+    "types": [
+        {
+            "id": "RemoteObjectId",
+            "type": "string",
+            "description": "Unique object identifier."
+        },
+        {
+            "id": "RemoteObject",
+            "type": "object",
+            "description": "Mirror object referencing original JavaScript object.",
+            "properties": [
+                { "name": "type", "type": "string", "enum": ["object", "function", "undefined", "string", "number", "boolean"], "description": "Object type." },
+                { "name": "subtype", "type": "string", "optional": true, "enum": ["array", "null", "node", "regexp", "date"], "description": "Object subtype hint. Specified for <code>object</code> type values only." },
+                { "name": "className", "type": "string", "optional": true, "description": "Object class (constructor) name. Specified for <code>object</code> type values only." },
+                { "name": "value", "type": "any", "optional": true, "description": "Remote object value (in case of primitive values or JSON values if it was requested)." },
+                { "name": "description", "type": "string", "optional": true, "description": "String representation of the object." },
+                { "name": "objectId", "$ref": "RemoteObjectId", "optional": true, "description": "Unique object identifier (for non-primitive values)." },
+                { "name": "preview", "$ref": "ObjectPreview", "optional": true, "description": "Preview containsing abbreviated property values." }
+            ]
+        },
+        {
+            "id": "ObjectPreview",
+            "type": "object",
+            "description": "Object containing abbreviated remote object value.",
+            "properties": [
+                { "name": "lossless", "type": "boolean", "description": "Determines whether preview is lossless (contains all information of the original object)." },
+                { "name": "overflow", "type": "boolean", "description": "True iff some of the properties of the original did not fit." },
+                { "name": "properties", "type": "array", "items": { "$ref": "PropertyPreview" }, "description": "List of the properties." }
+            ]
+        },
+        {
+            "id": "PropertyPreview",
+            "type": "object",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Property name." },
+                { "name": "type", "type": "string", "enum": ["object", "function", "undefined", "string", "number", "boolean"], "description": "Object type." },
+                { "name": "value", "type": "string", "optional": true, "description": "User-friendly property value string." },
+                { "name": "valuePreview", "$ref": "ObjectPreview", "optional": true, "description": "Nested value preview." },
+                { "name": "subtype", "type": "string", "optional": true, "enum": ["array", "null", "node", "regexp", "date"], "description": "Object subtype hint. Specified for <code>object</code> type values only." }
+            ]
+        },
+        {
+            "id": "PropertyDescriptor",
+            "type": "object",
+            "description": "Object property descriptor.",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Property name." },
+                { "name": "value", "$ref": "RemoteObject", "optional": true, "description": "The value associated with the property." },
+                { "name": "writable", "type": "boolean", "optional": true, "description": "True if the value associated with the property may be changed (data descriptors only)." },
+                { "name": "get", "$ref": "RemoteObject", "optional": true, "description": "A function which serves as a getter for the property, or <code>undefined</code> if there is no getter (accessor descriptors only)." },
+                { "name": "set", "$ref": "RemoteObject", "optional": true, "description": "A function which serves as a setter for the property, or <code>undefined</code> if there is no setter (accessor descriptors only)." },
+                { "name": "configurable", "type": "boolean", "description": "True if the type of this property descriptor may be changed and if the property may be deleted from the corresponding object." },
+                { "name": "enumerable", "type": "boolean", "description": "True if this property shows up during enumeration of the properties on the corresponding object." },
+                { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." },
+                { "name": "isOwn", "optional": true, "type": "boolean", "description": "True if the property is owned for the object." }
+            ]
+        },
+        {
+            "id": "InternalPropertyDescriptor",
+            "type": "object",
+            "description": "Object internal property descriptor. This property isn't normally visible in JavaScript code.",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Conventional property name." },
+                { "name": "value", "$ref": "RemoteObject", "optional": true, "description": "The value associated with the property." }
+            ]
+        },
+        {
+            "id": "CallArgument",
+            "type": "object",
+            "description": "Represents function call argument. Either remote object id <code>objectId</code> or primitive <code>value</code> or neither of (for undefined) them should be specified.",
+            "properties": [
+                { "name": "value", "type": "any", "optional": true, "description": "Primitive value." },
+                { "name": "objectId", "$ref": "RemoteObjectId", "optional": true, "description": "Remote object handle." }
+            ]
+        },
+        {
+            "id": "ExecutionContextId",
+            "type": "integer",
+            "description": "Id of an execution context."
+        },
+        {
+            "id": "RuntimeFrameId",
+            "type": "string",
+            "description": "Unique frame identifier. FIXME: Duplicate of Network.FrameId <https://webkit.org/b/125664> Web Inspector: FIX Type Dependency Issues"
+        },
+        {
+            "id": "ExecutionContextDescription",
+            "type": "object",
+            "description": "Description of an isolated world.",
+            "properties": [
+                { "name": "id", "$ref": "ExecutionContextId", "description": "Unique id of the execution context. It can be used to specify in which execution context script evaluation should be performed." },
+                { "name": "isPageContext", "type": "boolean", "description": "True if this is a context where inpspected web page scripts run. False if it is a content script isolated context." },
+                { "name": "name", "type": "string", "description": "Human readable name describing given context."},
+                { "name": "frameId", "$ref": "RuntimeFrameId", "description": "Id of the owning frame." }
+            ]
+        },
+        {
+            "id": "SyntaxErrorType",
+            "type": "string",
+            "enum": ["none", "irrecoverable", "unterminated-literal", "recoverable"],
+            "description": "Syntax error type: \"none\" for no error, \"irrecoverable\" for unrecoverable errors, \"unterminated-literal\" for when there is an unterminated literal, \"recoverable\" for when the expression is unfinished but valid so far."
+        },
+        {
+            "id": "ErrorRange",
+            "type": "object",
+            "description": "Range of an error in source code.",
+            "properties": [
+                { "name": "startOffset", "type": "integer", "description": "Start offset of range (inclusive)." },
+                { "name": "endOffset", "type": "integer", "description": "End offset of range (exclusive)." }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "parse",
+            "parameters": [
+                { "name": "source", "type": "string", "description": "Source code to parse." }
+            ],
+            "returns": [
+                { "name": "result", "$ref": "SyntaxErrorType", "description": "Parse result." },
+                { "name": "message", "type": "string", "optional": true, "description": "Parse error message." },
+                { "name": "range", "$ref": "ErrorRange", "optional": true, "description": "Range in the source where the error occurred." }
+            ],
+            "description": "Parses JavaScript source code for errors."
+        },
+        {
+            "name": "evaluate",
+            "parameters": [
+                { "name": "expression", "type": "string", "description": "Expression to evaluate." },
+                { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." },
+                { "name": "includeCommandLineAPI", "type": "boolean", "optional": true, "description": "Determines whether Command Line API should be available during the evaluation." },
+                { "name": "doNotPauseOnExceptionsAndMuteConsole", "type": "boolean", "optional": true, "description": "Specifies whether evaluation should stop on exceptions and mute console. Overrides setPauseOnException state." },
+                { "name": "contextId", "$ref": "Runtime.ExecutionContextId", "optional": true, "description": "Specifies in which isolated context to perform evaluation. Each content script lives in an isolated context and this parameter may be used to specify one of those contexts. If the parameter is omitted or 0 the evaluation will be performed in the context of the inspected page." },
+                { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object that should be sent by value." },
+                { "name": "generatePreview", "type": "boolean", "optional": true, "description": "Whether preview should be generated for the result." }
+            ],
+            "returns": [
+                { "name": "result", "$ref": "RemoteObject", "description": "Evaluation result." },
+                { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." }
+            ],
+            "description": "Evaluates expression on global object."
+        },
+        {
+            "name": "callFunctionOn",
+            "parameters": [
+                { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to call function on." },
+                { "name": "functionDeclaration", "type": "string", "description": "Declaration of the function to call." },
+                { "name": "arguments", "type": "array", "items": { "$ref": "CallArgument", "description": "Call argument." }, "optional": true, "description": "Call arguments. All call arguments must belong to the same JavaScript world as the target object." },
+                { "name": "doNotPauseOnExceptionsAndMuteConsole", "type": "boolean", "optional": true, "description": "Specifies whether function call should stop on exceptions and mute console. Overrides setPauseOnException state." },
+                { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object which should be sent by value." },
+                { "name": "generatePreview", "type": "boolean", "optional": true, "description": "Whether preview should be generated for the result." }
+            ],
+            "returns": [
+                { "name": "result", "$ref": "RemoteObject", "description": "Call result." },
+                { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." }
+            ],
+            "description": "Calls function with given declaration on the given object. Object group of the result is inherited from the target object."
+        },
+        {
+            "name": "getProperties",
+            "parameters": [
+                { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to return properties for." },
+                { "name": "ownProperties", "optional": true, "type": "boolean", "description": "If true, returns properties belonging only to the element itself, not to its prototype chain." }
+            ],
+            "returns": [
+                { "name": "result", "type": "array", "items": { "$ref": "PropertyDescriptor"}, "description": "Object properties." },
+                { "name": "internalProperties", "optional": true, "type": "array", "items": { "$ref": "InternalPropertyDescriptor"}, "description": "Internal object properties." }
+            ],
+            "description": "Returns properties of a given object. Object group of the result is inherited from the target object."
+        },
+        {
+            "name": "releaseObject",
+            "parameters": [
+                { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to release." }
+            ],
+            "description": "Releases remote object with given id."
+        },
+        {
+            "name": "releaseObjectGroup",
+            "parameters": [
+                { "name": "objectGroup", "type": "string", "description": "Symbolic object group name." }
+            ],
+            "description": "Releases all remote objects that belong to a given group."
+        },
+        {
+            "name": "enable",
+            "description": "Enables reporting of execution contexts creation by means of <code>executionContextCreated</code> event. When the reporting gets enabled the event will be sent immediately for each existing execution context."
+        },
+        {
+            "name": "disable",
+            "description": "Disables reporting of execution contexts creation."
+        }
+    ],
+    "events": [
+        {
+            "name": "executionContextCreated",
+            "parameters": [
+                { "name": "context", "$ref": "ExecutionContextDescription", "description": "A newly created execution contex." }
+            ],
+            "description": "Issued when new execution context is created."
+        }
+    ]
+},
+{
+    "domain": "ApplicationCache",
+    "availability": "web",
+    "types": [
+        {
+            "id": "ApplicationCacheResource",
+            "type": "object",
+            "description": "Detailed application cache resource information.",
+            "properties": [
+                { "name": "url", "type": "string", "description": "Resource url." },
+                { "name": "size", "type": "integer", "description": "Resource size." },
+                { "name": "type", "type": "string", "description": "Resource type." }
+            ]
+        },
+        {
+            "id": "ApplicationCache",
+            "type": "object",
+            "description": "Detailed application cache information.",
+            "properties": [
+                { "name": "manifestURL", "type": "string", "description": "Manifest URL." },
+                { "name": "size", "type": "number", "description": "Application cache size." },
+                { "name": "creationTime", "type": "number", "description": "Application cache creation time." },
+                { "name": "updateTime", "type": "number", "description": "Application cache update time." },
+                { "name": "resources", "type": "array", "items": { "$ref": "ApplicationCacheResource" }, "description": "Application cache resources." }
+            ]
+        },
+        {
+            "id": "FrameWithManifest",
+            "type": "object",
+            "description": "Frame identifier - manifest URL pair.",
+            "properties": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Frame identifier." },
+                { "name": "manifestURL", "type": "string", "description": "Manifest URL." },
+                { "name": "status", "type": "integer", "description": "Application cache status." }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "getFramesWithManifests",
+            "returns": [
+                { "name": "frameIds", "type": "array", "items": { "$ref": "FrameWithManifest" }, "description": "Array of frame identifiers with manifest urls for each frame containing a document associated with some application cache." }
+            ],
+            "description": "Returns array of frame identifiers with manifest urls for each frame containing a document associated with some application cache."
+        },
+        {
+            "name": "enable",
+            "description": "Enables application cache domain notifications."
+        },
+        {
+            "name": "getManifestForFrame",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Identifier of the frame containing document whose manifest is retrieved." }
+            ],
+            "returns": [
+                { "name": "manifestURL", "type": "string", "description": "Manifest URL for document in the given frame." }
+            ],
+            "description": "Returns manifest URL for document in the given frame."
+        },
+        {
+            "name": "getApplicationCacheForFrame",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Identifier of the frame containing document whose application cache is retrieved." }
+            ],
+            "returns": [
+                { "name": "applicationCache", "$ref": "ApplicationCache", "description": "Relevant application cache data for the document in given frame." }
+            ],
+            "description": "Returns relevant application cache data for the document in given frame."
+        }
+    ],
+    "events": [
+        {
+            "name": "applicationCacheStatusUpdated",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Identifier of the frame containing document whose application cache updated status." },
+                { "name": "manifestURL", "type": "string", "description": "Manifest URL." },
+                { "name": "status", "type": "integer", "description": "Updated application cache status." }
+            ]
+        },
+        {
+            "name": "networkStateUpdated",
+            "parameters": [
+                { "name": "isNowOnline", "type": "boolean" }
+            ]
+        }
+    ]
+}
+,
+{
+    "domain": "CSS",
+    "description": "This domain exposes CSS read/write operations. All CSS objects, like stylesheets, rules, and styles, have an associated <code>id</code> used in subsequent operations on the related object. Each object type has a specific <code>id</code> structure, and those are not interchangeable between objects of different kinds. CSS objects can be loaded using the <code>get*ForNode()</code> calls (which accept a DOM node id). Alternatively, a client can discover all the existing stylesheets with the <code>getAllStyleSheets()</code> method and subsequently load the required stylesheet contents using the <code>getStyleSheet[Text]()</code> methods.",
+    "availability": "web",
+    "types": [
+        {
+            "id": "StyleSheetId",
+            "type": "string"
+        },
+        {
+            "id": "CSSStyleId",
+            "type": "object",
+            "properties": [
+                { "name": "styleSheetId", "$ref": "StyleSheetId", "description": "Enclosing stylesheet identifier." },
+                { "name": "ordinal", "type": "integer", "description": "The style ordinal within the stylesheet." }
+            ],
+            "description": "This object identifies a CSS style in a unique way."
+        },
+        {
+            "id": "StyleSheetOrigin",
+            "type": "string",
+            "enum": ["user", "user-agent", "inspector", "regular"],
+            "description": "Stylesheet type: \"user\" for user stylesheets, \"user-agent\" for user-agent stylesheets, \"inspector\" for stylesheets created by the inspector (i.e. those holding the \"via inspector\" rules), \"regular\" for regular stylesheets."
+        },
+        {
+            "id": "CSSRuleId",
+            "type": "object",
+            "properties": [
+                { "name": "styleSheetId", "$ref": "StyleSheetId", "description": "Enclosing stylesheet identifier." },
+                { "name": "ordinal", "type": "integer", "description": "The rule ordinal within the stylesheet." }
+            ],
+            "description": "This object identifies a CSS rule in a unique way."
+        },
+        {
+            "id": "PseudoIdMatches",
+            "type": "object",
+            "properties": [
+                { "name": "pseudoId", "type": "integer", "description": "Pseudo style identifier (see <code>enum PseudoId</code> in <code>RenderStyleConstants.h</code>)."},
+                { "name": "matches", "type": "array", "items": { "$ref": "RuleMatch" }, "description": "Matches of CSS rules applicable to the pseudo style."}
+            ],
+            "description": "CSS rule collection for a single pseudo style."
+        },
+        {
+            "id": "InheritedStyleEntry",
+            "type": "object",
+            "properties": [
+                { "name": "inlineStyle", "$ref": "CSSStyle", "optional": true, "description": "The ancestor node's inline style, if any, in the style inheritance chain." },
+                { "name": "matchedCSSRules", "type": "array", "items": { "$ref": "RuleMatch" }, "description": "Matches of CSS rules matching the ancestor node in the style inheritance chain." }
+            ],
+            "description": "CSS rule collection for a single pseudo style."
+        },
+        {
+            "id": "RuleMatch",
+            "type": "object",
+            "properties": [
+                { "name": "rule", "$ref": "CSSRule", "description": "CSS rule in the match." },
+                { "name": "matchingSelectors", "type": "array", "items": { "type": "integer" }, "description": "Matching selector indices in the rule's selectorList selectors (0-based)." }
+            ],
+            "description": "Match data for a CSS rule."
+        },
+        {
+            "id": "SelectorList",
+            "type": "object",
+            "properties": [
+                { "name": "selectors", "type": "array", "items": { "type": "string" }, "description": "Selectors in the list." },
+                { "name": "text", "type": "string", "description": "Rule selector text." },
+                { "name": "range", "$ref": "SourceRange", "optional": true, "description": "Rule selector range in the underlying resource (if available)." }
+            ],
+            "description": "Selector list data."
+        },
+        {
+            "id": "CSSStyleAttribute",
+            "type": "object",
+            "properties": [
+                { "name": "name", "type": "string", "description": "DOM attribute name (e.g. \"width\")."},
+                { "name": "style", "$ref": "CSSStyle", "description": "CSS style generated by the respective DOM attribute."}
+            ],
+            "description": "CSS style information for a DOM style attribute."
+        },
+        {
+            "id": "CSSStyleSheetHeader",
+            "type": "object",
+            "properties": [
+                { "name": "styleSheetId", "$ref": "StyleSheetId", "description": "The stylesheet identifier."},
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Owner frame identifier."},
+                { "name": "sourceURL", "type": "string", "description": "Stylesheet resource URL."},
+                { "name": "origin", "$ref": "StyleSheetOrigin", "description": "Stylesheet origin."},
+                { "name": "title", "type": "string", "description": "Stylesheet title."},
+                { "name": "disabled", "type": "boolean", "description": "Denotes whether the stylesheet is disabled."}
+            ],
+            "description": "CSS stylesheet metainformation."
+        },
+        {
+            "id": "CSSStyleSheetBody",
+            "type": "object",
+            "properties": [
+                { "name": "styleSheetId", "$ref": "StyleSheetId", "description": "The stylesheet identifier."},
+                { "name": "rules", "type": "array", "items": { "$ref": "CSSRule" }, "description": "Stylesheet resource URL."},
+                { "name": "text", "type": "string", "optional": true, "description": "Stylesheet resource contents (if available)."}
+            ],
+            "description": "CSS stylesheet contents."
+        },
+        {
+            "id": "CSSRule",
+            "type": "object",
+            "properties": [
+                { "name": "ruleId", "$ref": "CSSRuleId", "optional": true, "description": "The CSS rule identifier (absent for user agent stylesheet and user-specified stylesheet rules)."},
+                { "name": "selectorList", "$ref": "SelectorList", "description": "Rule selector data." },
+                { "name": "sourceURL", "type": "string", "optional": true, "description": "Parent stylesheet resource URL (for regular rules)."},
+                { "name": "sourceLine", "type": "integer", "description": "Line ordinal of the rule selector start character in the resource."},
+                { "name": "origin", "$ref": "StyleSheetOrigin", "description": "Parent stylesheet's origin."},
+                { "name": "style", "$ref": "CSSStyle", "description": "Associated style declaration." },
+                { "name": "media", "type": "array", "items": { "$ref": "CSSMedia" }, "optional": true, "description": "Media list array (for rules involving media queries). The array enumerates media queries starting with the innermost one, going outwards." }
+            ],
+            "description": "CSS rule representation."
+        },
+        {
+            "id": "SourceRange",
+            "type": "object",
+            "properties": [
+                { "name": "startLine", "type": "integer", "description": "Start line of range." },
+                { "name": "startColumn", "type": "integer", "description": "Start column of range (inclusive)." },
+                { "name": "endLine", "type": "integer", "description": "End line of range" },
+                { "name": "endColumn", "type": "integer", "description": "End column of range (exclusive)." }
+            ],
+            "description": "Text range within a resource."
+        },
+        {
+            "id": "ShorthandEntry",
+            "type": "object",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Shorthand name." },
+                { "name": "value", "type": "string", "description": "Shorthand value." }
+            ]
+        },
+        {
+            "id": "CSSPropertyInfo",
+            "type": "object",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Property name." },
+                { "name": "longhands", "type": "array", "optional": true, "items": { "type": "string" }, "description": "Longhand property names." }
+            ]
+        },
+        {
+            "id": "CSSComputedStyleProperty",
+            "type": "object",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Computed style property name." },
+                { "name": "value", "type": "string", "description": "Computed style property value." }
+            ]
+        },
+        {
+            "id": "CSSStyle",
+            "type": "object",
+            "properties": [
+                { "name": "styleId", "$ref": "CSSStyleId", "optional": true, "description": "The CSS style identifier (absent for attribute styles)." },
+                { "name": "cssProperties", "type": "array", "items": { "$ref": "CSSProperty" }, "description": "CSS properties in the style." },
+                { "name": "shorthandEntries", "type": "array", "items": { "$ref": "ShorthandEntry" }, "description": "Computed values for all shorthands found in the style." },
+                { "name": "cssText", "type": "string", "optional": true, "description": "Style declaration text (if available)." },
+                { "name": "range", "$ref": "SourceRange", "optional": true, "description": "Style declaration range in the enclosing stylesheet (if available)." },
+                { "name": "width", "type": "string", "optional": true, "description": "The effective \"width\" property value from this style." },
+                { "name": "height", "type": "string", "optional": true, "description": "The effective \"height\" property value from this style." }
+            ],
+            "description": "CSS style representation."
+        },
+        {
+            "id": "CSSProperty",
+            "type": "object",
+            "properties": [
+                { "name": "name", "type": "string", "description": "The property name." },
+                { "name": "value", "type": "string", "description": "The property value." },
+                { "name": "priority", "type": "string", "optional": true, "description": "The property priority (implies \"\" if absent)." },
+                { "name": "implicit", "type": "boolean", "optional": true, "description": "Whether the property is implicit (implies <code>false</code> if absent)." },
+                { "name": "text", "type": "string", "optional": true, "description": "The full property text as specified in the style." },
+                { "name": "parsedOk", "type": "boolean", "optional": true, "description": "Whether the property is understood by the browser (implies <code>true</code> if absent)." },
+                { "name": "status", "type": "string", "enum": ["active", "inactive", "disabled", "style"], "optional": true, "description": "The property status: \"active\" if the property is effective in the style, \"inactive\" if the property is overridden by a same-named property in this style later on, \"disabled\" if the property is disabled by the user, \"style\" (implied if absent) if the property is reported by the browser rather than by the CSS source parser." },
+                { "name": "range", "$ref": "SourceRange", "optional": true, "description": "The entire property range in the enclosing style declaration (if available)." }
+            ],
+            "description": "CSS style effective visual dimensions and source offsets."
+        },
+        {
+            "id": "CSSMedia",
+            "type": "object",
+            "properties": [
+                { "name": "text", "type": "string", "description": "Media query text." },
+                { "name": "source", "type": "string", "enum": ["mediaRule", "importRule", "linkedSheet", "inlineSheet"], "description": "Source of the media query: \"mediaRule\" if specified by a @media rule, \"importRule\" if specified by an @import rule, \"linkedSheet\" if specified by a \"media\" attribute in a linked stylesheet's LINK tag, \"inlineSheet\" if specified by a \"media\" attribute in an inline stylesheet's STYLE tag." },
+                { "name": "sourceURL", "type": "string", "optional": true, "description": "URL of the document containing the media query description." },
+                { "name": "sourceLine", "type": "integer", "optional": true, "description": "Line in the document containing the media query (not defined for the \"stylesheet\" source)." }
+            ],
+            "description": "CSS media query descriptor."
+        },
+        {
+            "id": "Region",
+            "type": "object",
+            "properties": [
+                { "name": "regionOverset", "type": "string", "enum": ["overset", "fit", "empty"], "description": "The \"overset\" attribute of a Named Flow." },
+                { "name": "nodeId", "$ref": "DOM.NodeId", "description": "The corresponding DOM node id." }
+            ],
+            "description": "This object represents a region that flows from a Named Flow."
+        },
+        {
+            "id": "NamedFlow",
+            "type": "object",
+            "properties": [
+                { "name": "documentNodeId", "$ref": "DOM.NodeId", "description": "The document node id." },
+                { "name": "name", "type": "string", "description": "Named Flow identifier." },
+                { "name": "overset", "type": "boolean", "description": "The \"overset\" attribute of a Named Flow." },
+                { "name": "content", "type": "array", "items": { "$ref": "DOM.NodeId" }, "description": "An array of nodes that flow into the Named Flow." },
+                { "name": "regions", "type": "array", "items": { "$ref": "Region" }, "description": "An array of regions associated with the Named Flow." }
+            ],
+            "description": "This object represents a Named Flow."
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables the CSS agent for the given page. Clients should not assume that the CSS agent has been enabled until the result of this command is received."
+        },
+        {
+            "name": "disable",
+            "description": "Disables the CSS agent for the given page."
+        },
+        {
+            "name": "getMatchedStylesForNode",
+            "parameters": [
+                { "name": "nodeId", "$ref": "DOM.NodeId" },
+                { "name": "includePseudo", "type": "boolean", "optional": true, "description": "Whether to include pseudo styles (default: true)." },
+                { "name": "includeInherited", "type": "boolean", "optional": true, "description": "Whether to include inherited styles (default: true)." }
+            ],
+            "returns": [
+                { "name": "matchedCSSRules", "type": "array", "items": { "$ref": "RuleMatch" }, "optional": true, "description": "CSS rules matching this node, from all applicable stylesheets." },
+                { "name": "pseudoElements", "type": "array", "items": { "$ref": "PseudoIdMatches" }, "optional": true, "description": "Pseudo style matches for this node." },
+                { "name": "inherited", "type": "array", "items": { "$ref": "InheritedStyleEntry" }, "optional": true, "description": "A chain of inherited styles (from the immediate node parent up to the DOM tree root)." }
+            ],
+            "description": "Returns requested styles for a DOM node identified by <code>nodeId</code>."
+        },
+        {
+            "name": "getInlineStylesForNode",
+            "parameters": [
+                { "name": "nodeId", "$ref": "DOM.NodeId" }
+            ],
+            "returns": [
+                { "name": "inlineStyle", "$ref": "CSSStyle", "optional": true, "description": "Inline style for the specified DOM node." },
+                { "name": "attributesStyle", "$ref": "CSSStyle", "optional": true, "description": "Attribute-defined element style (e.g. resulting from \"width=20 height=100%\")."}
+            ],
+            "description": "Returns the styles defined inline (explicitly in the \"style\" attribute and implicitly, using DOM attributes) for a DOM node identified by <code>nodeId</code>."
+        },
+        {
+            "name": "getComputedStyleForNode",
+            "parameters": [
+                { "name": "nodeId", "$ref": "DOM.NodeId" }
+            ],
+            "returns": [
+                { "name": "computedStyle", "type": "array", "items": { "$ref": "CSSComputedStyleProperty" }, "description": "Computed style for the specified DOM node." }
+            ],
+            "description": "Returns the computed style for a DOM node identified by <code>nodeId</code>."
+        },
+        {
+            "name": "getAllStyleSheets",
+            "returns": [
+                { "name": "headers", "type": "array", "items": { "$ref": "CSSStyleSheetHeader" }, "description": "Descriptor entries for all available stylesheets." }
+            ],
+            "description": "Returns metainfo entries for all known stylesheets."
+        },
+        {
+            "name": "getStyleSheet",
+            "parameters": [
+                { "name": "styleSheetId", "$ref": "StyleSheetId" }
+            ],
+            "returns": [
+                { "name": "styleSheet", "$ref": "CSSStyleSheetBody", "description": "Stylesheet contents for the specified <code>styleSheetId</code>." }
+            ],
+            "description": "Returns stylesheet data for the specified <code>styleSheetId</code>."
+        },
+        {
+            "name": "getStyleSheetText",
+            "parameters": [
+                { "name": "styleSheetId", "$ref": "StyleSheetId" }
+            ],
+            "returns": [
+                { "name": "text", "type": "string", "description": "The stylesheet text." }
+            ],
+            "description": "Returns the current textual content and the URL for a stylesheet."
+        },
+        {
+            "name": "setStyleSheetText",
+            "parameters": [
+                { "name": "styleSheetId", "$ref": "StyleSheetId" },
+                { "name": "text", "type": "string" }
+            ],
+            "description": "Sets the new stylesheet text, thereby invalidating all existing <code>CSSStyleId</code>'s and <code>CSSRuleId</code>'s contained by this stylesheet."
+        },
+        {
+            "name": "setStyleText",
+            "parameters": [
+                { "name": "styleId", "$ref": "CSSStyleId" },
+                { "name": "text", "type": "string" }
+            ],
+            "returns": [
+                { "name": "style", "$ref": "CSSStyle", "description": "The resulting style after the text modification." }
+            ],
+            "description": "Sets the new <code>text</code> for the respective style."
+        },
+        {
+            "name": "setRuleSelector",
+            "parameters": [
+                { "name": "ruleId", "$ref": "CSSRuleId" },
+                { "name": "selector", "type": "string" }
+            ],
+            "returns": [
+                { "name": "rule", "$ref": "CSSRule", "description": "The resulting rule after the selector modification." }
+            ],
+            "description": "Modifies the rule selector."
+        },
+        {
+            "name": "addRule",
+            "parameters": [
+                { "name": "contextNodeId", "$ref": "DOM.NodeId" },
+                { "name": "selector", "type": "string" }
+            ],
+            "returns": [
+                { "name": "rule", "$ref": "CSSRule", "description": "The newly created rule." }
+            ],
+            "description": "Creates a new empty rule with the given <code>selector</code> in a special \"inspector\" stylesheet in the owner document of the context node."
+        },
+        {
+            "name": "getSupportedCSSProperties",
+            "returns": [
+                { "name": "cssProperties", "type": "array", "items": { "$ref": "CSSPropertyInfo" }, "description": "Supported property metainfo." }
+            ],
+            "description": "Returns all supported CSS property names."
+        },
+        {
+            "name": "forcePseudoState",
+            "parameters": [
+                { "name": "nodeId", "$ref": "DOM.NodeId", "description": "The element id for which to force the pseudo state." },
+                { "name": "forcedPseudoClasses", "type": "array", "items": { "type": "string", "enum": ["active", "focus", "hover", "visited"] }, "description": "Element pseudo classes to force when computing the element's style." }
+            ],
+            "description": "Ensures that the given node will have specified pseudo-classes whenever its style is computed by the browser."
+        },
+        {
+            "name": "getNamedFlowCollection",
+            "parameters": [
+                { "name": "documentNodeId", "$ref": "DOM.NodeId", "description": "The document node id for which to get the Named Flow Collection." }
+            ],
+            "returns": [
+                { "name": "namedFlows", "type": "array", "items": { "$ref": "NamedFlow" }, "description": "An array containing the Named Flows in the document." }
+            ],
+            "description": "Returns the Named Flows from the document."
+        }
+    ],
+    "events": [
+        {
+            "name": "mediaQueryResultChanged",
+            "description": "Fires whenever a MediaQuery result changes (for example, after a browser window has been resized.) The current implementation considers only viewport-dependent media features."
+        },
+        {
+            "name": "styleSheetChanged",
+            "parameters": [
+                { "name": "styleSheetId", "$ref": "StyleSheetId" }
+            ],
+            "description": "Fired whenever a stylesheet is changed as a result of the client operation."
+        },
+        {
+            "name": "namedFlowCreated",
+            "parameters": [
+                { "name": "namedFlow", "$ref": "NamedFlow", "description": "The new Named Flow." }
+            ],
+            "description": "Fires when a Named Flow is created."
+        },
+        {
+            "name": "namedFlowRemoved",
+            "parameters": [
+                { "name": "documentNodeId", "$ref": "DOM.NodeId", "description": "The document node id." },
+                { "name": "flowName", "type": "string", "description": "Identifier of the removed Named Flow." }
+            ],
+            "description": "Fires when a Named Flow is removed: has no associated content nodes and regions."
+        },
+        {
+            "name": "regionOversetChanged",
+            "parameters": [
+                { "name": "namedFlow", "$ref": "NamedFlow", "description": "The Named Flow containing the regions whose regionOverset values changed." }
+            ],
+            "description": "Fires if any of the regionOverset values changed in a Named Flow's region chain."
+        },
+        {
+            "name": "registeredNamedFlowContentElement",
+            "parameters": [
+                { "name": "documentNodeId", "$ref": "DOM.NodeId", "description": "The document node id." },
+                { "name": "flowName", "type": "string", "description": "Named Flow identifier for which the new content element was registered." },
+                { "name": "contentNodeId", "$ref": "DOM.NodeId", "description": "The node id of the registered content node." },
+                { "name": "nextContentNodeId", "$ref": "DOM.NodeId", "description": "The node id of the element following the registered content node." }
+            ],
+            "description": "Fires when a Named Flow's has been registered with a new content node."
+        },
+        {
+            "name": "unregisteredNamedFlowContentElement",
+            "parameters": [
+                { "name": "documentNodeId", "$ref": "DOM.NodeId", "description": "The document node id." },
+                { "name": "flowName", "type": "string", "description": "Named Flow identifier for which the new content element was unregistered." },
+                { "name": "contentNodeId", "$ref": "DOM.NodeId", "description": "The node id of the unregistered content node." }
+            ],
+            "description": "Fires when a Named Flow's has been registered with a new content node."
+        }
+    ]
+}
+,
+{
+    "domain": "DOM",
+    "description": "This domain exposes DOM read/write operations. Each DOM Node is represented with its mirror object that has an <code>id</code>. This <code>id</code> can be used to get additional information on the Node, resolve it into the JavaScript object wrapper, etc. It is important that client receives DOM events only for the nodes that are known to the client. Backend keeps track of the nodes that were sent to the client and never sends the same node twice. It is client's responsibility to collect information about the nodes that were sent to the client.<p>Note that <code>iframe</code> owner elements will return corresponding document elements as their child nodes.</p>",
+    "availability": "web",
+    "types": [
+        {
+            "id": "NodeId",
+            "type": "integer",
+            "description": "Unique DOM node identifier."
+        },
+        {
+            "id": "BackendNodeId",
+            "type": "integer",
+            "description": "Unique DOM node identifier used to reference a node that may not have been pushed to the front-end."
+        },
+        {
+            "id": "LiveRegionRelevant",
+            "type": "string",
+            "enum": ["additions", "removals", "text"],
+            "description": "Token values of @aria-relevant attribute."
+        },
+        {
+            "id": "Node",
+            "type": "object",
+            "properties": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Node identifier that is passed into the rest of the DOM messages as the <code>nodeId</code>. Backend will only push node with given <code>id</code> once. It is aware of all requested nodes and will only fire DOM events for nodes known to the client." },
+                { "name": "nodeType", "type": "integer", "description": "<code>Node</code>'s nodeType." },
+                { "name": "nodeName", "type": "string", "description": "<code>Node</code>'s nodeName." },
+                { "name": "localName", "type": "string", "description": "<code>Node</code>'s localName." },
+                { "name": "nodeValue", "type": "string", "description": "<code>Node</code>'s nodeValue." },
+                { "name": "childNodeCount", "type": "integer", "optional": true, "description": "Child count for <code>Container</code> nodes." },
+                { "name": "children", "type": "array", "optional": true, "items": { "$ref": "Node" }, "description": "Child nodes of this node when requested with children." },
+                { "name": "attributes", "type": "array", "optional": true, "items": { "type": "string" }, "description": "Attributes of the <code>Element</code> node in the form of flat array <code>[name1, value1, name2, value2]</code>." },
+                { "name": "documentURL", "type": "string", "optional": true, "description": "Document URL that <code>Document</code> or <code>FrameOwner</code> node points to." },
+                { "name": "baseURL", "type": "string", "optional": true, "description": "Base URL that <code>Document</code> or <code>FrameOwner</code> node uses for URL completion." },
+                { "name": "publicId", "type": "string", "optional": true, "description": "<code>DocumentType</code>'s publicId." },
+                { "name": "systemId", "type": "string", "optional": true, "description": "<code>DocumentType</code>'s systemId." },
+                { "name": "internalSubset", "type": "string", "optional": true, "description": "<code>DocumentType</code>'s internalSubset." },
+                { "name": "xmlVersion", "type": "string", "optional": true, "description": "<code>Document</code>'s XML version in case of XML documents." },
+                { "name": "name", "type": "string", "optional": true, "description": "<code>Attr</code>'s name." },
+                { "name": "value", "type": "string", "optional": true, "description": "<code>Attr</code>'s value." },
+                { "name": "frameId", "$ref": "Network.FrameId", "optional": true, "description": "Frame ID for frame owner elements." },
+                { "name": "contentDocument", "$ref": "Node", "optional": true, "description": "Content document for frame owner elements." },
+                { "name": "shadowRoots", "type": "array", "optional": true, "items": { "$ref": "Node" }, "description": "Shadow root list for given element host." },
+                { "name": "templateContent", "$ref": "Node", "optional": true, "description": "Content document fragment for template elements" },
+                { "name": "role", "type": "string", "optional": true, "description": "Computed value for first recognized role token, default role per element, or overridden role." }
+            ],
+            "description": "DOM interaction is implemented in terms of mirror objects that represent the actual DOM nodes. DOMNode is a base node mirror type."
+        },
+        {
+            "id": "EventListener",
+            "type": "object",
+            "properties": [
+                { "name": "type", "type": "string", "description": "<code>EventListener</code>'s type." },
+                { "name": "useCapture", "type": "boolean", "description": "<code>EventListener</code>'s useCapture." },
+                { "name": "isAttribute", "type": "boolean", "description": "<code>EventListener</code>'s isAttribute." },
+                { "name": "nodeId", "$ref": "NodeId", "description": "Target <code>DOMNode</code> id." },
+                { "name": "handlerBody", "type": "string", "description": "Event handler function body." },
+                { "name": "location", "$ref": "Debugger.Location", "optional": true, "description": "Handler code location." },
+                { "name": "sourceName", "type": "string", "optional": true, "description": "Source script URL." },
+                { "name": "handler", "$ref": "Runtime.RemoteObject", "optional": true, "description": "Event handler function value." }
+            ],
+            "description": "A structure holding event listener properties."
+        },
+        {
+            "id": "AccessibilityProperties",
+            "description": "A structure holding accessibility properties.",
+            "type": "object",
+            "properties": [
+                { "name": "activeDescendantNodeId", "$ref": "NodeId", "optional": true, "description": "<code>DOMNode</code> id of the accessibility object referenced by aria-activedescendant." },
+                { "name": "busy", "type": "boolean", "optional": true, "description": "Value of @aria-busy on current or ancestor node." },
+                { "name": "checked", "type": "string", "optional": true, "enum": ["true", "false", "mixed"], "description": "Checked state of certain form controls." },
+                { "name": "childNodeIds", "type": "array", "items": { "$ref": "NodeId" }, "optional": true, "description": "Array of <code>DOMNode</code> ids of the accessibility tree children if available." },
+                { "name": "controlledNodeIds", "type": "array", "items": { "$ref": "NodeId" }, "optional": true, "description": "Array of <code>DOMNode</code> ids of any nodes referenced via @aria-controls." },
+                { "name": "disabled", "type": "boolean", "optional": true, "description": "Disabled state of form controls." },
+                { "name": "exists", "type": "boolean", "description": "Indicates whether there is an existing AX object for the DOM node. If this is false, all the other properties will be default values." },
+                { "name": "expanded", "type": "boolean", "optional": true, "description": "Expanded state." },
+                { "name": "flowedNodeIds", "type": "array", "items": { "$ref": "NodeId" }, "optional": true, "description": "Array of <code>DOMNode</code> ids of any nodes referenced via @aria-flowto." },
+                { "name": "focused", "type": "boolean", "optional": true, "description": "Focused state. Only defined on focusable elements." },
+                { "name": "ignored", "type": "boolean", "optional": true, "description": "Indicates whether the accessibility of the associated AX object node is ignored, whether heuristically or explicitly." },
+                { "name": "ignoredByDefault", "type": "boolean", "optional": true, "description": "State indicating whether the accessibility of the associated AX object node is ignored by default for node type." },
+                { "name": "invalid", "type": "string", "optional": true, "enum": ["true", "false", "grammar", "spelling"], "description": "Invalid status of form controls." },
+                { "name": "hidden", "type": "boolean", "optional": true, "description": "Hidden state. True if node or an ancestor is hidden via CSS or explicit @aria-hidden, to clarify why the element is ignored." },
+                { "name": "label", "type": "string", "description": "Computed label value for the node, sometimes calculated by referencing other nodes." },
+                { "name": "liveRegionAtomic", "type": "boolean", "optional": true, "description": "Value of @aria-atomic." },
+                { "name": "liveRegionRelevant", "type": "array", "items": { "type": "string" }, "optional": true, "description": "Token value(s) of element's @aria-relevant attribute. Array of string values matching $ref LiveRegionRelevant. FIXME: Enum values blocked by http://webkit.org/b/133711" },
+                { "name": "liveRegionStatus", "type": "string", "optional": true, "enum": ["assertive", "polite", "off"], "description": "Value of element's @aria-live attribute." },
+                { "name": "mouseEventNodeId", "$ref": "NodeId", "optional": true, "description": "<code>DOMNode</code> id of node or closest ancestor node that has a mousedown, mouseup, or click event handler." },
+                { "name": "nodeId", "$ref": "NodeId", "description": "Target <code>DOMNode</code> id." },
+                { "name": "ownedNodeIds", "type": "array", "items": { "$ref": "NodeId" }, "optional": true, "description": "Array of <code>DOMNode</code> ids of any nodes referenced via @aria-owns." },
+                { "name": "parentNodeId", "$ref": "NodeId", "optional": true, "description": "<code>DOMNode</code> id of the accessibility tree parent object if available." },
+                { "name": "pressed", "type": "boolean", "optional": true, "description": "Pressed state for toggle buttons." },
+                { "name": "readonly", "type": "boolean", "optional": true, "description": "Readonly state of text controls." },
+                { "name": "required", "type": "boolean", "optional": true, "description": "Required state of form controls." },
+                { "name": "role", "type": "string", "description": "Computed value for first recognized role token, default role per element, or overridden role." },
+                { "name": "selected", "type": "boolean", "optional": true, "description": "Selected state of certain form controls." },
+                { "name": "selectedChildNodeIds", "type": "array", "items": { "$ref": "NodeId" }, "optional": true, "description": "Array of <code>DOMNode</code> ids of any children marked as selected." }
+            ]
+        },
+        {
+            "id": "RGBA",
+            "type": "object",
+            "properties": [
+                { "name": "r", "type": "integer", "description": "The red component, in the [0-255] range." },
+                { "name": "g", "type": "integer", "description": "The green component, in the [0-255] range." },
+                { "name": "b", "type": "integer", "description": "The blue component, in the [0-255] range." },
+                { "name": "a", "type": "number", "optional": true, "description": "The alpha component, in the [0-1] range (default: 1)." }
+            ],
+            "description": "A structure holding an RGBA color."
+        },
+        {
+            "id": "Quad",
+            "type": "array",
+            "items": { "type": "number" },
+            "minItems": 8,
+            "maxItems": 8,
+            "description": "An array of quad vertices, x immediately followed by y for each point, points clock-wise."
+        },
+        {
+            "id": "HighlightConfig",
+            "type": "object",
+            "properties": [
+                { "name": "showInfo", "type": "boolean", "optional": true, "description": "Whether the node info tooltip should be shown (default: false)." },
+                { "name": "contentColor", "$ref": "RGBA", "optional": true, "description": "The content box highlight fill color (default: transparent)." },
+                { "name": "paddingColor", "$ref": "RGBA", "optional": true, "description": "The padding highlight fill color (default: transparent)." },
+                { "name": "borderColor", "$ref": "RGBA", "optional": true, "description": "The border highlight fill color (default: transparent)." },
+                { "name": "marginColor", "$ref": "RGBA", "optional": true, "description": "The margin highlight fill color (default: transparent)." }
+            ],
+            "description": "Configuration data for the highlighting of page elements."
+        }
+    ],
+    "commands": [
+        {
+            "name": "getDocument",
+            "returns": [
+                { "name": "root", "$ref": "Node", "description": "Resulting node." }
+            ],
+            "description": "Returns the root DOM node to the caller."
+        },
+        {
+            "name": "requestChildNodes",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to get children for." },
+                { "name": "depth", "type": "integer", "optional": true, "description": "The maximum depth at which children should be retrieved, defaults to 1. Use -1 for the entire subtree or provide an integer larger than 0." }
+            ],
+            "description": "Requests that children of the node with given id are returned to the caller in form of <code>setChildNodes</code> events where not only immediate children are retrieved, but all children down to the specified depth."
+        },
+        {
+            "name": "querySelector",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to query upon." },
+                { "name": "selector", "type": "string", "description": "Selector string." }
+            ],
+            "returns": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Query selector result." }
+            ],
+            "description": "Executes <code>querySelector</code> on a given node."
+        },
+        {
+            "name": "querySelectorAll",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to query upon." },
+                { "name": "selector", "type": "string", "description": "Selector string." }
+            ],
+            "returns": [
+                { "name": "nodeIds", "type": "array", "items": { "$ref": "NodeId" }, "description": "Query selector result." }
+            ],
+            "description": "Executes <code>querySelectorAll</code> on a given node."
+        },
+        {
+            "name": "setNodeName",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to set name for." },
+                { "name": "name", "type": "string", "description": "New node's name." }
+            ],
+            "returns": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "New node's id." }
+            ],
+            "description": "Sets node name for a node with given id."
+        },
+        {
+            "name": "setNodeValue",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to set value for." },
+                { "name": "value", "type": "string", "description": "New node's value." }
+            ],
+            "description": "Sets node value for a node with given id."
+        },
+        {
+            "name": "removeNode",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to remove." }
+            ],
+            "description": "Removes node with given id."
+        },
+        {
+            "name": "setAttributeValue",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the element to set attribute for." },
+                { "name": "name", "type": "string", "description": "Attribute name." },
+                { "name": "value", "type": "string", "description": "Attribute value." }
+            ],
+            "description": "Sets attribute for an element with given id."
+        },
+        {
+            "name": "setAttributesAsText",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the element to set attributes for." },
+                { "name": "text", "type": "string", "description": "Text with a number of attributes. Will parse this text using HTML parser." },
+                { "name": "name", "type": "string", "optional": true, "description": "Attribute name to replace with new attributes derived from text in case text parsed successfully." }
+            ],
+            "description": "Sets attributes on element with given id. This method is useful when user edits some existing attribute value and types in several attribute name/value pairs."
+        },
+        {
+            "name": "removeAttribute",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the element to remove attribute from." },
+                { "name": "name", "type": "string", "description": "Name of the attribute to remove." }
+            ],
+            "description": "Removes attribute with given name from an element with given id."
+        },
+        {
+            "name": "getEventListenersForNode",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to get listeners for." },
+                { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name for handler value. Handler value is not returned without this parameter specified." }
+            ],
+            "returns": [
+                { "name": "listeners", "type": "array", "items": { "$ref": "EventListener"}, "description": "Array of relevant listeners." }
+            ],
+            "description": "Returns event listeners relevant to the node."
+        },
+        {
+            "name": "getAccessibilityPropertiesForNode",
+            "description": "Returns a dictionary of accessibility properties for the node.",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node for which to get accessibility properties." }
+            ],
+            "returns": [
+                { "name": "properties", "$ref": "AccessibilityProperties", "description": "Dictionary of relevant accessibility properties." }
+            ]
+        },
+        {
+            "name": "getOuterHTML",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to get markup for." }
+            ],
+            "returns": [
+                { "name": "outerHTML", "type": "string", "description": "Outer HTML markup." }
+            ],
+            "description": "Returns node's HTML markup."
+        },
+        {
+            "name": "setOuterHTML",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to set markup for." },
+                { "name": "outerHTML", "type": "string", "description": "Outer HTML markup to set." }
+            ],
+            "description": "Sets node HTML markup, returns new node id."
+        },
+        {
+            "name": "performSearch",
+            "parameters": [
+                { "name": "query", "type": "string", "description": "Plain text or query selector or XPath search query." },
+                { "name": "nodeIds", "type": "array", "items": { "$ref": "NodeId" }, "optional": true, "description": "Ids of nodes to use as starting points for the search." }
+            ],
+            "returns": [
+                { "name": "searchId", "type": "string", "description": "Unique search session identifier." },
+                { "name": "resultCount", "type": "integer", "description": "Number of search results." }
+            ],
+            "description": "Searches for a given string in the DOM tree. Use <code>getSearchResults</code> to access search results or <code>cancelSearch</code> to end this search session."
+        },
+        {
+            "name": "getSearchResults",
+            "parameters": [
+                { "name": "searchId", "type": "string", "description": "Unique search session identifier." },
+                { "name": "fromIndex", "type": "integer", "description": "Start index of the search result to be returned." },
+                { "name": "toIndex", "type": "integer", "description": "End index of the search result to be returned." }
+            ],
+            "returns": [
+                { "name": "nodeIds", "type": "array", "items": { "$ref": "NodeId" }, "description": "Ids of the search result nodes." }
+            ],
+            "description": "Returns search results from given <code>fromIndex</code> to given <code>toIndex</code> from the sarch with the given identifier."
+        },
+        {
+            "name": "discardSearchResults",
+            "parameters": [
+                { "name": "searchId", "type": "string", "description": "Unique search session identifier." }
+            ],
+            "description": "Discards search results from the session with the given id. <code>getSearchResults</code> should no longer be called for that search."
+        },
+        {
+            "name": "requestNode",
+            "parameters": [
+                { "name": "objectId", "$ref": "Runtime.RemoteObjectId", "description": "JavaScript object id to convert into node." }
+            ],
+            "returns": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Node id for given object." }
+            ],
+            "description": "Requests that the node is sent to the caller given the JavaScript node object reference. All nodes that form the path from the node to the root are also sent to the client as a series of <code>setChildNodes</code> notifications."
+        },
+        {
+            "name": "setInspectModeEnabled",
+            "parameters": [
+                { "name": "enabled", "type": "boolean", "description": "True to enable inspection mode, false to disable it." },
+                { "name": "highlightConfig", "$ref": "HighlightConfig", "optional": true, "description": "A descriptor for the highlight appearance of hovered-over nodes. May be omitted if <code>enabled == false</code>." }
+            ],
+            "description": "Enters the 'inspect' mode. In this mode, elements that user is hovering over are highlighted. Backend then generates 'inspect' command upon element selection."
+        },
+        {
+            "name": "highlightRect",
+            "parameters": [
+                { "name": "x", "type": "integer", "description": "X coordinate" },
+                { "name": "y", "type": "integer", "description": "Y coordinate" },
+                { "name": "width", "type": "integer", "description": "Rectangle width" },
+                { "name": "height", "type": "integer", "description": "Rectangle height" },
+                { "name": "color", "$ref": "RGBA", "optional": true, "description": "The highlight fill color (default: transparent)." },
+                { "name": "outlineColor", "$ref": "RGBA", "optional": true, "description": "The highlight outline color (default: transparent)." },
+                { "name": "usePageCoordinates", "type": "boolean", "optional": true, "description": "Indicates whether the provided parameters are in page coordinates or in viewport coordinates (the default)." }
+            ],
+            "description": "Highlights given rectangle. Coordinates are absolute with respect to the main frame viewport."
+        },
+        {
+            "name": "highlightQuad",
+            "parameters": [
+                { "name": "quad", "$ref": "Quad", "description": "Quad to highlight" },
+                { "name": "color", "$ref": "RGBA", "optional": true, "description": "The highlight fill color (default: transparent)." },
+                { "name": "outlineColor", "$ref": "RGBA", "optional": true, "description": "The highlight outline color (default: transparent)." },
+                { "name": "usePageCoordinates", "type": "boolean", "optional": true, "description": "Indicates whether the provided parameters are in page coordinates or in viewport coordinates (the default)." }
+            ],
+            "description": "Highlights given quad. Coordinates are absolute with respect to the main frame viewport."
+        },
+        {
+            "name": "highlightNode",
+            "parameters": [
+                { "name": "highlightConfig", "$ref": "HighlightConfig", "description": "A descriptor for the highlight appearance." },
+                { "name": "nodeId", "$ref": "NodeId", "optional": true, "description": "Identifier of the node to highlight." },
+                { "name": "objectId", "$ref": "Runtime.RemoteObjectId", "optional": true, "description": "JavaScript object id of the node to be highlighted." }
+            ],
+            "description": "Highlights DOM node with given id or with the given JavaScript object wrapper. Either nodeId or objectId must be specified."
+        },
+        {
+            "name": "hideHighlight",
+            "description": "Hides DOM node highlight."
+        },
+        {
+            "name": "highlightFrame",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Identifier of the frame to highlight." },
+                { "name": "contentColor", "$ref": "RGBA", "optional": true, "description": "The content box highlight fill color (default: transparent)." },
+                { "name": "contentOutlineColor", "$ref": "RGBA", "optional": true, "description": "The content box highlight outline color (default: transparent)." }
+            ],
+            "description": "Highlights owner element of the frame with given id."
+        },
+        {
+            "name": "pushNodeByPathToFrontend",
+            "parameters": [
+                { "name": "path", "type": "string", "description": "Path to node in the proprietary format." }
+            ],
+            "returns": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node for given path." }
+            ],
+            "description": "Requests that the node is sent to the caller given its path. // FIXME, use XPath"
+        },
+        {
+            "name": "pushNodeByBackendIdToFrontend",
+            "parameters": [
+                { "name": "backendNodeId", "$ref": "BackendNodeId", "description": "The backend node id of the node." }
+            ],
+            "returns": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "The pushed node's id." }
+            ],
+            "description": "Requests that the node is sent to the caller given its backend node id."
+        },
+        {
+            "name": "releaseBackendNodeIds",
+            "parameters": [
+                { "name": "nodeGroup", "type": "string", "description": "The backend node ids group name." }
+            ],
+            "description": "Requests that group of <code>BackendNodeIds</code> is released."
+        },
+        {
+            "name": "resolveNode",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to resolve." },
+                { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." }
+            ],
+            "returns": [
+                { "name": "object", "$ref": "Runtime.RemoteObject", "description": "JavaScript object wrapper for given node." }
+            ],
+            "description": "Resolves JavaScript node object for given node id."
+        },
+        {
+            "name": "getAttributes",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to retrieve attibutes for." }
+            ],
+            "returns": [
+                { "name": "attributes", "type": "array", "items": { "type": "string" }, "description": "An interleaved array of node attribute names and values." }
+            ],
+            "description": "Returns attributes for the specified node."
+        },
+        {
+            "name": "moveTo",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to drop." },
+                { "name": "targetNodeId", "$ref": "NodeId", "description": "Id of the element to drop into." },
+                { "name": "insertBeforeNodeId", "$ref": "NodeId", "optional": true, "description": "Drop node before given one." }
+            ],
+            "returns": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "New id of the moved node." }
+            ],
+            "description": "Moves node into the new container, places it before the given anchor."
+        },
+        {
+            "name": "undo",
+            "description": "Undoes the last performed action."
+        },
+        {
+            "name": "redo",
+            "description": "Re-does the last undone action."
+        },
+        {
+            "name": "markUndoableState",
+            "description": "Marks last undoable state."
+        },
+        {
+            "name": "focus",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to focus." }
+            ],
+            "description": "Focuses the given element."
+        }
+    ],
+    "events": [
+        {
+            "name": "documentUpdated",
+            "description": "Fired when <code>Document</code> has been totally updated. Node ids are no longer valid."
+        },
+        {
+            "name": "setChildNodes",
+            "parameters": [
+                { "name": "parentId", "$ref": "NodeId", "description": "Parent node id to populate with children." },
+                { "name": "nodes", "type": "array", "items": { "$ref": "Node"}, "description": "Child nodes array." }
+            ],
+            "description": "Fired when backend wants to provide client with the missing DOM structure. This happens upon most of the calls requesting node ids."
+        },
+        {
+            "name": "attributeModified",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                { "name": "name", "type": "string", "description": "Attribute name." },
+                { "name": "value", "type": "string", "description": "Attribute value." }
+            ],
+            "description": "Fired when <code>Element</code>'s attribute is modified."
+        },
+        {
+            "name": "attributeRemoved",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                { "name": "name", "type": "string", "description": "A ttribute name." }
+            ],
+            "description": "Fired when <code>Element</code>'s attribute is removed."
+        },
+        {
+            "name": "inlineStyleInvalidated",
+            "parameters": [
+                { "name": "nodeIds", "type": "array", "items": { "$ref": "NodeId" }, "description": "Ids of the nodes for which the inline styles have been invalidated." }
+            ],
+            "description": "Fired when <code>Element</code>'s inline style is modified via a CSS property modification."
+        },
+        {
+            "name": "characterDataModified",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                { "name": "characterData", "type": "string", "description": "New text value." }
+            ],
+            "description": "Mirrors <code>DOMCharacterDataModified</code> event."
+        },
+        {
+            "name": "childNodeCountUpdated",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                { "name": "childNodeCount", "type": "integer", "description": "New node count." }
+            ],
+            "description": "Fired when <code>Container</code>'s child node count has changed."
+        },
+        {
+            "name": "childNodeInserted",
+            "parameters": [
+                { "name": "parentNodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                { "name": "previousNodeId", "$ref": "NodeId", "description": "If of the previous siblint." },
+                { "name": "node", "$ref": "Node", "description": "Inserted node data." }
+            ],
+            "description": "Mirrors <code>DOMNodeInserted</code> event."
+        },
+        {
+            "name": "childNodeRemoved",
+            "parameters": [
+                { "name": "parentNodeId", "$ref": "NodeId", "description": "Parent id." },
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has been removed." }
+            ],
+            "description": "Mirrors <code>DOMNodeRemoved</code> event."
+        },
+        {
+            "name": "shadowRootPushed",
+            "parameters": [
+                { "name": "hostId", "$ref": "NodeId", "description": "Host element id." },
+                { "name": "root", "$ref": "Node", "description": "Shadow root." }
+            ],
+            "description": "Called when shadow root is pushed into the element."
+        },
+        {
+            "name": "shadowRootPopped",
+            "parameters": [
+                { "name": "hostId", "$ref": "NodeId", "description": "Host element id." },
+                { "name": "rootId", "$ref": "NodeId", "description": "Shadow root id." }
+            ],
+            "description": "Called when shadow root is popped from the element."
+        }
+    ]
+}
+,
+{
+    "domain": "DOMDebugger",
+    "description": "DOM debugging allows setting breakpoints on particular DOM operations and events. JavaScript execution will stop on these operations as if there was a regular breakpoint set.",
+    "availability": "web",
+    "types": [
+        {
+            "id": "DOMBreakpointType",
+            "type": "string",
+            "enum": ["subtree-modified", "attribute-modified", "node-removed"],
+            "description": "DOM breakpoint type."
+        }
+    ],
+    "commands": [
+        {
+            "name": "setDOMBreakpoint",
+            "parameters": [
+                { "name": "nodeId", "$ref": "DOM.NodeId", "description": "Identifier of the node to set breakpoint on." },
+                { "name": "type", "$ref": "DOMBreakpointType", "description": "Type of the operation to stop upon." }
+            ],
+            "description": "Sets breakpoint on particular operation with DOM."
+        },
+        {
+            "name": "removeDOMBreakpoint",
+            "parameters": [
+                { "name": "nodeId", "$ref": "DOM.NodeId", "description": "Identifier of the node to remove breakpoint from." },
+                { "name": "type", "$ref": "DOMBreakpointType", "description": "Type of the breakpoint to remove." }
+            ],
+            "description": "Removes DOM breakpoint that was set using <code>setDOMBreakpoint</code>."
+        },
+        {
+            "name": "setEventListenerBreakpoint",
+            "parameters": [
+                { "name": "eventName", "type": "string", "description": "DOM Event name to stop on (any DOM event will do)." }
+            ],
+            "description": "Sets breakpoint on particular DOM event."
+        },
+        {
+            "name": "removeEventListenerBreakpoint",
+            "parameters": [
+                { "name": "eventName", "type": "string", "description": "Event name." }
+            ],
+            "description": "Removes breakpoint on particular DOM event."
+        },
+        {
+            "name": "setInstrumentationBreakpoint",
+            "parameters": [
+                { "name": "eventName", "type": "string", "description": "Instrumentation name to stop on." }
+            ],
+            "description": "Sets breakpoint on particular native event."
+        },
+        {
+            "name": "removeInstrumentationBreakpoint",
+            "parameters": [
+                { "name": "eventName", "type": "string", "description": "Instrumentation name to stop on." }
+            ],
+            "description": "Sets breakpoint on particular native event."
+        },
+        {
+            "name": "setXHRBreakpoint",
+            "parameters": [
+                { "name": "url", "type": "string", "description": "Resource URL substring. All XHRs having this substring in the URL will get stopped upon." }
+            ],
+            "description": "Sets breakpoint on XMLHttpRequest."
+        },
+        {
+            "name": "removeXHRBreakpoint",
+            "parameters": [
+                { "name": "url", "type": "string", "description": "Resource URL substring." }
+            ],
+            "description": "Removes breakpoint from XMLHttpRequest."
+        }
+    ]
+}
+,
+{
+    "domain": "DOMStorage",
+    "description": "Query and modify DOM storage.",
+    "availability": "web",
+    "types": [
+        {
+            "id": "StorageId",
+            "type": "object",
+            "description": "DOM Storage identifier.",
+            "properties": [
+                { "name": "securityOrigin", "type": "string", "description": "Security origin for the storage." },
+                { "name": "isLocalStorage", "type": "boolean", "description": "Whether the storage is local storage (not session storage)." }
+            ]
+        },
+        {
+            "id": "Item",
+            "type": "array",
+            "description": "DOM Storage item.",
+            "items": { "type": "string" }
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables storage tracking, storage events will now be delivered to the client."
+        },
+        {
+            "name": "disable",
+            "description": "Disables storage tracking, prevents storage events from being sent to the client."
+        },
+        {
+            "name": "getDOMStorageItems",
+            "parameters": [
+                { "name": "storageId", "$ref": "StorageId" }
+            ],
+            "returns": [
+                { "name": "entries", "type": "array", "items": { "$ref": "Item" } }
+            ]
+        },
+        {
+            "name": "setDOMStorageItem",
+            "parameters": [
+                { "name": "storageId", "$ref": "StorageId" },
+                { "name": "key", "type": "string" },
+                { "name": "value", "type": "string" }
+            ]
+        },
+        {
+            "name": "removeDOMStorageItem",
+            "parameters": [
+                { "name": "storageId", "$ref": "StorageId" },
+                { "name": "key", "type": "string" }
+            ]
+        }
+    ],
+    "events": [
+        {
+            "name": "domStorageItemsCleared",
+            "parameters": [
+                { "name": "storageId", "$ref": "StorageId" }
+            ]
+        },
+        {
+            "name": "domStorageItemRemoved",
+            "parameters": [
+                { "name": "storageId", "$ref": "StorageId" },
+                { "name": "key", "type": "string" }
+            ]
+        },
+        {
+            "name": "domStorageItemAdded",
+            "parameters": [
+                { "name": "storageId", "$ref": "StorageId" },
+                { "name": "key", "type": "string" },
+                { "name": "newValue", "type": "string" }
+            ]
+        },
+        {
+            "name": "domStorageItemUpdated",
+            "parameters": [
+                { "name": "storageId", "$ref": "StorageId" },
+                { "name": "key", "type": "string" },
+                { "name": "oldValue", "type": "string" },
+                { "name": "newValue", "type": "string" }
+            ]
+        }
+    ]
+}
+,
+{
+    "domain": "Database",
+    "availability": "web",
+    "types": [
+        {
+            "id": "DatabaseId",
+            "type": "string",
+            "description": "Unique identifier of Database object."
+        },
+        {
+            "id": "Database",
+            "type": "object",
+            "description": "Database object.",
+            "properties": [
+                { "name": "id", "$ref": "DatabaseId", "description": "Database ID." },
+                { "name": "domain", "type": "string", "description": "Database domain." },
+                { "name": "name", "type": "string", "description": "Database name." },
+                { "name": "version", "type": "string", "description": "Database version." }
+            ]
+        },
+        {
+            "id": "Error",
+            "type": "object",
+            "description": "Database error.",
+            "properties": [
+                { "name": "message", "type": "string", "description": "Error message." },
+                { "name": "code", "type": "integer", "description": "Error code." }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables database tracking, database events will now be delivered to the client."
+        },
+        {
+            "name": "disable",
+            "description": "Disables database tracking, prevents database events from being sent to the client."
+        },
+        {
+            "name": "getDatabaseTableNames",
+            "parameters": [
+                { "name": "databaseId", "$ref": "DatabaseId" }
+            ],
+            "returns": [
+                { "name": "tableNames", "type": "array", "items": { "type": "string" } }
+            ]
+        },
+        {
+            "name": "executeSQL",
+            "async": true,
+            "parameters": [
+                { "name": "databaseId", "$ref": "DatabaseId" },
+                { "name": "query", "type": "string" }
+            ],
+            "returns": [
+                { "name": "columnNames", "type": "array", "optional": true, "items": { "type": "string" } },
+                { "name": "values", "type": "array", "optional": true, "items": { "type": "any" }},
+                { "name": "sqlError", "$ref": "Error", "optional": true }
+            ]
+        }
+    ],
+    "events": [
+        {
+            "name": "addDatabase",
+            "parameters": [
+                { "name": "database", "$ref": "Database" }
+            ]
+        }
+    ]
+}
+,
+{
+    "domain": "IndexedDB",
+    "availability": "web",
+    "types": [
+        {
+            "id": "DatabaseWithObjectStores",
+            "type": "object",
+            "description": "Database with an array of object stores.",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Database name." },
+                { "name": "version", "type": "number", "description": "Database version." },
+                { "name": "objectStores", "type": "array", "items": { "$ref": "ObjectStore" }, "description": "Object stores in this database." }
+            ]
+        },
+        {
+            "id": "ObjectStore",
+            "type": "object",
+            "description": "Object store.",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Object store name." },
+                { "name": "keyPath", "$ref": "KeyPath", "description": "Object store key path." },
+                { "name": "autoIncrement", "type": "boolean", "description": "If true, object store has auto increment flag set." },
+                { "name": "indexes", "type": "array", "items": { "$ref": "ObjectStoreIndex" }, "description": "Indexes in this object store." }
+            ]
+        },
+        {
+            "id": "ObjectStoreIndex",
+            "type": "object",
+            "description": "Object store index.",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Index name." },
+                { "name": "keyPath", "$ref": "KeyPath", "description": "Index key path." },
+                { "name": "unique", "type": "boolean", "description": "If true, index is unique." },
+                { "name": "multiEntry", "type": "boolean", "description": "If true, index allows multiple entries for a key." }
+            ]
+        },
+        {
+            "id": "Key",
+            "type": "object",
+            "description": "Key.",
+            "properties": [
+                { "name": "type", "type": "string", "enum": ["number", "string", "date", "array"], "description": "Key type." },
+                { "name": "number", "type": "number", "optional": true, "description": "Number value." },
+                { "name": "string", "type": "string", "optional": true, "description": "String value." },
+                { "name": "date", "type": "number", "optional": true, "description": "Date value." },
+                { "name": "array", "type": "array", "optional": true, "items": { "$ref": "Key" }, "description": "Array value." }
+            ]
+        },
+        {
+            "id": "KeyRange",
+            "type": "object",
+            "description": "Key range.",
+            "properties": [
+                { "name": "lower", "$ref": "Key", "optional": true, "description": "Lower bound." },
+                { "name": "upper", "$ref": "Key", "optional": true, "description": "Upper bound." },
+                { "name": "lowerOpen", "type": "boolean", "description": "If true lower bound is open." },
+                { "name": "upperOpen", "type": "boolean", "description": "If true upper bound is open." }
+            ]
+        },
+        {
+            "id": "DataEntry",
+            "type": "object",
+            "description": "Data entry.",
+            "properties": [
+                { "name": "key", "$ref": "Runtime.RemoteObject", "description": "Key." },
+                { "name": "primaryKey", "$ref": "Runtime.RemoteObject", "description": "Primary key." },
+                { "name": "value", "$ref": "Runtime.RemoteObject", "description": "Value." }
+            ]
+        },
+        {
+            "id": "KeyPath",
+            "type": "object",
+            "description": "Key path.",
+            "properties": [
+                { "name": "type", "type": "string", "enum": ["null", "string", "array"], "description": "Key path type." },
+                { "name": "string", "type": "string", "optional": true, "description": "String value." },
+                { "name": "array", "type": "array", "optional": true, "items": { "type": "string" }, "description": "Array value." }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables events from backend."
+        },
+        {
+            "name": "disable",
+            "description": "Disables events from backend."
+        },
+        {
+            "name": "requestDatabaseNames",
+            "async": true,
+            "parameters": [
+                { "name": "securityOrigin", "type": "string", "description": "Security origin." }
+            ],
+            "returns": [
+                { "name": "databaseNames", "type": "array", "items": { "type": "string" }, "description": "Database names for origin." }
+            ],
+            "description": "Requests database names for given security origin."
+        },
+        {
+            "name": "requestDatabase",
+            "async": true,
+            "parameters": [
+                { "name": "securityOrigin", "type": "string", "description": "Security origin." },
+                { "name": "databaseName", "type": "string", "description": "Database name." }
+            ],
+            "returns": [
+                { "name": "databaseWithObjectStores", "$ref": "DatabaseWithObjectStores", "description": "Database with an array of object stores." }
+            ],
+            "description": "Requests database with given name in given frame."
+        },
+        {
+            "name": "requestData",
+            "async": true,
+            "parameters": [
+                { "name": "securityOrigin", "type": "string", "description": "Security origin." },
+                { "name": "databaseName", "type": "string", "description": "Database name." },
+                { "name": "objectStoreName", "type": "string", "description": "Object store name." },
+                { "name": "indexName", "type": "string", "description": "Index name, empty string for object store data requests." },
+                { "name": "skipCount", "type": "integer", "description": "Number of records to skip." },
+                { "name": "pageSize", "type": "integer", "description": "Number of records to fetch." },
+                { "name": "keyRange", "$ref": "KeyRange", "optional": true, "description": "Key range." }
+            ],
+            "returns": [
+                { "name": "objectStoreDataEntries", "type": "array", "items": { "$ref": "DataEntry" }, "description": "Array of object store data entries." },
+                { "name": "hasMore", "type": "boolean", "description": "If true, there are more entries to fetch in the given range." }
+            ],
+            "description": "Requests data from object store or index."
+        },
+        {
+            "name": "clearObjectStore",
+            "async": true,
+            "parameters": [
+                { "name": "securityOrigin", "type": "string", "description": "Security origin." },
+                { "name": "databaseName", "type": "string", "description": "Database name." },
+                { "name": "objectStoreName", "type": "string", "description": "Object store name." }
+            ],
+            "returns": [
+            ],
+            "description": "Clears all entries from an object store."
+        }
+    ]
+}
+,
+{
+    "domain": "LayerTree",
+    "availability": "web",
+    "types": [
+        {
+            "id": "LayerId",
+            "type": "string",
+            "description": "Unique RenderLayer identifier."
+        },
+        {
+            "id": "PseudoElementId",
+            "type": "string",
+            "description": "Unique PseudoElement identifier."
+        },
+        {
+            "id": "IntRect",
+            "type": "object",
+            "description": "A rectangle.",
+            "properties": [
+                { "name": "x", "type": "integer", "description": "The x position." },
+                { "name": "y", "type": "integer", "description": "The y position." },
+                { "name": "width", "type": "integer", "description": "The width metric." },
+                { "name": "height", "type": "integer", "description": "The height metric." }
+            ]
+        },
+        {
+            "id": "Layer",
+            "type": "object",
+            "description": "Information about a compositing layer.",
+            "properties": [
+                { "name": "layerId", "$ref": "LayerId", "description": "The unique id for this layer." },
+                { "name": "nodeId", "$ref": "DOM.NodeId", "description": "The id for the node associated with this layer." },
+                { "name": "bounds", "$ref": "IntRect", "description": "Bounds of the layer in absolute page coordinates." },
+                { "name": "paintCount", "type": "integer", "description": "Indicates how many time this layer has painted." },
+                { "name": "memory", "type": "integer", "description": "Estimated memory used by this layer." },
+                { "name": "compositedBounds", "$ref": "IntRect", "description": "The bounds of the composited layer." },
+                { "name": "isInShadowTree", "type": "boolean", "optional": true, "description": "Indicates whether this layer is associated with an element hosted in a shadow tree." },
+                { "name": "isReflection", "type": "boolean", "optional": true, "description": "Indicates whether this layer was used to provide a reflection for the element." },
+                { "name": "isGeneratedContent", "type": "boolean", "optional": true, "description": "Indicates whether the layer is attached to a pseudo element that is CSS generated content." },
+                { "name": "isAnonymous", "type": "boolean", "optional": true, "description": "Indicates whether the layer was created for a CSS anonymous block or box." },
+                { "name": "pseudoElementId", "$ref": "PseudoElementId", "optional": true, "description": "The id for the pseudo element associated with this layer." },
+                { "name": "pseudoElement", "type": "string", "optional": true, "description": "The name of the CSS pseudo-element that prompted the layer to be generated." }
+            ]
+        },
+        {
+            "id": "CompositingReasons",
+            "type": "object",
+            "description": "An object containing the reasons why the layer was composited as properties.",
+            "properties": [
+                { "name": "transform3D", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a CSS 3D transform." },
+                { "name": "video", "type": "boolean", "optional": true, "description": "Composition due to association with a <video> element." },
+                { "name": "canvas", "type": "boolean", "optional": true, "description": "Composition due to the element being a <canvas> element." },
+                { "name": "plugin", "type": "boolean", "optional": true, "description": "Composition due to association with a plugin." },
+                { "name": "iFrame", "type": "boolean", "optional": true, "description": "Composition due to association with an <iframe> element." },
+                { "name": "backfaceVisibilityHidden", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a \"backface-visibility: hidden\" style." },
+                { "name": "clipsCompositingDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with an element clipping compositing descendants." },
+                { "name": "animation", "type": "boolean", "optional": true, "description": "Composition due to association with an animated element." },
+                { "name": "filters", "type": "boolean", "optional": true, "description": "Composition due to association with an element with CSS filters applied." },
+                { "name": "positionFixed", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a \"position: fixed\" style." },
+                { "name": "positionSticky", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a \"position: sticky\" style." },
+                { "name": "overflowScrollingTouch", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a \"overflow-scrolling: touch\" style." },
+                { "name": "stacking", "type": "boolean", "optional": true, "description": "Composition due to association with an element establishing a stacking context." },
+                { "name": "overlap", "type": "boolean", "optional": true, "description": "Composition due to association with an element overlapping other composited elements." },
+                { "name": "negativeZIndexChildren", "type": "boolean", "optional": true, "description": "Composition due to association with an element with descendants that have a negative z-index." },
+                { "name": "transformWithCompositedDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with an element with composited descendants." },
+                { "name": "opacityWithCompositedDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with an element with opacity applied and composited descendants." },
+                { "name": "maskWithCompositedDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with a masked element and composited descendants." },
+                { "name": "reflectionWithCompositedDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a reflection and composited descendants." },
+                { "name": "filterWithCompositedDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with an element with CSS filters applied and composited descendants." },
+                { "name": "blendingWithCompositedDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with an element with CSS blending applied and composited descendants." },
+                { "name": "isolatesCompositedBlendingDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with an element isolating compositing descendants having CSS blending applied." },
+                { "name": "perspective", "type": "boolean", "optional": true, "description": "Composition due to association with an element with perspective applied." },
+                { "name": "preserve3D", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a \"transform-style: preserve-3d\" style." },
+                { "name": "root", "type": "boolean", "optional": true, "description": "Composition due to association with the root element." },
+                { "name": "blending", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a \"blend-mode\" style." }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables compositing tree inspection."
+        },
+        {
+            "name": "disable",
+            "description": "Disables compositing tree inspection."
+        },
+        {
+            "name": "layersForNode",
+            "parameters": [
+                { "name": "nodeId", "$ref": "DOM.NodeId", "description": "Root of the subtree for which we want to gather layers." }                ],
+            "description": "Returns the layer tree structure of the current page.",
+            "returns": [
+                { "name": "layers", "type": "array", "items": { "$ref": "Layer" }, "description": "Child layers." }
+            ]
+        },
+        {
+            "name": "reasonsForCompositingLayer",
+            "parameters": [
+                { "name": "layerId", "$ref": "LayerId", "description": "The id of the layer for which we want to get the reasons it was composited." }
+            ],
+            "description": "Provides the reasons why the given layer was composited.",
+            "returns": [
+                { "name": "compositingReasons", "$ref": "CompositingReasons", "description": "An object containing the reasons why the layer was composited as properties." }
+            ]
+        }
+    ],
+    "events": [
+        {
+            "name": "layerTreeDidChange"
+        }
+    ]
+}
+,
+{
+    "domain": "Network",
+    "description": "Network domain allows tracking network activities of the page. It exposes information about http, file, data and other requests and responses, their headers, bodies, timing, etc.",
+    "availability": "web",
+    "types": [
+        {
+            "id": "LoaderId",
+            "type": "string",
+            "description": "Unique loader identifier."
+        },
+        {
+            "id": "FrameId",
+            "type": "string",
+            "description": "Unique frame identifier."
+        },
+        {
+            "id": "RequestId",
+            "type": "string",
+            "description": "Unique request identifier."
+        },
+        {
+            "id": "Timestamp",
+            "type": "number",
+            "description": "Number of seconds since epoch."
+        },
+        {
+            "id": "Headers",
+            "type": "object",
+            "description": "Request / response headers as keys / values of JSON object."
+        },
+        {
+            "id": "ResourceTiming",
+            "type": "object",
+            "description": "Timing information for the request.",
+            "properties": [
+                { "name": "navigationStart", "type": "number", "description": "Timing's navigationStart is a baseline in seconds, while the other numbers are ticks in milliseconds relatively to this navigationStart." },
+                { "name": "domainLookupStart", "type": "number", "description": "Started DNS address resolve." },
+                { "name": "domainLookupEnd", "type": "number", "description": "Finished DNS address resolve." },
+                { "name": "connectStart", "type": "number", "description": "Started connecting to the remote host." },
+                { "name": "connectEnd", "type": "number", "description": "Connected to the remote host." },
+                { "name": "secureConnectionStart", "type": "number", "description": "Started SSL handshake." },
+                { "name": "requestStart", "type": "number", "description": "Started sending request." },
+                { "name": "responseStart", "type": "number", "description": "Started receiving response headers." }
+            ]
+        },
+        {
+            "id": "Request",
+            "type": "object",
+            "description": "HTTP request data.",
+            "properties": [
+                { "name": "url", "type": "string", "description": "Request URL." },
+                { "name": "method", "type": "string", "description": "HTTP request method." },
+                { "name": "headers", "$ref": "Headers", "description": "HTTP request headers." },
+                { "name": "postData", "type": "string", "optional": true, "description": "HTTP POST request data." }
+            ]
+        },
+        {
+            "id": "Response",
+            "type": "object",
+            "description": "HTTP response data.",
+            "properties": [
+                { "name": "url", "type": "string", "description": "Response URL. This URL can be different from CachedResource.url in case of redirect." },
+                { "name": "status", "type": "number", "description": "HTTP response status code." },
+                { "name": "statusText", "type": "string", "description": "HTTP response status text." },
+                { "name": "headers", "$ref": "Headers", "description": "HTTP response headers." },
+                { "name": "headersText", "type": "string", "optional": true, "description": "HTTP response headers text." },
+                { "name": "mimeType", "type": "string", "description": "Resource mimeType as determined by the browser." },
+                { "name": "requestHeaders", "$ref": "Headers", "optional": true, "description": "Refined HTTP request headers that were actually transmitted over the network." },
+                { "name": "requestHeadersText", "type": "string", "optional": true, "description": "HTTP request headers text." },
+                { "name": "connectionReused", "type": "boolean", "description": "Specifies whether physical connection was actually reused for this request." },
+                { "name": "connectionId", "type": "number", "description": "Physical connection id that was actually used for this request." },
+                { "name": "fromDiskCache", "type": "boolean", "optional": true, "description": "Specifies that the request was served from the disk cache." },
+                { "name": "timing", "$ref": "ResourceTiming", "optional": true, "description": "Timing information for the given request." }
+            ]
+        },
+        {
+            "id": "WebSocketRequest",
+            "type": "object",
+            "description": "WebSocket request data.",
+            "properties": [
+                { "name": "headers", "$ref": "Headers", "description": "HTTP response headers." }
+            ]
+        },
+        {
+            "id": "WebSocketResponse",
+            "type": "object",
+            "description": "WebSocket response data.",
+            "properties": [
+                { "name": "status", "type": "number", "description": "HTTP response status code." },
+                { "name": "statusText", "type": "string", "description": "HTTP response status text." },
+                { "name": "headers", "$ref": "Headers", "description": "HTTP response headers." }
+            ]
+        },
+        {
+            "id": "WebSocketFrame",
+            "type": "object",
+            "description": "WebSocket frame data.",
+            "properties": [
+                { "name": "opcode", "type": "number", "description": "WebSocket frame opcode." },
+                { "name": "mask", "type": "boolean", "description": "WebSocket frame mask." },
+                { "name": "payloadData", "type": "string", "description": "WebSocket frame payload data." }
+            ]
+        },
+        {
+            "id": "CachedResource",
+            "type": "object",
+            "description": "Information about the cached resource.",
+            "properties": [
+                { "name": "url", "type": "string", "description": "Resource URL. This is the url of the original network request." },
+                { "name": "type", "$ref": "Page.ResourceType", "description": "Type of this resource." },
+                { "name": "response", "$ref": "Response", "optional": true, "description": "Cached response data." },
+                { "name": "bodySize", "type": "number", "description": "Cached response body size." },
+                { "name": "sourceMapURL", "type": "string", "optional": true, "description": "URL of source map associated with this resource (if any)." }
+            ]
+        },
+        {
+            "id": "Initiator",
+            "type": "object",
+            "description": "Information about the request initiator.",
+            "properties": [
+                { "name": "type", "type": "string", "enum": ["parser", "script", "other"], "description": "Type of this initiator." },
+                { "name": "stackTrace", "$ref": "Console.StackTrace", "optional": true, "description": "Initiator JavaScript stack trace, set for Script only." },
+                { "name": "url", "type": "string", "optional": true, "description": "Initiator URL, set for Parser type only." },
+                { "name": "lineNumber", "type": "number", "optional": true, "description": "Initiator line number, set for Parser type only." }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables network tracking, network events will now be delivered to the client."
+        },
+        {
+            "name": "disable",
+            "description": "Disables network tracking, prevents network events from being sent to the client."
+        },
+        {
+            "name": "setExtraHTTPHeaders",
+            "description": "Specifies whether to always send extra HTTP headers with the requests from this page.",
+            "parameters": [
+                { "name": "headers", "$ref": "Headers", "description": "Map with extra HTTP headers." }
+            ]
+        },
+        {
+            "name": "getResponseBody",
+            "description": "Returns content served for the given request.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Identifier of the network request to get content for." }
+            ],
+            "returns": [
+                { "name": "body", "type": "string", "description": "Response body." },
+                { "name": "base64Encoded", "type": "boolean", "description": "True, if content was sent as base64." }
+            ]
+        },
+        {
+            "name": "setCacheDisabled",
+            "parameters": [
+                { "name": "cacheDisabled", "type": "boolean", "description": "Cache disabled state." }
+            ],
+            "description": "Toggles ignoring cache for each request. If <code>true</code>, cache will not be used."
+        },
+        {
+            "name": "loadResource",
+            "async": true,
+            "parameters": [
+                { "name": "frameId", "$ref": "FrameId", "description": "Frame to load the resource from." },
+                { "name": "url", "type": "string", "description": "URL of the resource to load." }
+            ],
+            "returns": [
+                { "name": "content", "type": "string", "description": "Resource content." },
+                { "name": "mimeType", "type": "string", "description": "Resource mimeType." },
+                { "name": "status", "type": "number", "description": "HTTP response status code." }
+            ],
+            "description": "Loads a resource in the context of a frame on the inspected page without cross origin checks."
+        }
+    ],
+    "events": [
+        {
+            "name": "requestWillBeSent",
+            "description": "Fired when page is about to send HTTP request.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "frameId", "$ref": "FrameId", "description": "Frame identifier." },
+                { "name": "loaderId", "$ref": "LoaderId", "description": "Loader identifier." },
+                { "name": "documentURL", "type": "string", "description": "URL of the document this request is loaded for." },
+                { "name": "request", "$ref": "Request", "description": "Request data." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "initiator", "$ref": "Initiator", "description": "Request initiator." },
+                { "name": "redirectResponse", "optional": true, "$ref": "Response", "description": "Redirect response data." },
+                { "name": "type", "$ref": "Page.ResourceType", "optional": true, "description": "Resource type." }
+            ]
+        },
+        {
+            "name": "requestServedFromCache",
+            "description": "Fired if request ended up loading from cache.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." }
+            ]
+        },
+        {
+            "name": "responseReceived",
+            "description": "Fired when HTTP response is available.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "frameId", "$ref": "FrameId", "description": "Frame identifier." },
+                { "name": "loaderId", "$ref": "LoaderId", "description": "Loader identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "type", "$ref": "Page.ResourceType", "description": "Resource type." },
+                { "name": "response", "$ref": "Response", "description": "Response data." }
+            ]
+        },
+        {
+            "name": "dataReceived",
+            "description": "Fired when data chunk was received over the network.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "dataLength", "type": "integer", "description": "Data chunk length." },
+                { "name": "encodedDataLength", "type": "integer", "description": "Actual bytes received (might be less than dataLength for compressed encodings)." }
+            ]
+        },
+        {
+            "name": "loadingFinished",
+            "description": "Fired when HTTP request has finished loading.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "sourceMapURL", "type": "string", "optional": true, "description": "URL of source map associated with this resource (if any)." }
+            ]
+        },
+        {
+            "name": "loadingFailed",
+            "description": "Fired when HTTP request has failed to load.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "errorText", "type": "string", "description": "User friendly error message." },
+                { "name": "canceled", "type": "boolean", "optional": true, "description": "True if loading was canceled." }
+            ]
+        },
+        {
+            "name": "requestServedFromMemoryCache",
+            "description": "Fired when HTTP request has been served from memory cache.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "frameId", "$ref": "FrameId", "description": "Frame identifier." },
+                { "name": "loaderId", "$ref": "LoaderId", "description": "Loader identifier." },
+                { "name": "documentURL", "type": "string", "description": "URL of the document this request is loaded for." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "initiator", "$ref": "Initiator", "description": "Request initiator." },
+                { "name": "resource", "$ref": "CachedResource", "description": "Cached resource data." }
+            ]
+        },
+        {
+            "name": "webSocketWillSendHandshakeRequest",
+            "description": "Fired when WebSocket is about to initiate handshake.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "request", "$ref": "WebSocketRequest", "description": "WebSocket request data." }
+            ]
+        },
+        {
+            "name": "webSocketHandshakeResponseReceived",
+            "description": "Fired when WebSocket handshake response becomes available.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "response", "$ref": "WebSocketResponse", "description": "WebSocket response data." }
+            ]
+        },
+        {
+            "name": "webSocketCreated",
+            "description": "Fired upon WebSocket creation.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "url", "type": "string", "description": "WebSocket request URL." }
+            ]
+        },
+        {
+            "name": "webSocketClosed",
+            "description": "Fired when WebSocket is closed.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." }
+            ]
+        },
+        {
+            "name": "webSocketFrameReceived",
+            "description": "Fired when WebSocket frame is received.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "response", "$ref": "WebSocketFrame", "description": "WebSocket response data." }
+            ]
+        },
+        {
+            "name": "webSocketFrameError",
+            "description": "Fired when WebSocket frame error occurs.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "errorMessage", "type": "string", "description": "WebSocket frame error message." }
+            ]
+        },
+        {
+            "name": "webSocketFrameSent",
+            "description": "Fired when WebSocket frame is sent.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "response", "$ref": "WebSocketFrame", "description": "WebSocket response data." }
+            ]
+        }
+    ]
+}
+,
+{
+    "domain": "Page",
+    "description": "Actions and events related to the inspected page belong to the page domain.",
+    "availability": "web",
+    "types": [
+        {
+            "id": "ResourceType",
+            "type": "string",
+            "enum": ["Document", "Stylesheet", "Image", "Font", "Script", "XHR", "WebSocket", "Other"],
+            "description": "Resource type as it was perceived by the rendering engine."
+        },
+        {
+            "id": "CoordinateSystem",
+            "type": "string",
+            "enum": ["Viewport", "Page"],
+            "description": "Coordinate system used by supplied coordinates."
+        },
+        {
+            "id": "Frame",
+            "type": "object",
+            "description": "Information about the Frame on the page.",
+            "properties": [
+                { "name": "id", "type": "string", "description": "Frame unique identifier." },
+                { "name": "parentId", "type": "string", "optional": true, "description": "Parent frame identifier." },
+                { "name": "loaderId", "$ref": "Network.LoaderId", "description": "Identifier of the loader associated with this frame." },
+                { "name": "name", "type": "string", "optional": true, "description": "Frame's name as specified in the tag." },
+                { "name": "url", "type": "string", "description": "Frame document's URL." },
+                { "name": "securityOrigin", "type": "string", "description": "Frame document's security origin." },
+                { "name": "mimeType", "type": "string", "description": "Frame document's mimeType as determined by the browser." }
+            ]
+        },
+        {
+            "id": "FrameResourceTree",
+            "type": "object",
+            "description": "Information about the Frame hierarchy along with their cached resources.",
+            "properties": [
+                { "name": "frame", "$ref": "Frame", "description": "Frame information for this tree item." },
+                { "name": "childFrames", "type": "array", "optional": true, "items": { "$ref": "FrameResourceTree" }, "description": "Child frames." },
+                { "name": "resources", "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": [
+                            { "name": "url", "type": "string", "description": "Resource URL." },
+                            { "name": "type", "$ref": "ResourceType", "description": "Type of this resource." },
+                            { "name": "mimeType", "type": "string", "description": "Resource mimeType as determined by the browser." },
+                            { "name": "failed", "type": "boolean", "optional": true, "description": "True if the resource failed to load." },
+                            { "name": "canceled", "type": "boolean", "optional": true, "description": "True if the resource was canceled during loading." },
+                            { "name": "sourceMapURL", "type": "string", "optional": true, "description": "URL of source map associated with this resource (if any)." }
+                        ]
+                    },
+                    "description": "Information about frame resources."
+                }
+            ]
+        },
+        {
+            "id": "SearchResult",
+            "type": "object",
+            "description": "Search result for resource.",
+            "properties": [
+                { "name": "url", "type": "string", "description": "Resource URL." },
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Resource frame id." },
+                { "name": "matchesCount", "type": "number", "description": "Number of matches in the resource content." }
+            ]
+        },
+        {
+            "id": "Cookie",
+            "type": "object",
+            "description": "Cookie object",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Cookie name." },
+                { "name": "value", "type": "string", "description": "Cookie value." },
+                { "name": "domain", "type": "string", "description": "Cookie domain." },
+                { "name": "path", "type": "string", "description": "Cookie path." },
+                { "name": "expires", "type": "number", "description": "Cookie expires." },
+                { "name": "size", "type": "integer", "description": "Cookie size." },
+                { "name": "httpOnly", "type": "boolean", "description": "True if cookie is http-only." },
+                { "name": "secure", "type": "boolean", "description": "True if cookie is secure." },
+                { "name": "session", "type": "boolean", "description": "True in case of session cookie." }
+            ]
+        },
+        {
+            "id": "ScriptIdentifier",
+            "type": "string",
+            "description": "Unique script identifier."
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables page domain notifications."
+        },
+        {
+            "name": "disable",
+            "description": "Disables page domain notifications."
+        },
+        {
+            "name": "addScriptToEvaluateOnLoad",
+            "parameters": [
+                { "name": "scriptSource", "type": "string" }
+            ],
+            "returns": [
+                { "name": "identifier", "$ref": "ScriptIdentifier", "description": "Identifier of the added script." }
+            ]
+        },
+        {
+            "name": "removeScriptToEvaluateOnLoad",
+            "parameters": [
+                { "name": "identifier", "$ref": "ScriptIdentifier" }
+            ]
+        },
+        {
+            "name": "reload",
+            "parameters": [
+                { "name": "ignoreCache", "type": "boolean", "optional": true, "description": "If true, browser cache is ignored (as if the user pressed Shift+refresh)." },
+                { "name": "scriptToEvaluateOnLoad", "type": "string", "optional": true, "description": "If set, the script will be injected into all frames of the inspected page after reload." }
+            ],
+            "description": "Reloads given page optionally ignoring the cache."
+        },
+        {
+            "name": "navigate",
+            "parameters": [
+                { "name": "url", "type": "string", "description": "URL to navigate the page to." }
+            ],
+            "description": "Navigates current page to the given URL."
+        },
+        {
+            "name": "getCookies",
+            "returns": [
+                { "name": "cookies", "type": "array", "items": { "$ref": "Cookie"}, "description": "Array of cookie objects." }
+            ],
+            "description": "Returns all browser cookies. Depending on the backend support, will return detailed cookie information in the <code>cookies</code> field."
+        },
+        {
+            "name": "deleteCookie",
+            "parameters": [
+                { "name": "cookieName", "type": "string", "description": "Name of the cookie to remove." },
+                { "name": "url", "type": "string", "description": "URL to match cooke domain and path." }
+            ],
+            "description": "Deletes browser cookie with given name, domain and path."
+        },
+        {
+            "name": "getResourceTree",
+            "description": "Returns present frame / resource tree structure.",
+            "returns": [
+                { "name": "frameTree", "$ref": "FrameResourceTree", "description": "Present frame / resource tree structure." }
+            ]
+        },
+        {
+            "name": "getResourceContent",
+            "description": "Returns content of the given resource.",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Frame id to get resource for." },
+                { "name": "url", "type": "string", "description": "URL of the resource to get content for." }
+            ],
+            "returns": [
+                { "name": "content", "type": "string", "description": "Resource content." },
+                { "name": "base64Encoded", "type": "boolean", "description": "True, if content was served as base64." }
+            ]
+        },
+        {
+            "name": "searchInResource",
+            "description": "Searches for given string in resource content.",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Frame id for resource to search in." },
+                { "name": "url", "type": "string", "description": "URL of the resource to search in." },
+                { "name": "query", "type": "string", "description": "String to search for."  },
+                { "name": "caseSensitive", "type": "boolean", "optional": true, "description": "If true, search is case sensitive." },
+                { "name": "isRegex", "type": "boolean", "optional": true, "description": "If true, treats string parameter as regex." }
+            ],
+            "returns": [
+                { "name": "result", "type": "array", "items": { "$ref": "GenericTypes.SearchMatch" }, "description": "List of search matches." }
+            ]
+        },
+        {
+            "name": "searchInResources",
+            "description": "Searches for given string in frame / resource tree structure.",
+            "parameters": [
+                { "name": "text", "type": "string", "description": "String to search for."  },
+                { "name": "caseSensitive", "type": "boolean", "optional": true, "description": "If true, search is case sensitive." },
+                { "name": "isRegex", "type": "boolean", "optional": true, "description": "If true, treats string parameter as regex." }
+            ],
+            "returns": [
+                { "name": "result", "type": "array", "items": { "$ref": "SearchResult" }, "description": "List of search results." }
+            ]
+        },
+        {
+            "name": "setDocumentContent",
+            "description": "Sets given markup as the document's HTML.",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Frame id to set HTML for." },
+                { "name": "html", "type": "string", "description": "HTML content to set."  }
+            ]
+        },
+        {
+            "name": "getScriptExecutionStatus",
+            "description": "Determines if scripts can be executed in the page.",
+            "returns": [
+                { "name": "result", "type": "string", "enum": ["allowed", "disabled", "forbidden"], "description": "Script execution status: \"allowed\" if scripts can be executed, \"disabled\" if script execution has been disabled through page settings, \"forbidden\" if script execution for the given page is not possible for other reasons." }
+            ]
+        },
+        {
+            "name": "setScriptExecutionDisabled",
+            "description": "Switches script execution in the page.",
+            "parameters": [
+                { "name": "value", "type": "boolean", "description": "Whether script execution should be disabled in the page." }
+            ]
+        },
+        {
+            "name": "setTouchEmulationEnabled",
+            "parameters": [
+                { "name": "enabled", "type": "boolean", "description": "Whether the touch event emulation should be enabled." }
+            ],
+            "description": "Toggles mouse event-based touch event emulation."
+        },
+        {
+            "name": "setEmulatedMedia",
+            "parameters": [
+                { "name": "media", "type": "string", "description": "Media type to emulate. Empty string disables the override." }
+            ],
+            "description": "Emulates the given media for CSS media queries."
+        },
+        {
+            "name": "getCompositingBordersVisible",
+            "description": "Indicates the visibility of compositing borders.",
+            "returns": [
+                { "name": "result", "type": "boolean", "description": "If true, compositing borders are visible." }
+            ]
+        },
+        {
+            "name": "setCompositingBordersVisible",
+            "description": "Controls the visibility of compositing borders.",
+            "parameters": [
+                { "name": "visible", "type": "boolean", "description": "True for showing compositing borders." }
+            ]
+        },
+        {
+            "name": "snapshotNode",
+            "description": "Capture a snapshot of the specified node that does not include unrelated layers.",
+            "parameters": [
+                { "name": "nodeId", "$ref": "DOM.NodeId", "description": "Id of the node to snapshot." }
+            ],
+            "returns": [
+                { "name": "dataURL", "type": "string", "description": "Base64-encoded image data (PNG)." }
+            ]
+        },
+        {
+            "name": "snapshotRect",
+            "description": "Capture a snapshot of the page within the specified rectangle and coordinate system.",
+            "parameters": [
+                { "name": "x", "type": "integer", "description": "X coordinate" },
+                { "name": "y", "type": "integer", "description": "Y coordinate" },
+                { "name": "width", "type": "integer", "description": "Rectangle width" },
+                { "name": "height", "type": "integer", "description": "Rectangle height" },
+                { "name": "coordinateSystem", "$ref": "CoordinateSystem", "description": "Indicates the coordinate system of the supplied rectangle." }
+            ],
+            "returns": [
+                { "name": "dataURL", "type": "string", "description": "Base64-encoded image data (PNG)." }
+            ]
+        },
+        {
+            "name": "handleJavaScriptDialog",
+            "description": "Accepts or dismisses a JavaScript initiated dialog (alert, confirm, prompt, or onbeforeunload).",
+            "parameters": [
+                { "name": "accept", "type": "boolean", "description": "Whether to accept or dismiss the dialog." },
+                { "name": "promptText", "type": "string", "optional": true, "description": "The text to enter into the dialog prompt before accepting. Used only if this is a prompt dialog." }
+            ]
+        },
+        {
+            "name": "archive",
+            "description": "Grab an archive of the page.",
+            "returns": [
+                { "name": "data", "type": "string", "description": "Base64-encoded web archive." }
+            ]
+        }
+    ],
+    "events": [
+        {
+            "name": "domContentEventFired",
+            "parameters": [
+                { "name": "timestamp", "type": "number" }
+            ]
+        },
+        {
+            "name": "loadEventFired",
+            "parameters": [
+                { "name": "timestamp", "type": "number" }
+            ]
+        },
+        {
+            "name": "frameNavigated",
+            "description": "Fired once navigation of the frame has completed. Frame is now associated with the new loader.",
+            "parameters": [
+                { "name": "frame", "$ref": "Frame", "description": "Frame object." }
+            ]
+        },
+        {
+            "name": "frameDetached",
+            "description": "Fired when frame has been detached from its parent.",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Id of the frame that has been detached." }
+            ]
+        },
+        {
+            "name": "frameStartedLoading",
+            "description": "Fired when frame has started loading.",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Id of the frame that has started loading." }
+            ]
+        },
+        {
+            "name": "frameStoppedLoading",
+            "description": "Fired when frame has stopped loading.",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Id of the frame that has stopped loading." }
+            ]
+        },
+        {
+            "name": "frameScheduledNavigation",
+            "description": "Fired when frame schedules a potential navigation.",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Id of the frame that has scheduled a navigation." },
+                { "name": "delay", "type": "number", "description": "Delay (in seconds) until the navigation is scheduled to begin. The navigation is not guaranteed to start." }
+            ]
+        },
+        {
+            "name": "frameClearedScheduledNavigation",
+            "description": "Fired when frame no longer has a scheduled navigation.",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Id of the frame that has cleared its scheduled navigation." }
+            ]
+        },
+        {
+            "name": "javascriptDialogOpening",
+            "description": "Fired when a JavaScript initiated dialog (alert, confirm, prompt, or onbeforeunload) is about to open.",
+            "parameters": [
+                { "name": "message", "type": "string", "description": "Message that will be displayed by the dialog." }
+            ]
+        },
+        {
+            "name": "javascriptDialogClosed",
+            "description": "Fired when a JavaScript initiated dialog (alert, confirm, prompt, or onbeforeunload) has been closed."
+        },
+        {
+            "name": "scriptsEnabled",
+            "description": "Fired when the JavaScript is enabled/disabled on the page",
+            "parameters": [
+                { "name": "isEnabled", "type": "boolean", "description": "Whether script execution is enabled or disabled on the page." }
+            ]
+        }
+    ]
+}
+,
+{
+    "domain": "Timeline",
+    "description": "Timeline provides its clients with instrumentation records that are generated during the page runtime. Timeline instrumentation can be started and stopped using corresponding commands. While timeline is started, it is generating timeline event records.",
+    "availability": "web",
+    "types": [
+        {
+            "id": "EventType",
+            "type": "string",
+            "enum": ["EventDispatch", "ScheduleStyleRecalculation", "RecalculateStyles", "InvalidateLayout", "Layout", "Paint", "ResizeImage", "ParseHTML", "TimerInstall", "TimerRemove", "TimerFire", "EvaluateScript", "MarkLoad", "MarkDOMContent", "TimeStamp", "Time", "TimeEnd", "ScheduleResourceRequest", "ResourceSendRequest", "ResourceReceiveResponse", "ResourceReceivedData", "ResourceFinish", "XHRReadyStateChange", "XHRLoad", "FunctionCall", "ProbeSample", "ConsoleProfile", "RequestAnimationFrame", "CancelAnimationFrame", "FireAnimationFrame", "WebSocketCreate", "WebSocketSendHandshakeRequest", "WebSocketReceiveHandshakeResponse", "WebSocketDestroy"],
+            "description": "Timeline record type."
+        },
+        {
+            "id": "TimelineEvent",
+            "type": "object",
+            "properties": [
+                { "name": "type", "$ref": "EventType", "description": "Event type." },
+                { "name": "data", "type": "object", "description": "Event data." },
+                { "name": "children", "type": "array", "optional": true, "items": { "$ref": "TimelineEvent" }, "description": "Nested records." }
+            ],
+            "description": "Timeline record contains information about the recorded activity."
+        }
+    ],
+    "commands": [
+        {
+            "name": "start",
+            "parameters": [
+                { "name": "maxCallStackDepth", "optional": true, "type": "integer", "description": "Samples JavaScript stack traces up to <code>maxCallStackDepth</code>, defaults to 5." }
+            ],
+            "description": "Starts capturing instrumentation events."
+        },
+        {
+            "name": "stop",
+            "description": "Stops capturing instrumentation events."
+        }
+    ],
+    "events": [
+        {
+            "name": "eventRecorded",
+            "parameters": [
+                { "name": "record", "$ref": "TimelineEvent", "description": "Timeline event record data." }
+            ],
+            "description": "Fired for every instrumentation event while timeline is started."
+        },
+        {
+            "name": "recordingStarted",
+            "description": "Fired when recording has started."
+        },
+        {
+            "name": "recordingStopped",
+            "description": "Fired when recording has stopped."
+        }
+    ]
+}
+]}

--- a/source/ProtocolGenerator/Inspector-iOS-9.0.json
+++ b/source/ProtocolGenerator/Inspector-iOS-9.0.json
@@ -1,0 +1,3310 @@
+{"domains":[
+{
+    "domain": "ApplicationCache",
+    "availability": "web",
+    "types": [
+        {
+            "id": "ApplicationCacheResource",
+            "type": "object",
+            "description": "Detailed application cache resource information.",
+            "properties": [
+                { "name": "url", "type": "string", "description": "Resource url." },
+                { "name": "size", "type": "integer", "description": "Resource size." },
+                { "name": "type", "type": "string", "description": "Resource type." }
+            ]
+        },
+        {
+            "id": "ApplicationCache",
+            "type": "object",
+            "description": "Detailed application cache information.",
+            "properties": [
+                { "name": "manifestURL", "type": "string", "description": "Manifest URL." },
+                { "name": "size", "type": "number", "description": "Application cache size." },
+                { "name": "creationTime", "type": "number", "description": "Application cache creation time." },
+                { "name": "updateTime", "type": "number", "description": "Application cache update time." },
+                { "name": "resources", "type": "array", "items": { "$ref": "ApplicationCacheResource" }, "description": "Application cache resources." }
+            ]
+        },
+        {
+            "id": "FrameWithManifest",
+            "type": "object",
+            "description": "Frame identifier - manifest URL pair.",
+            "properties": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Frame identifier." },
+                { "name": "manifestURL", "type": "string", "description": "Manifest URL." },
+                { "name": "status", "type": "integer", "description": "Application cache status." }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "getFramesWithManifests",
+            "returns": [
+                { "name": "frameIds", "type": "array", "items": { "$ref": "FrameWithManifest" }, "description": "Array of frame identifiers with manifest urls for each frame containing a document associated with some application cache." }
+            ],
+            "description": "Returns array of frame identifiers with manifest urls for each frame containing a document associated with some application cache."
+        },
+        {
+            "name": "enable",
+            "description": "Enables application cache domain notifications."
+        },
+        {
+            "name": "getManifestForFrame",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Identifier of the frame containing document whose manifest is retrieved." }
+            ],
+            "returns": [
+                { "name": "manifestURL", "type": "string", "description": "Manifest URL for document in the given frame." }
+            ],
+            "description": "Returns manifest URL for document in the given frame."
+        },
+        {
+            "name": "getApplicationCacheForFrame",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Identifier of the frame containing document whose application cache is retrieved." }
+            ],
+            "returns": [
+                { "name": "applicationCache", "$ref": "ApplicationCache", "description": "Relevant application cache data for the document in given frame." }
+            ],
+            "description": "Returns relevant application cache data for the document in given frame."
+        }
+    ],
+    "events": [
+        {
+            "name": "applicationCacheStatusUpdated",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Identifier of the frame containing document whose application cache updated status." },
+                { "name": "manifestURL", "type": "string", "description": "Manifest URL." },
+                { "name": "status", "type": "integer", "description": "Updated application cache status." }
+            ]
+        },
+        {
+            "name": "networkStateUpdated",
+            "parameters": [
+                { "name": "isNowOnline", "type": "boolean" }
+            ]
+        }
+    ]
+}
+,
+{
+    "domain": "CSS",
+    "description": "This domain exposes CSS read/write operations. All CSS objects, like stylesheets, rules, and styles, have an associated <code>id</code> used in subsequent operations on the related object. Each object type has a specific <code>id</code> structure, and those are not interchangeable between objects of different kinds. CSS objects can be loaded using the <code>get*ForNode()</code> calls (which accept a DOM node id). Alternatively, a client can discover all the existing stylesheets with the <code>getAllStyleSheets()</code> method and subsequently load the required stylesheet contents using the <code>getStyleSheet[Text]()</code> methods.",
+    "availability": "web",
+    "types": [
+        {
+            "id": "StyleSheetId",
+            "type": "string"
+        },
+        {
+            "id": "CSSStyleId",
+            "type": "object",
+            "properties": [
+                { "name": "styleSheetId", "$ref": "StyleSheetId", "description": "Enclosing stylesheet identifier." },
+                { "name": "ordinal", "type": "integer", "description": "The style ordinal within the stylesheet." }
+            ],
+            "description": "This object identifies a CSS style in a unique way."
+        },
+        {
+            "id": "StyleSheetOrigin",
+            "type": "string",
+            "enum": ["user", "user-agent", "inspector", "regular"],
+            "description": "Stylesheet type: \"user\" for user stylesheets, \"user-agent\" for user-agent stylesheets, \"inspector\" for stylesheets created by the inspector (i.e. those holding the \"via inspector\" rules), \"regular\" for regular stylesheets."
+        },
+        {
+            "id": "CSSRuleId",
+            "type": "object",
+            "properties": [
+                { "name": "styleSheetId", "$ref": "StyleSheetId", "description": "Enclosing stylesheet identifier." },
+                { "name": "ordinal", "type": "integer", "description": "The rule ordinal within the stylesheet." }
+            ],
+            "description": "This object identifies a CSS rule in a unique way."
+        },
+        {
+            "id": "PseudoIdMatches",
+            "type": "object",
+            "properties": [
+                { "name": "pseudoId", "type": "integer", "description": "Pseudo style identifier (see <code>enum PseudoId</code> in <code>RenderStyleConstants.h</code>)."},
+                { "name": "matches", "type": "array", "items": { "$ref": "RuleMatch" }, "description": "Matches of CSS rules applicable to the pseudo style."}
+            ],
+            "description": "CSS rule collection for a single pseudo style."
+        },
+        {
+            "id": "InheritedStyleEntry",
+            "type": "object",
+            "properties": [
+                { "name": "inlineStyle", "$ref": "CSSStyle", "optional": true, "description": "The ancestor node's inline style, if any, in the style inheritance chain." },
+                { "name": "matchedCSSRules", "type": "array", "items": { "$ref": "RuleMatch" }, "description": "Matches of CSS rules matching the ancestor node in the style inheritance chain." }
+            ],
+            "description": "CSS rule collection for a single pseudo style."
+        },
+        {
+            "id": "RuleMatch",
+            "type": "object",
+            "properties": [
+                { "name": "rule", "$ref": "CSSRule", "description": "CSS rule in the match." },
+                { "name": "matchingSelectors", "type": "array", "items": { "type": "integer" }, "description": "Matching selector indices in the rule's selectorList selectors (0-based)." }
+            ],
+            "description": "Match data for a CSS rule."
+        },
+        {
+            "id": "CSSSelector",
+            "type": "object",
+            "properties": [
+                { "name": "text", "type": "string", "description": "Canonicalized selector text." },
+                { "name": "specificity", "optional": true, "type": "array", "items": { "type": "integer" }, "description": "Specificity (a, b, c) tuple. Included if the selector is sent in response to CSS.getMatchedStylesForNode which provides a context element." },
+                { "name": "dynamic", "optional": true, "type": "boolean", "description": "Whether or not the specificity can be dynamic. Included if the selector is sent in response to CSS.getMatchedStylesForNode which provides a context element." }
+            ],
+            "description": "CSS selector."
+        },
+        {
+            "id": "SelectorList",
+            "type": "object",
+            "properties": [
+                { "name": "selectors", "type": "array", "items": { "$ref": "CSSSelector" }, "description": "Selectors in the list." },
+                { "name": "text", "type": "string", "description": "Rule selector text." },
+                { "name": "range", "$ref": "SourceRange", "optional": true, "description": "Rule selector range in the underlying resource (if available)." }
+            ],
+            "description": "Selector list data."
+        },
+        {
+            "id": "CSSStyleAttribute",
+            "type": "object",
+            "properties": [
+                { "name": "name", "type": "string", "description": "DOM attribute name (e.g. \"width\")."},
+                { "name": "style", "$ref": "CSSStyle", "description": "CSS style generated by the respective DOM attribute."}
+            ],
+            "description": "CSS style information for a DOM style attribute."
+        },
+        {
+            "id": "CSSStyleSheetHeader",
+            "type": "object",
+            "properties": [
+                { "name": "styleSheetId", "$ref": "StyleSheetId", "description": "The stylesheet identifier."},
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Owner frame identifier."},
+                { "name": "sourceURL", "type": "string", "description": "Stylesheet resource URL."},
+                { "name": "origin", "$ref": "StyleSheetOrigin", "description": "Stylesheet origin."},
+                { "name": "title", "type": "string", "description": "Stylesheet title."},
+                { "name": "disabled", "type": "boolean", "description": "Denotes whether the stylesheet is disabled."}
+            ],
+            "description": "CSS stylesheet metainformation."
+        },
+        {
+            "id": "CSSStyleSheetBody",
+            "type": "object",
+            "properties": [
+                { "name": "styleSheetId", "$ref": "StyleSheetId", "description": "The stylesheet identifier."},
+                { "name": "rules", "type": "array", "items": { "$ref": "CSSRule" }, "description": "Stylesheet resource URL."},
+                { "name": "text", "type": "string", "optional": true, "description": "Stylesheet resource contents (if available)."}
+            ],
+            "description": "CSS stylesheet contents."
+        },
+        {
+            "id": "CSSRule",
+            "type": "object",
+            "properties": [
+                { "name": "ruleId", "$ref": "CSSRuleId", "optional": true, "description": "The CSS rule identifier (absent for user agent stylesheet and user-specified stylesheet rules)."},
+                { "name": "selectorList", "$ref": "SelectorList", "description": "Rule selector data." },
+                { "name": "sourceURL", "type": "string", "optional": true, "description": "Parent stylesheet resource URL (for regular rules)."},
+                { "name": "sourceLine", "type": "integer", "description": "Line ordinal of the rule selector start character in the resource."},
+                { "name": "origin", "$ref": "StyleSheetOrigin", "description": "Parent stylesheet's origin."},
+                { "name": "style", "$ref": "CSSStyle", "description": "Associated style declaration." },
+                { "name": "media", "type": "array", "items": { "$ref": "CSSMedia" }, "optional": true, "description": "Media list array (for rules involving media queries). The array enumerates media queries starting with the innermost one, going outwards." }
+            ],
+            "description": "CSS rule representation."
+        },
+        {
+            "id": "SourceRange",
+            "type": "object",
+            "properties": [
+                { "name": "startLine", "type": "integer", "description": "Start line of range." },
+                { "name": "startColumn", "type": "integer", "description": "Start column of range (inclusive)." },
+                { "name": "endLine", "type": "integer", "description": "End line of range" },
+                { "name": "endColumn", "type": "integer", "description": "End column of range (exclusive)." }
+            ],
+            "description": "Text range within a resource."
+        },
+        {
+            "id": "ShorthandEntry",
+            "type": "object",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Shorthand name." },
+                { "name": "value", "type": "string", "description": "Shorthand value." }
+            ]
+        },
+        {
+            "id": "CSSPropertyInfo",
+            "type": "object",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Property name." },
+                { "name": "longhands", "type": "array", "optional": true, "items": { "type": "string" }, "description": "Longhand property names." },
+                { "name": "values", "type": "array", "optional": true, "items": { "type": "string" }, "description": "Supported values for this property." }
+            ]
+        },
+        {
+            "id": "CSSComputedStyleProperty",
+            "type": "object",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Computed style property name." },
+                { "name": "value", "type": "string", "description": "Computed style property value." }
+            ]
+        },
+        {
+            "id": "CSSStyle",
+            "type": "object",
+            "properties": [
+                { "name": "styleId", "$ref": "CSSStyleId", "optional": true, "description": "The CSS style identifier (absent for attribute styles)." },
+                { "name": "cssProperties", "type": "array", "items": { "$ref": "CSSProperty" }, "description": "CSS properties in the style." },
+                { "name": "shorthandEntries", "type": "array", "items": { "$ref": "ShorthandEntry" }, "description": "Computed values for all shorthands found in the style." },
+                { "name": "cssText", "type": "string", "optional": true, "description": "Style declaration text (if available)." },
+                { "name": "range", "$ref": "SourceRange", "optional": true, "description": "Style declaration range in the enclosing stylesheet (if available)." },
+                { "name": "width", "type": "string", "optional": true, "description": "The effective \"width\" property value from this style." },
+                { "name": "height", "type": "string", "optional": true, "description": "The effective \"height\" property value from this style." }
+            ],
+            "description": "CSS style representation."
+        },
+        {
+            "id": "CSSPropertyStatus",
+	    "type": "string",
+            "enum": ["active", "inactive", "disabled", "style"],
+            "description": "The property status: \"active\" if the property is effective in the style, \"inactive\" if the property is overridden by a same-named property in this style later on, \"disabled\" if the property is disabled by the user, \"style\" (implied if absent) if the property is reported by the browser rather than by the CSS source parser."
+        },
+        {
+            "id": "CSSProperty",
+            "type": "object",
+            "properties": [
+                { "name": "name", "type": "string", "description": "The property name." },
+                { "name": "value", "type": "string", "description": "The property value." },
+                { "name": "priority", "type": "string", "optional": true, "description": "The property priority (implies \"\" if absent)." },
+                { "name": "implicit", "type": "boolean", "optional": true, "description": "Whether the property is implicit (implies <code>false</code> if absent)." },
+                { "name": "text", "type": "string", "optional": true, "description": "The full property text as specified in the style." },
+                { "name": "parsedOk", "type": "boolean", "optional": true, "description": "Whether the property is understood by the browser (implies <code>true</code> if absent)." },
+                { "name": "status", "$ref": "CSSPropertyStatus", "optional": true, "description": "Whether the property is active or disabled." },
+                { "name": "range", "$ref": "SourceRange", "optional": true, "description": "The entire property range in the enclosing style declaration (if available)." }
+            ],
+            "description": "CSS style effective visual dimensions and source offsets."
+        },
+        {
+            "id": "CSSMedia",
+            "type": "object",
+            "properties": [
+                { "name": "text", "type": "string", "description": "Media query text." },
+                { "name": "source", "type": "string", "enum": ["mediaRule", "importRule", "linkedSheet", "inlineSheet"], "description": "Source of the media query: \"mediaRule\" if specified by a @media rule, \"importRule\" if specified by an @import rule, \"linkedSheet\" if specified by a \"media\" attribute in a linked stylesheet's LINK tag, \"inlineSheet\" if specified by a \"media\" attribute in an inline stylesheet's STYLE tag." },
+                { "name": "sourceURL", "type": "string", "optional": true, "description": "URL of the document containing the media query description." },
+                { "name": "sourceLine", "type": "integer", "optional": true, "description": "Line in the document containing the media query (not defined for the \"stylesheet\" source)." }
+            ],
+            "description": "CSS media query descriptor."
+        },
+        {
+            "id": "Region",
+            "type": "object",
+            "properties": [
+                { "name": "regionOverset", "type": "string", "enum": ["overset", "fit", "empty"], "description": "The \"overset\" attribute of a Named Flow." },
+                { "name": "nodeId", "$ref": "DOM.NodeId", "description": "The corresponding DOM node id." }
+            ],
+            "description": "This object represents a region that flows from a Named Flow."
+        },
+        {
+            "id": "NamedFlow",
+            "type": "object",
+            "properties": [
+                { "name": "documentNodeId", "$ref": "DOM.NodeId", "description": "The document node id." },
+                { "name": "name", "type": "string", "description": "Named Flow identifier." },
+                { "name": "overset", "type": "boolean", "description": "The \"overset\" attribute of a Named Flow." },
+                { "name": "content", "type": "array", "items": { "$ref": "DOM.NodeId" }, "description": "An array of nodes that flow into the Named Flow." },
+                { "name": "regions", "type": "array", "items": { "$ref": "Region" }, "description": "An array of regions associated with the Named Flow." }
+            ],
+            "description": "This object represents a Named Flow."
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables the CSS agent for the given page. Clients should not assume that the CSS agent has been enabled until the result of this command is received."
+        },
+        {
+            "name": "disable",
+            "description": "Disables the CSS agent for the given page."
+        },
+        {
+            "name": "getMatchedStylesForNode",
+            "parameters": [
+                { "name": "nodeId", "$ref": "DOM.NodeId" },
+                { "name": "includePseudo", "type": "boolean", "optional": true, "description": "Whether to include pseudo styles (default: true)." },
+                { "name": "includeInherited", "type": "boolean", "optional": true, "description": "Whether to include inherited styles (default: true)." }
+            ],
+            "returns": [
+                { "name": "matchedCSSRules", "type": "array", "items": { "$ref": "RuleMatch" }, "optional": true, "description": "CSS rules matching this node, from all applicable stylesheets." },
+                { "name": "pseudoElements", "type": "array", "items": { "$ref": "PseudoIdMatches" }, "optional": true, "description": "Pseudo style matches for this node." },
+                { "name": "inherited", "type": "array", "items": { "$ref": "InheritedStyleEntry" }, "optional": true, "description": "A chain of inherited styles (from the immediate node parent up to the DOM tree root)." }
+            ],
+            "description": "Returns requested styles for a DOM node identified by <code>nodeId</code>."
+        },
+        {
+            "name": "getInlineStylesForNode",
+            "parameters": [
+                { "name": "nodeId", "$ref": "DOM.NodeId" }
+            ],
+            "returns": [
+                { "name": "inlineStyle", "$ref": "CSSStyle", "optional": true, "description": "Inline style for the specified DOM node." },
+                { "name": "attributesStyle", "$ref": "CSSStyle", "optional": true, "description": "Attribute-defined element style (e.g. resulting from \"width=20 height=100%\")."}
+            ],
+            "description": "Returns the styles defined inline (explicitly in the \"style\" attribute and implicitly, using DOM attributes) for a DOM node identified by <code>nodeId</code>."
+        },
+        {
+            "name": "getComputedStyleForNode",
+            "parameters": [
+                { "name": "nodeId", "$ref": "DOM.NodeId" }
+            ],
+            "returns": [
+                { "name": "computedStyle", "type": "array", "items": { "$ref": "CSSComputedStyleProperty" }, "description": "Computed style for the specified DOM node." }
+            ],
+            "description": "Returns the computed style for a DOM node identified by <code>nodeId</code>."
+        },
+        {
+            "name": "getAllStyleSheets",
+            "returns": [
+                { "name": "headers", "type": "array", "items": { "$ref": "CSSStyleSheetHeader" }, "description": "Descriptor entries for all available stylesheets." }
+            ],
+            "description": "Returns metainfo entries for all known stylesheets."
+        },
+        {
+            "name": "getStyleSheet",
+            "parameters": [
+                { "name": "styleSheetId", "$ref": "StyleSheetId" }
+            ],
+            "returns": [
+                { "name": "styleSheet", "$ref": "CSSStyleSheetBody", "description": "Stylesheet contents for the specified <code>styleSheetId</code>." }
+            ],
+            "description": "Returns stylesheet data for the specified <code>styleSheetId</code>."
+        },
+        {
+            "name": "getStyleSheetText",
+            "parameters": [
+                { "name": "styleSheetId", "$ref": "StyleSheetId" }
+            ],
+            "returns": [
+                { "name": "text", "type": "string", "description": "The stylesheet text." }
+            ],
+            "description": "Returns the current textual content and the URL for a stylesheet."
+        },
+        {
+            "name": "setStyleSheetText",
+            "parameters": [
+                { "name": "styleSheetId", "$ref": "StyleSheetId" },
+                { "name": "text", "type": "string" }
+            ],
+            "description": "Sets the new stylesheet text, thereby invalidating all existing <code>CSSStyleId</code>'s and <code>CSSRuleId</code>'s contained by this stylesheet."
+        },
+        {
+            "name": "setStyleText",
+            "parameters": [
+                { "name": "styleId", "$ref": "CSSStyleId" },
+                { "name": "text", "type": "string" }
+            ],
+            "returns": [
+                { "name": "style", "$ref": "CSSStyle", "description": "The resulting style after the text modification." }
+            ],
+            "description": "Sets the new <code>text</code> for the respective style."
+        },
+        {
+            "name": "setRuleSelector",
+            "parameters": [
+                { "name": "ruleId", "$ref": "CSSRuleId" },
+                { "name": "selector", "type": "string" }
+            ],
+            "returns": [
+                { "name": "rule", "$ref": "CSSRule", "description": "The resulting rule after the selector modification." }
+            ],
+            "description": "Modifies the rule selector."
+        },
+        {
+            "name": "addRule",
+            "parameters": [
+                { "name": "contextNodeId", "$ref": "DOM.NodeId" },
+                { "name": "selector", "type": "string" }
+            ],
+            "returns": [
+                { "name": "rule", "$ref": "CSSRule", "description": "The newly created rule." }
+            ],
+            "description": "Creates a new empty rule with the given <code>selector</code> in a special \"inspector\" stylesheet in the owner document of the context node."
+        },
+        {
+            "name": "getSupportedCSSProperties",
+            "returns": [
+                { "name": "cssProperties", "type": "array", "items": { "$ref": "CSSPropertyInfo" }, "description": "Supported property metainfo." }
+            ],
+            "description": "Returns all supported CSS property names."
+        },
+        {
+            "name": "forcePseudoState",
+            "parameters": [
+                { "name": "nodeId", "$ref": "DOM.NodeId", "description": "The element id for which to force the pseudo state." },
+                { "name": "forcedPseudoClasses", "type": "array", "items": { "type": "string", "enum": ["active", "focus", "hover", "visited"] }, "description": "Element pseudo classes to force when computing the element's style." }
+            ],
+            "description": "Ensures that the given node will have specified pseudo-classes whenever its style is computed by the browser."
+        },
+        {
+            "name": "getNamedFlowCollection",
+            "parameters": [
+                { "name": "documentNodeId", "$ref": "DOM.NodeId", "description": "The document node id for which to get the Named Flow Collection." }
+            ],
+            "returns": [
+                { "name": "namedFlows", "type": "array", "items": { "$ref": "NamedFlow" }, "description": "An array containing the Named Flows in the document." }
+            ],
+            "description": "Returns the Named Flows from the document."
+        }
+    ],
+    "events": [
+        {
+            "name": "mediaQueryResultChanged",
+            "description": "Fires whenever a MediaQuery result changes (for example, after a browser window has been resized.) The current implementation considers only viewport-dependent media features."
+        },
+        {
+            "name": "styleSheetChanged",
+            "parameters": [
+                { "name": "styleSheetId", "$ref": "StyleSheetId" }
+            ],
+            "description": "Fired whenever a stylesheet is changed as a result of the client operation."
+        },
+        {
+            "name": "namedFlowCreated",
+            "parameters": [
+                { "name": "namedFlow", "$ref": "NamedFlow", "description": "The new Named Flow." }
+            ],
+            "description": "Fires when a Named Flow is created."
+        },
+        {
+            "name": "namedFlowRemoved",
+            "parameters": [
+                { "name": "documentNodeId", "$ref": "DOM.NodeId", "description": "The document node id." },
+                { "name": "flowName", "type": "string", "description": "Identifier of the removed Named Flow." }
+            ],
+            "description": "Fires when a Named Flow is removed: has no associated content nodes and regions."
+        },
+        {
+            "name": "regionOversetChanged",
+            "parameters": [
+                { "name": "namedFlow", "$ref": "NamedFlow", "description": "The Named Flow containing the regions whose regionOverset values changed." }
+            ],
+            "description": "Fires if any of the regionOverset values changed in a Named Flow's region chain."
+        },
+        {
+            "name": "registeredNamedFlowContentElement",
+            "parameters": [
+                { "name": "documentNodeId", "$ref": "DOM.NodeId", "description": "The document node id." },
+                { "name": "flowName", "type": "string", "description": "Named Flow identifier for which the new content element was registered." },
+                { "name": "contentNodeId", "$ref": "DOM.NodeId", "description": "The node id of the registered content node." },
+                { "name": "nextContentNodeId", "$ref": "DOM.NodeId", "description": "The node id of the element following the registered content node." }
+            ],
+            "description": "Fires when a Named Flow's has been registered with a new content node."
+        },
+        {
+            "name": "unregisteredNamedFlowContentElement",
+            "parameters": [
+                { "name": "documentNodeId", "$ref": "DOM.NodeId", "description": "The document node id." },
+                { "name": "flowName", "type": "string", "description": "Named Flow identifier for which the new content element was unregistered." },
+                { "name": "contentNodeId", "$ref": "DOM.NodeId", "description": "The node id of the unregistered content node." }
+            ],
+            "description": "Fires when a Named Flow's has been registered with a new content node."
+        }
+    ]
+}
+,
+{
+    "domain": "Console",
+    "description": "Console domain defines methods and events for interaction with the JavaScript console. Console collects messages created by means of the <a href='http://getfirebug.com/wiki/index.php/Console_API'>JavaScript Console API</a>. One needs to enable this domain using <code>enable</code> command in order to start receiving the console messages. Browser collects messages issued while console domain is not enabled as well and reports them using <code>messageAdded</code> notification upon enabling.",
+    "types": [
+        {
+            "id": "ConsoleMessage",
+            "type": "object",
+            "description": "Console message.",
+            "properties": [
+                { "name": "source", "type": "string", "enum": ["xml", "javascript", "network", "console-api", "storage", "appcache", "rendering", "css", "security", "content-blocker", "other"], "description": "Message source." },
+                { "name": "level", "type": "string", "enum": ["log", "info", "warning", "error", "debug"], "description": "Message severity." },
+                { "name": "text", "type": "string", "description": "Message text." },
+                { "name": "type", "type": "string", "optional": true, "enum": ["log", "dir", "dirxml", "table", "trace", "clear", "startGroup", "startGroupCollapsed", "endGroup", "assert", "timing", "profile", "profileEnd"], "description": "Console message type." },
+                { "name": "url", "type": "string", "optional": true, "description": "URL of the message origin." },
+                { "name": "line", "type": "integer", "optional": true, "description": "Line number in the resource that generated this message." },
+                { "name": "column", "type": "integer", "optional": true, "description": "Column number on the line in the resource that generated this message." },
+                { "name": "repeatCount", "type": "integer", "optional": true, "description": "Repeat count for repeated messages." },
+                { "name": "parameters", "type": "array", "items": { "$ref": "Runtime.RemoteObject" }, "optional": true, "description": "Message parameters in case of the formatted message." },
+                { "name": "stackTrace", "$ref": "StackTrace", "optional": true, "description": "JavaScript stack trace for assertions and error messages." },
+                { "name": "networkRequestId", "$ref": "Network.RequestId", "optional": true, "description": "Identifier of the network request associated with this message." }
+            ]
+        },
+        {
+            "id": "CallFrame",
+            "type": "object",
+            "description": "Stack entry for console errors and assertions.",
+            "properties": [
+                { "name": "functionName", "type": "string", "description": "JavaScript function name." },
+                { "name": "url", "type": "string", "description": "JavaScript script name or url." },
+                { "name": "lineNumber", "type": "integer", "description": "JavaScript script line number." },
+                { "name": "columnNumber", "type": "integer", "description": "JavaScript script column number." }
+            ]
+        },
+        {
+            "id": "StackTrace",
+            "type": "array",
+            "items": { "$ref": "CallFrame" },
+            "description": "Call frames for assertions or error messages."
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables console domain, sends the messages collected so far to the client by means of the <code>messageAdded</code> notification."
+        },
+        {
+            "name": "disable",
+            "description": "Disables console domain, prevents further console messages from being reported to the client."
+        },
+        {
+            "name": "clearMessages",
+            "description": "Clears console messages collected in the browser."
+        },
+        {
+            "name": "setMonitoringXHREnabled",
+            "parameters": [
+                { "name": "enabled", "type": "boolean", "description": "Monitoring enabled state." }
+            ],
+            "description": "Toggles monitoring of XMLHttpRequest. If <code>true</code>, console will receive messages upon each XHR issued."
+        },
+        {
+            "name": "addInspectedNode",
+            "parameters": [
+                { "name": "nodeId", "$ref": "DOM.NodeId", "description": "DOM node id to be accessible by means of $x command line API." }
+            ],
+            "description": "Enables console to refer to the node with given id via $x (see Command Line API for more details $x functions)."
+        }
+    ],
+    "events": [
+        {
+            "name": "messageAdded",
+            "parameters": [
+                { "name": "message", "$ref": "ConsoleMessage", "description": "Console message that has been added." }
+            ],
+            "description": "Issued when new console message is added."
+        },
+        {
+            "name": "messageRepeatCountUpdated",
+            "parameters": [
+                { "name": "count", "type": "integer", "description": "New repeat count value." }
+            ],
+            "description": "Issued when subsequent message(s) are equal to the previous one(s)."
+        },
+        {
+            "name": "messagesCleared",
+            "description": "Issued when console is cleared. This happens either upon <code>clearMessages</code> command or after page navigation."
+        }
+    ]
+}
+,
+{
+    "domain": "DOM",
+    "description": "This domain exposes DOM read/write operations. Each DOM Node is represented with its mirror object that has an <code>id</code>. This <code>id</code> can be used to get additional information on the Node, resolve it into the JavaScript object wrapper, etc. It is important that client receives DOM events only for the nodes that are known to the client. Backend keeps track of the nodes that were sent to the client and never sends the same node twice. It is client's responsibility to collect information about the nodes that were sent to the client.<p>Note that <code>iframe</code> owner elements will return corresponding document elements as their child nodes.</p>",
+    "availability": "web",
+    "types": [
+        {
+            "id": "NodeId",
+            "type": "integer",
+            "description": "Unique DOM node identifier."
+        },
+        {
+            "id": "BackendNodeId",
+            "type": "integer",
+            "description": "Unique DOM node identifier used to reference a node that may not have been pushed to the front-end."
+        },
+        {
+            "id": "LiveRegionRelevant",
+            "type": "string",
+            "enum": ["additions", "removals", "text"],
+            "description": "Token values of @aria-relevant attribute."
+        },
+        {
+            "id": "Node",
+            "type": "object",
+            "properties": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Node identifier that is passed into the rest of the DOM messages as the <code>nodeId</code>. Backend will only push node with given <code>id</code> once. It is aware of all requested nodes and will only fire DOM events for nodes known to the client." },
+                { "name": "nodeType", "type": "integer", "description": "<code>Node</code>'s nodeType." },
+                { "name": "nodeName", "type": "string", "description": "<code>Node</code>'s nodeName." },
+                { "name": "localName", "type": "string", "description": "<code>Node</code>'s localName." },
+                { "name": "nodeValue", "type": "string", "description": "<code>Node</code>'s nodeValue." },
+                { "name": "childNodeCount", "type": "integer", "optional": true, "description": "Child count for <code>Container</code> nodes." },
+                { "name": "children", "type": "array", "optional": true, "items": { "$ref": "Node" }, "description": "Child nodes of this node when requested with children." },
+                { "name": "attributes", "type": "array", "optional": true, "items": { "type": "string" }, "description": "Attributes of the <code>Element</code> node in the form of flat array <code>[name1, value1, name2, value2]</code>." },
+                { "name": "documentURL", "type": "string", "optional": true, "description": "Document URL that <code>Document</code> or <code>FrameOwner</code> node points to." },
+                { "name": "baseURL", "type": "string", "optional": true, "description": "Base URL that <code>Document</code> or <code>FrameOwner</code> node uses for URL completion." },
+                { "name": "publicId", "type": "string", "optional": true, "description": "<code>DocumentType</code>'s publicId." },
+                { "name": "systemId", "type": "string", "optional": true, "description": "<code>DocumentType</code>'s systemId." },
+                { "name": "internalSubset", "type": "string", "optional": true, "description": "<code>DocumentType</code>'s internalSubset." },
+                { "name": "xmlVersion", "type": "string", "optional": true, "description": "<code>Document</code>'s XML version in case of XML documents." },
+                { "name": "name", "type": "string", "optional": true, "description": "<code>Attr</code>'s name." },
+                { "name": "value", "type": "string", "optional": true, "description": "<code>Attr</code>'s value." },
+                { "name": "frameId", "$ref": "Network.FrameId", "optional": true, "description": "Frame ID for frame owner elements." },
+                { "name": "contentDocument", "$ref": "Node", "optional": true, "description": "Content document for frame owner elements." },
+                { "name": "shadowRoots", "type": "array", "optional": true, "items": { "$ref": "Node" }, "description": "Shadow root list for given element host." },
+                { "name": "templateContent", "$ref": "Node", "optional": true, "description": "Content document fragment for template elements" },
+                { "name": "role", "type": "string", "optional": true, "description": "Computed value for first recognized role token, default role per element, or overridden role." }
+            ],
+            "description": "DOM interaction is implemented in terms of mirror objects that represent the actual DOM nodes. DOMNode is a base node mirror type."
+        },
+        {
+            "id": "EventListener",
+            "type": "object",
+            "properties": [
+                { "name": "type", "type": "string", "description": "<code>EventListener</code>'s type." },
+                { "name": "useCapture", "type": "boolean", "description": "<code>EventListener</code>'s useCapture." },
+                { "name": "isAttribute", "type": "boolean", "description": "<code>EventListener</code>'s isAttribute." },
+                { "name": "nodeId", "$ref": "NodeId", "description": "Target <code>DOMNode</code> id." },
+                { "name": "handlerBody", "type": "string", "description": "Event handler function body." },
+                { "name": "location", "$ref": "Debugger.Location", "optional": true, "description": "Handler code location." },
+                { "name": "sourceName", "type": "string", "optional": true, "description": "Source script URL." },
+                { "name": "handler", "$ref": "Runtime.RemoteObject", "optional": true, "description": "Event handler function value." }
+            ],
+            "description": "A structure holding event listener properties."
+        },
+        {
+            "id": "AccessibilityProperties",
+            "description": "A structure holding accessibility properties.",
+            "type": "object",
+            "properties": [
+                { "name": "activeDescendantNodeId", "$ref": "NodeId", "optional": true, "description": "<code>DOMNode</code> id of the accessibility object referenced by aria-activedescendant." },
+                { "name": "busy", "type": "boolean", "optional": true, "description": "Value of @aria-busy on current or ancestor node." },
+                { "name": "checked", "type": "string", "optional": true, "enum": ["true", "false", "mixed"], "description": "Checked state of certain form controls." },
+                { "name": "childNodeIds", "type": "array", "items": { "$ref": "NodeId" }, "optional": true, "description": "Array of <code>DOMNode</code> ids of the accessibility tree children if available." },
+                { "name": "controlledNodeIds", "type": "array", "items": { "$ref": "NodeId" }, "optional": true, "description": "Array of <code>DOMNode</code> ids of any nodes referenced via @aria-controls." },
+                { "name": "disabled", "type": "boolean", "optional": true, "description": "Disabled state of form controls." },
+                { "name": "exists", "type": "boolean", "description": "Indicates whether there is an existing AX object for the DOM node. If this is false, all the other properties will be default values." },
+                { "name": "expanded", "type": "boolean", "optional": true, "description": "Expanded state." },
+                { "name": "flowedNodeIds", "type": "array", "items": { "$ref": "NodeId" }, "optional": true, "description": "Array of <code>DOMNode</code> ids of any nodes referenced via @aria-flowto." },
+                { "name": "focused", "type": "boolean", "optional": true, "description": "Focused state. Only defined on focusable elements." },
+                { "name": "ignored", "type": "boolean", "optional": true, "description": "Indicates whether the accessibility of the associated AX object node is ignored, whether heuristically or explicitly." },
+                { "name": "ignoredByDefault", "type": "boolean", "optional": true, "description": "State indicating whether the accessibility of the associated AX object node is ignored by default for node type." },
+                { "name": "invalid", "type": "string", "optional": true, "enum": ["true", "false", "grammar", "spelling"], "description": "Invalid status of form controls." },
+                { "name": "hidden", "type": "boolean", "optional": true, "description": "Hidden state. True if node or an ancestor is hidden via CSS or explicit @aria-hidden, to clarify why the element is ignored." },
+                { "name": "label", "type": "string", "description": "Computed label value for the node, sometimes calculated by referencing other nodes." },
+                { "name": "liveRegionAtomic", "type": "boolean", "optional": true, "description": "Value of @aria-atomic." },
+                { "name": "liveRegionRelevant", "type": "array", "items": { "type": "string" }, "optional": true, "description": "Token value(s) of element's @aria-relevant attribute. Array of string values matching $ref LiveRegionRelevant. FIXME: Enum values blocked by http://webkit.org/b/133711" },
+                { "name": "liveRegionStatus", "type": "string", "optional": true, "enum": ["assertive", "polite", "off"], "description": "Value of element's @aria-live attribute." },
+                { "name": "mouseEventNodeId", "$ref": "NodeId", "optional": true, "description": "<code>DOMNode</code> id of node or closest ancestor node that has a mousedown, mouseup, or click event handler." },
+                { "name": "nodeId", "$ref": "NodeId", "description": "Target <code>DOMNode</code> id." },
+                { "name": "ownedNodeIds", "type": "array", "items": { "$ref": "NodeId" }, "optional": true, "description": "Array of <code>DOMNode</code> ids of any nodes referenced via @aria-owns." },
+                { "name": "parentNodeId", "$ref": "NodeId", "optional": true, "description": "<code>DOMNode</code> id of the accessibility tree parent object if available." },
+                { "name": "pressed", "type": "boolean", "optional": true, "description": "Pressed state for toggle buttons." },
+                { "name": "readonly", "type": "boolean", "optional": true, "description": "Readonly state of text controls." },
+                { "name": "required", "type": "boolean", "optional": true, "description": "Required state of form controls." },
+                { "name": "role", "type": "string", "description": "Computed value for first recognized role token, default role per element, or overridden role." },
+                { "name": "selected", "type": "boolean", "optional": true, "description": "Selected state of certain form controls." },
+                { "name": "selectedChildNodeIds", "type": "array", "items": { "$ref": "NodeId" }, "optional": true, "description": "Array of <code>DOMNode</code> ids of any children marked as selected." }
+            ]
+        },
+        {
+            "id": "RGBAColor",
+            "type": "object",
+            "properties": [
+                { "name": "r", "type": "integer", "description": "The red component, in the [0-255] range." },
+                { "name": "g", "type": "integer", "description": "The green component, in the [0-255] range." },
+                { "name": "b", "type": "integer", "description": "The blue component, in the [0-255] range." },
+                { "name": "a", "type": "number", "optional": true, "description": "The alpha component, in the [0-1] range (default: 1)." }
+            ],
+            "description": "A structure holding an RGBA color."
+        },
+        {
+            "id": "Quad",
+            "type": "array",
+            "items": { "type": "number" },
+            "minItems": 8,
+            "maxItems": 8,
+            "description": "An array of quad vertices, x immediately followed by y for each point, points clock-wise."
+        },
+        {
+            "id": "HighlightConfig",
+            "type": "object",
+            "properties": [
+                { "name": "showInfo", "type": "boolean", "optional": true, "description": "Whether the node info tooltip should be shown (default: false)." },
+                { "name": "contentColor", "$ref": "RGBAColor", "optional": true, "description": "The content box highlight fill color (default: transparent)." },
+                { "name": "paddingColor", "$ref": "RGBAColor", "optional": true, "description": "The padding highlight fill color (default: transparent)." },
+                { "name": "borderColor", "$ref": "RGBAColor", "optional": true, "description": "The border highlight fill color (default: transparent)." },
+                { "name": "marginColor", "$ref": "RGBAColor", "optional": true, "description": "The margin highlight fill color (default: transparent)." }
+            ],
+            "description": "Configuration data for the highlighting of page elements."
+        }
+    ],
+    "commands": [
+        {
+            "name": "getDocument",
+            "returns": [
+                { "name": "root", "$ref": "Node", "description": "Resulting node." }
+            ],
+            "description": "Returns the root DOM node to the caller."
+        },
+        {
+            "name": "requestChildNodes",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to get children for." },
+                { "name": "depth", "type": "integer", "optional": true, "description": "The maximum depth at which children should be retrieved, defaults to 1. Use -1 for the entire subtree or provide an integer larger than 0." }
+            ],
+            "description": "Requests that children of the node with given id are returned to the caller in form of <code>setChildNodes</code> events where not only immediate children are retrieved, but all children down to the specified depth."
+        },
+        {
+            "name": "querySelector",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to query upon." },
+                { "name": "selector", "type": "string", "description": "Selector string." }
+            ],
+            "returns": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Query selector result." }
+            ],
+            "description": "Executes <code>querySelector</code> on a given node."
+        },
+        {
+            "name": "querySelectorAll",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to query upon." },
+                { "name": "selector", "type": "string", "description": "Selector string." }
+            ],
+            "returns": [
+                { "name": "nodeIds", "type": "array", "items": { "$ref": "NodeId" }, "description": "Query selector result." }
+            ],
+            "description": "Executes <code>querySelectorAll</code> on a given node."
+        },
+        {
+            "name": "setNodeName",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to set name for." },
+                { "name": "name", "type": "string", "description": "New node's name." }
+            ],
+            "returns": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "New node's id." }
+            ],
+            "description": "Sets node name for a node with given id."
+        },
+        {
+            "name": "setNodeValue",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to set value for." },
+                { "name": "value", "type": "string", "description": "New node's value." }
+            ],
+            "description": "Sets node value for a node with given id."
+        },
+        {
+            "name": "removeNode",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to remove." }
+            ],
+            "description": "Removes node with given id."
+        },
+        {
+            "name": "setAttributeValue",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the element to set attribute for." },
+                { "name": "name", "type": "string", "description": "Attribute name." },
+                { "name": "value", "type": "string", "description": "Attribute value." }
+            ],
+            "description": "Sets attribute for an element with given id."
+        },
+        {
+            "name": "setAttributesAsText",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the element to set attributes for." },
+                { "name": "text", "type": "string", "description": "Text with a number of attributes. Will parse this text using HTML parser." },
+                { "name": "name", "type": "string", "optional": true, "description": "Attribute name to replace with new attributes derived from text in case text parsed successfully." }
+            ],
+            "description": "Sets attributes on element with given id. This method is useful when user edits some existing attribute value and types in several attribute name/value pairs."
+        },
+        {
+            "name": "removeAttribute",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the element to remove attribute from." },
+                { "name": "name", "type": "string", "description": "Name of the attribute to remove." }
+            ],
+            "description": "Removes attribute with given name from an element with given id."
+        },
+        {
+            "name": "getEventListenersForNode",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to get listeners for." },
+                { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name for handler value. Handler value is not returned without this parameter specified." }
+            ],
+            "returns": [
+                { "name": "listeners", "type": "array", "items": { "$ref": "EventListener"}, "description": "Array of relevant listeners." }
+            ],
+            "description": "Returns event listeners relevant to the node."
+        },
+        {
+            "name": "getAccessibilityPropertiesForNode",
+            "description": "Returns a dictionary of accessibility properties for the node.",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node for which to get accessibility properties." }
+            ],
+            "returns": [
+                { "name": "properties", "$ref": "AccessibilityProperties", "description": "Dictionary of relevant accessibility properties." }
+            ]
+        },
+        {
+            "name": "getOuterHTML",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to get markup for." }
+            ],
+            "returns": [
+                { "name": "outerHTML", "type": "string", "description": "Outer HTML markup." }
+            ],
+            "description": "Returns node's HTML markup."
+        },
+        {
+            "name": "setOuterHTML",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to set markup for." },
+                { "name": "outerHTML", "type": "string", "description": "Outer HTML markup to set." }
+            ],
+            "description": "Sets node HTML markup, returns new node id."
+        },
+        {
+            "name": "performSearch",
+            "parameters": [
+                { "name": "query", "type": "string", "description": "Plain text or query selector or XPath search query." },
+                { "name": "nodeIds", "type": "array", "items": { "$ref": "NodeId" }, "optional": true, "description": "Ids of nodes to use as starting points for the search." }
+            ],
+            "returns": [
+                { "name": "searchId", "type": "string", "description": "Unique search session identifier." },
+                { "name": "resultCount", "type": "integer", "description": "Number of search results." }
+            ],
+            "description": "Searches for a given string in the DOM tree. Use <code>getSearchResults</code> to access search results or <code>cancelSearch</code> to end this search session."
+        },
+        {
+            "name": "getSearchResults",
+            "parameters": [
+                { "name": "searchId", "type": "string", "description": "Unique search session identifier." },
+                { "name": "fromIndex", "type": "integer", "description": "Start index of the search result to be returned." },
+                { "name": "toIndex", "type": "integer", "description": "End index of the search result to be returned." }
+            ],
+            "returns": [
+                { "name": "nodeIds", "type": "array", "items": { "$ref": "NodeId" }, "description": "Ids of the search result nodes." }
+            ],
+            "description": "Returns search results from given <code>fromIndex</code> to given <code>toIndex</code> from the sarch with the given identifier."
+        },
+        {
+            "name": "discardSearchResults",
+            "parameters": [
+                { "name": "searchId", "type": "string", "description": "Unique search session identifier." }
+            ],
+            "description": "Discards search results from the session with the given id. <code>getSearchResults</code> should no longer be called for that search."
+        },
+        {
+            "name": "requestNode",
+            "parameters": [
+                { "name": "objectId", "$ref": "Runtime.RemoteObjectId", "description": "JavaScript object id to convert into node." }
+            ],
+            "returns": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Node id for given object." }
+            ],
+            "description": "Requests that the node is sent to the caller given the JavaScript node object reference. All nodes that form the path from the node to the root are also sent to the client as a series of <code>setChildNodes</code> notifications."
+        },
+        {
+            "name": "setInspectModeEnabled",
+            "parameters": [
+                { "name": "enabled", "type": "boolean", "description": "True to enable inspection mode, false to disable it." },
+                { "name": "highlightConfig", "$ref": "HighlightConfig", "optional": true, "description": "A descriptor for the highlight appearance of hovered-over nodes. May be omitted if <code>enabled == false</code>." }
+            ],
+            "description": "Enters the 'inspect' mode. In this mode, elements that user is hovering over are highlighted. Backend then generates 'inspect' command upon element selection."
+        },
+        {
+            "name": "highlightRect",
+            "parameters": [
+                { "name": "x", "type": "integer", "description": "X coordinate" },
+                { "name": "y", "type": "integer", "description": "Y coordinate" },
+                { "name": "width", "type": "integer", "description": "Rectangle width" },
+                { "name": "height", "type": "integer", "description": "Rectangle height" },
+                { "name": "color", "$ref": "RGBAColor", "optional": true, "description": "The highlight fill color (default: transparent)." },
+                { "name": "outlineColor", "$ref": "RGBAColor", "optional": true, "description": "The highlight outline color (default: transparent)." },
+                { "name": "usePageCoordinates", "type": "boolean", "optional": true, "description": "Indicates whether the provided parameters are in page coordinates or in viewport coordinates (the default)." }
+            ],
+            "description": "Highlights given rectangle. Coordinates are absolute with respect to the main frame viewport."
+        },
+        {
+            "name": "highlightQuad",
+            "parameters": [
+                { "name": "quad", "$ref": "Quad", "description": "Quad to highlight" },
+                { "name": "color", "$ref": "RGBAColor", "optional": true, "description": "The highlight fill color (default: transparent)." },
+                { "name": "outlineColor", "$ref": "RGBAColor", "optional": true, "description": "The highlight outline color (default: transparent)." },
+                { "name": "usePageCoordinates", "type": "boolean", "optional": true, "description": "Indicates whether the provided parameters are in page coordinates or in viewport coordinates (the default)." }
+            ],
+            "description": "Highlights given quad. Coordinates are absolute with respect to the main frame viewport."
+        },
+        {
+            "name": "highlightSelector",
+            "parameters": [
+                { "name": "highlightConfig", "$ref": "HighlightConfig", "description": "A descriptor for the highlight appearance." },
+                { "name": "selectorString", "type": "string", "description": "A CSS selector for finding matching nodes to highlight." },
+                { "name": "frameId", "type": "string", "optional": true, "description": "Identifier of the frame which will be searched using the selector.  If not provided, the main frame will be used." }
+            ],
+            "description": "Highlights all DOM nodes that match a given selector. A string containing a CSS selector must be specified."
+        },
+        {
+            "name": "highlightNode",
+            "parameters": [
+                { "name": "highlightConfig", "$ref": "HighlightConfig", "description": "A descriptor for the highlight appearance." },
+                { "name": "nodeId", "$ref": "NodeId", "optional": true, "description": "Identifier of the node to highlight." },
+                { "name": "objectId", "$ref": "Runtime.RemoteObjectId", "optional": true, "description": "JavaScript object id of the node to be highlighted." }
+            ],
+            "description": "Highlights DOM node with given id or with the given JavaScript object wrapper. Either nodeId or objectId must be specified."
+        },
+        {
+            "name": "hideHighlight",
+            "description": "Hides DOM node highlight."
+        },
+        {
+            "name": "highlightFrame",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Identifier of the frame to highlight." },
+                { "name": "contentColor", "$ref": "RGBAColor", "optional": true, "description": "The content box highlight fill color (default: transparent)." },
+                { "name": "contentOutlineColor", "$ref": "RGBAColor", "optional": true, "description": "The content box highlight outline color (default: transparent)." }
+            ],
+            "description": "Highlights owner element of the frame with given id."
+        },
+        {
+            "name": "pushNodeByPathToFrontend",
+            "parameters": [
+                { "name": "path", "type": "string", "description": "Path to node in the proprietary format." }
+            ],
+            "returns": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node for given path." }
+            ],
+            "description": "Requests that the node is sent to the caller given its path. // FIXME, use XPath"
+        },
+        {
+            "name": "pushNodeByBackendIdToFrontend",
+            "parameters": [
+                { "name": "backendNodeId", "$ref": "BackendNodeId", "description": "The backend node id of the node." }
+            ],
+            "returns": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "The pushed node's id." }
+            ],
+            "description": "Requests that the node is sent to the caller given its backend node id."
+        },
+        {
+            "name": "releaseBackendNodeIds",
+            "parameters": [
+                { "name": "nodeGroup", "type": "string", "description": "The backend node ids group name." }
+            ],
+            "description": "Requests that group of <code>BackendNodeIds</code> is released."
+        },
+        {
+            "name": "resolveNode",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to resolve." },
+                { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." }
+            ],
+            "returns": [
+                { "name": "object", "$ref": "Runtime.RemoteObject", "description": "JavaScript object wrapper for given node." }
+            ],
+            "description": "Resolves JavaScript node object for given node id."
+        },
+        {
+            "name": "getAttributes",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to retrieve attibutes for." }
+            ],
+            "returns": [
+                { "name": "attributes", "type": "array", "items": { "type": "string" }, "description": "An interleaved array of node attribute names and values." }
+            ],
+            "description": "Returns attributes for the specified node."
+        },
+        {
+            "name": "moveTo",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to drop." },
+                { "name": "targetNodeId", "$ref": "NodeId", "description": "Id of the element to drop into." },
+                { "name": "insertBeforeNodeId", "$ref": "NodeId", "optional": true, "description": "Drop node before given one." }
+            ],
+            "returns": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "New id of the moved node." }
+            ],
+            "description": "Moves node into the new container, places it before the given anchor."
+        },
+        {
+            "name": "undo",
+            "description": "Undoes the last performed action."
+        },
+        {
+            "name": "redo",
+            "description": "Re-does the last undone action."
+        },
+        {
+            "name": "markUndoableState",
+            "description": "Marks last undoable state."
+        },
+        {
+            "name": "focus",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to focus." }
+            ],
+            "description": "Focuses the given element."
+        }
+    ],
+    "events": [
+        {
+            "name": "documentUpdated",
+            "description": "Fired when <code>Document</code> has been totally updated. Node ids are no longer valid."
+        },
+        {
+            "name": "setChildNodes",
+            "parameters": [
+                { "name": "parentId", "$ref": "NodeId", "description": "Parent node id to populate with children." },
+                { "name": "nodes", "type": "array", "items": { "$ref": "Node"}, "description": "Child nodes array." }
+            ],
+            "description": "Fired when backend wants to provide client with the missing DOM structure. This happens upon most of the calls requesting node ids."
+        },
+        {
+            "name": "attributeModified",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                { "name": "name", "type": "string", "description": "Attribute name." },
+                { "name": "value", "type": "string", "description": "Attribute value." }
+            ],
+            "description": "Fired when <code>Element</code>'s attribute is modified."
+        },
+        {
+            "name": "attributeRemoved",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                { "name": "name", "type": "string", "description": "A ttribute name." }
+            ],
+            "description": "Fired when <code>Element</code>'s attribute is removed."
+        },
+        {
+            "name": "inlineStyleInvalidated",
+            "parameters": [
+                { "name": "nodeIds", "type": "array", "items": { "$ref": "NodeId" }, "description": "Ids of the nodes for which the inline styles have been invalidated." }
+            ],
+            "description": "Fired when <code>Element</code>'s inline style is modified via a CSS property modification."
+        },
+        {
+            "name": "characterDataModified",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                { "name": "characterData", "type": "string", "description": "New text value." }
+            ],
+            "description": "Mirrors <code>DOMCharacterDataModified</code> event."
+        },
+        {
+            "name": "childNodeCountUpdated",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                { "name": "childNodeCount", "type": "integer", "description": "New node count." }
+            ],
+            "description": "Fired when <code>Container</code>'s child node count has changed."
+        },
+        {
+            "name": "childNodeInserted",
+            "parameters": [
+                { "name": "parentNodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                { "name": "previousNodeId", "$ref": "NodeId", "description": "If of the previous siblint." },
+                { "name": "node", "$ref": "Node", "description": "Inserted node data." }
+            ],
+            "description": "Mirrors <code>DOMNodeInserted</code> event."
+        },
+        {
+            "name": "childNodeRemoved",
+            "parameters": [
+                { "name": "parentNodeId", "$ref": "NodeId", "description": "Parent id." },
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has been removed." }
+            ],
+            "description": "Mirrors <code>DOMNodeRemoved</code> event."
+        },
+        {
+            "name": "shadowRootPushed",
+            "parameters": [
+                { "name": "hostId", "$ref": "NodeId", "description": "Host element id." },
+                { "name": "root", "$ref": "Node", "description": "Shadow root." }
+            ],
+            "description": "Called when shadow root is pushed into the element."
+        },
+        {
+            "name": "shadowRootPopped",
+            "parameters": [
+                { "name": "hostId", "$ref": "NodeId", "description": "Host element id." },
+                { "name": "rootId", "$ref": "NodeId", "description": "Shadow root id." }
+            ],
+            "description": "Called when shadow root is popped from the element."
+        }
+    ]
+}
+,
+{
+    "domain": "DOMDebugger",
+    "description": "DOM debugging allows setting breakpoints on particular DOM operations and events. JavaScript execution will stop on these operations as if there was a regular breakpoint set.",
+    "availability": "web",
+    "types": [
+        {
+            "id": "DOMBreakpointType",
+            "type": "string",
+            "enum": ["subtree-modified", "attribute-modified", "node-removed"],
+            "description": "DOM breakpoint type."
+        }
+    ],
+    "commands": [
+        {
+            "name": "setDOMBreakpoint",
+            "parameters": [
+                { "name": "nodeId", "$ref": "DOM.NodeId", "description": "Identifier of the node to set breakpoint on." },
+                { "name": "type", "$ref": "DOMBreakpointType", "description": "Type of the operation to stop upon." }
+            ],
+            "description": "Sets breakpoint on particular operation with DOM."
+        },
+        {
+            "name": "removeDOMBreakpoint",
+            "parameters": [
+                { "name": "nodeId", "$ref": "DOM.NodeId", "description": "Identifier of the node to remove breakpoint from." },
+                { "name": "type", "$ref": "DOMBreakpointType", "description": "Type of the breakpoint to remove." }
+            ],
+            "description": "Removes DOM breakpoint that was set using <code>setDOMBreakpoint</code>."
+        },
+        {
+            "name": "setEventListenerBreakpoint",
+            "parameters": [
+                { "name": "eventName", "type": "string", "description": "DOM Event name to stop on (any DOM event will do)." }
+            ],
+            "description": "Sets breakpoint on particular DOM event."
+        },
+        {
+            "name": "removeEventListenerBreakpoint",
+            "parameters": [
+                { "name": "eventName", "type": "string", "description": "Event name." }
+            ],
+            "description": "Removes breakpoint on particular DOM event."
+        },
+        {
+            "name": "setInstrumentationBreakpoint",
+            "parameters": [
+                { "name": "eventName", "type": "string", "description": "Instrumentation name to stop on." }
+            ],
+            "description": "Sets breakpoint on particular native event."
+        },
+        {
+            "name": "removeInstrumentationBreakpoint",
+            "parameters": [
+                { "name": "eventName", "type": "string", "description": "Instrumentation name to stop on." }
+            ],
+            "description": "Sets breakpoint on particular native event."
+        },
+        {
+            "name": "setXHRBreakpoint",
+            "parameters": [
+                { "name": "url", "type": "string", "description": "Resource URL substring. All XHRs having this substring in the URL will get stopped upon." }
+            ],
+            "description": "Sets breakpoint on XMLHttpRequest."
+        },
+        {
+            "name": "removeXHRBreakpoint",
+            "parameters": [
+                { "name": "url", "type": "string", "description": "Resource URL substring." }
+            ],
+            "description": "Removes breakpoint from XMLHttpRequest."
+        }
+    ]
+}
+,
+{
+    "domain": "DOMStorage",
+    "description": "Query and modify DOM storage.",
+    "availability": "web",
+    "types": [
+        {
+            "id": "StorageId",
+            "type": "object",
+            "description": "DOM Storage identifier.",
+            "properties": [
+                { "name": "securityOrigin", "type": "string", "description": "Security origin for the storage." },
+                { "name": "isLocalStorage", "type": "boolean", "description": "Whether the storage is local storage (not session storage)." }
+            ]
+        },
+        {
+            "id": "Item",
+            "type": "array",
+            "description": "DOM Storage item.",
+            "items": { "type": "string" }
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables storage tracking, storage events will now be delivered to the client."
+        },
+        {
+            "name": "disable",
+            "description": "Disables storage tracking, prevents storage events from being sent to the client."
+        },
+        {
+            "name": "getDOMStorageItems",
+            "parameters": [
+                { "name": "storageId", "$ref": "StorageId" }
+            ],
+            "returns": [
+                { "name": "entries", "type": "array", "items": { "$ref": "Item" } }
+            ]
+        },
+        {
+            "name": "setDOMStorageItem",
+            "parameters": [
+                { "name": "storageId", "$ref": "StorageId" },
+                { "name": "key", "type": "string" },
+                { "name": "value", "type": "string" }
+            ]
+        },
+        {
+            "name": "removeDOMStorageItem",
+            "parameters": [
+                { "name": "storageId", "$ref": "StorageId" },
+                { "name": "key", "type": "string" }
+            ]
+        }
+    ],
+    "events": [
+        {
+            "name": "domStorageItemsCleared",
+            "parameters": [
+                { "name": "storageId", "$ref": "StorageId" }
+            ]
+        },
+        {
+            "name": "domStorageItemRemoved",
+            "parameters": [
+                { "name": "storageId", "$ref": "StorageId" },
+                { "name": "key", "type": "string" }
+            ]
+        },
+        {
+            "name": "domStorageItemAdded",
+            "parameters": [
+                { "name": "storageId", "$ref": "StorageId" },
+                { "name": "key", "type": "string" },
+                { "name": "newValue", "type": "string" }
+            ]
+        },
+        {
+            "name": "domStorageItemUpdated",
+            "parameters": [
+                { "name": "storageId", "$ref": "StorageId" },
+                { "name": "key", "type": "string" },
+                { "name": "oldValue", "type": "string" },
+                { "name": "newValue", "type": "string" }
+            ]
+        }
+    ]
+}
+,
+{
+    "domain": "Database",
+    "availability": "web",
+    "types": [
+        {
+            "id": "DatabaseId",
+            "type": "string",
+            "description": "Unique identifier of Database object."
+        },
+        {
+            "id": "Database",
+            "type": "object",
+            "description": "Database object.",
+            "properties": [
+                { "name": "id", "$ref": "DatabaseId", "description": "Database ID." },
+                { "name": "domain", "type": "string", "description": "Database domain." },
+                { "name": "name", "type": "string", "description": "Database name." },
+                { "name": "version", "type": "string", "description": "Database version." }
+            ]
+        },
+        {
+            "id": "Error",
+            "type": "object",
+            "description": "Database error.",
+            "properties": [
+                { "name": "message", "type": "string", "description": "Error message." },
+                { "name": "code", "type": "integer", "description": "Error code." }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables database tracking, database events will now be delivered to the client."
+        },
+        {
+            "name": "disable",
+            "description": "Disables database tracking, prevents database events from being sent to the client."
+        },
+        {
+            "name": "getDatabaseTableNames",
+            "parameters": [
+                { "name": "databaseId", "$ref": "DatabaseId" }
+            ],
+            "returns": [
+                { "name": "tableNames", "type": "array", "items": { "type": "string" } }
+            ]
+        },
+        {
+            "name": "executeSQL",
+            "async": true,
+            "parameters": [
+                { "name": "databaseId", "$ref": "DatabaseId" },
+                { "name": "query", "type": "string" }
+            ],
+            "returns": [
+                { "name": "columnNames", "type": "array", "optional": true, "items": { "type": "string" } },
+                { "name": "values", "type": "array", "optional": true, "items": { "type": "any" }},
+                { "name": "sqlError", "$ref": "Error", "optional": true }
+            ]
+        }
+    ],
+    "events": [
+        {
+            "name": "addDatabase",
+            "parameters": [
+                { "name": "database", "$ref": "Database" }
+            ]
+        }
+    ]
+}
+,
+{
+    "domain": "Debugger",
+    "description": "Debugger domain exposes JavaScript debugging capabilities. It allows setting and removing breakpoints, stepping through execution, exploring stack traces, etc.",
+    "types": [
+        {
+            "id": "BreakpointId",
+            "type": "string",
+            "description": "Breakpoint identifier."
+        },
+        {
+            "id": "BreakpointActionIdentifier",
+            "type": "integer",
+            "description": "Breakpoint action identifier."
+        },
+        {
+            "id": "ScriptId",
+            "type": "string",
+            "description": "Unique script identifier."
+        },
+        {
+            "id": "CallFrameId",
+            "type": "string",
+            "description": "Call frame identifier."
+        },
+        {
+            "id": "Location",
+            "type": "object",
+            "properties": [
+                { "name": "scriptId", "$ref": "ScriptId", "description": "Script identifier as reported in the <code>Debugger.scriptParsed</code>." },
+                { "name": "lineNumber", "type": "integer", "description": "Line number in the script." },
+                { "name": "columnNumber", "type": "integer", "optional": true, "description": "Column number in the script." }
+            ],
+            "description": "Location in the source code."
+        },
+        {
+            "id": "BreakpointAction",
+            "type": "object",
+            "properties": [
+                { "name": "type", "type": "string", "enum": ["log", "evaluate", "sound", "probe"], "description": "Different kinds of breakpoint actions." },
+                { "name": "data", "type": "string", "optional": true, "description": "Data associated with this breakpoint type (e.g. for type \"eval\" this is the JavaScript string to evalulate)." },
+                { "name": "id", "$ref": "BreakpointActionIdentifier", "optional": true, "description": "A frontend-assigned identifier for this breakpoint action." }
+            ],
+            "description": "Action to perform when a breakpoint is triggered."
+        },
+        {
+            "id": "BreakpointOptions",
+            "type": "object",
+            "properties": [
+                { "name": "condition", "type": "string", "optional": true, "description": "Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true." },
+                { "name": "actions", "type": "array", "optional": true, "items": { "$ref": "BreakpointAction" }, "description": "Actions to perform automatically when the breakpoint is triggered." },
+                { "name": "autoContinue", "type": "boolean", "optional": true, "description": "Automatically continue after hitting this breakpoint and running actions." }
+            ],
+            "description": "Extra options that modify breakpoint behavior."
+        },
+        {
+            "id": "FunctionDetails",
+            "type": "object",
+            "properties": [
+                { "name": "location", "$ref": "Location", "description": "Location of the function." },
+                { "name": "name", "type": "string", "optional": true, "description": "Name of the function. Not present for anonymous functions." },
+                { "name": "displayName", "type": "string", "optional": true, "description": "Display name of the function(specified in 'displayName' property on the function object)." },
+                { "name": "inferredName", "type": "string", "optional": true, "description": "Name of the function inferred from its initial assignment." },
+                { "name": "scopeChain", "type": "array", "optional": true, "items": { "$ref": "Scope" }, "description": "Scope chain for this closure." }
+            ],
+            "description": "Information about the function."
+        },
+        {
+            "id": "CallFrame",
+            "type": "object",
+            "properties": [
+                { "name": "callFrameId", "$ref": "CallFrameId", "description": "Call frame identifier. This identifier is only valid while the virtual machine is paused." },
+                { "name": "functionName", "type": "string", "description": "Name of the JavaScript function called on this call frame." },
+                { "name": "location", "$ref": "Location", "description": "Location in the source code." },
+                { "name": "scopeChain", "type": "array", "items": { "$ref": "Scope" }, "description": "Scope chain for this call frame." },
+                { "name": "this", "$ref": "Runtime.RemoteObject", "description": "<code>this</code> object for this call frame." }
+            ],
+            "description": "JavaScript call frame. Array of call frames form the call stack."
+        },
+        {
+            "id": "Scope",
+            "type": "object",
+            "properties": [
+                { "name": "type", "type": "string", "enum": ["global", "local", "with", "closure", "catch", "functionName"], "description": "Scope type." },
+                { "name": "object", "$ref": "Runtime.RemoteObject", "description": "Object representing the scope. For <code>global</code> and <code>with</code> scopes it represents the actual object; for the rest of the scopes, it is artificial transient object enumerating scope variables as its properties." }
+            ],
+            "description": "Scope description."
+        },
+        {
+            "id": "ProbeSample",
+            "description": "A sample collected by evaluating a probe breakpoint action.",
+            "type": "object",
+            "properties": [
+                { "name": "probeId", "$ref": "BreakpointActionIdentifier", "description": "Identifier of the probe breakpoint action that created the sample." },
+                { "name": "sampleId", "type": "integer", "description": "Unique identifier for this sample." },
+                { "name": "batchId", "type": "integer", "description": "A batch identifier which is the same for all samples taken at the same breakpoint hit." },
+                { "name": "timestamp", "type": "number", "description": "Timestamp of when the sample was taken." },
+                { "name": "payload", "$ref": "Runtime.RemoteObject", "description": "Contents of the sample." }
+            ]
+        },
+        {
+            "id": "AssertPauseReason",
+            "description": "The pause reason auxiliary data when paused because of an assertion.",
+            "type": "object",
+            "properties": [
+                { "name": "message", "type": "string", "optional": true, "description": "The console.assert message string if provided." }
+            ]
+        },
+        {
+            "id": "BreakpointPauseReason",
+            "description": "The pause reason auxiliary data when paused because of hitting a breakpoint.",
+            "type": "object",
+            "properties": [
+                { "name": "breakpointId", "type": "string", "description": "The identifier of the breakpoint causing the pause." }
+            ]
+        },
+        {
+            "id": "CSPViolationPauseReason",
+            "description": "The pause reason auxiliary data when paused because of a Content Security Policy directive.",
+            "type": "object",
+            "properties": [
+                { "name": "directive", "type": "string", "description": "The CSP directive that blocked script execution." }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables debugger for the given page. Clients should not assume that the debugging has been enabled until the result for this command is received."
+        },
+        {
+            "name": "disable",
+            "description": "Disables debugger for given page."
+        },
+        {
+            "name": "setBreakpointsActive",
+            "parameters": [
+                { "name": "active", "type": "boolean", "description": "New value for breakpoints active state." }
+            ],
+            "description": "Activates / deactivates all breakpoints on the page."
+        },
+        {
+            "name": "setBreakpointByUrl",
+            "parameters": [
+                { "name": "lineNumber", "type": "integer", "description": "Line number to set breakpoint at." },
+                { "name": "url", "type": "string", "optional": true, "description": "URL of the resources to set breakpoint on." },
+                { "name": "urlRegex", "type": "string", "optional": true, "description": "Regex pattern for the URLs of the resources to set breakpoints on. Either <code>url</code> or <code>urlRegex</code> must be specified." },
+                { "name": "columnNumber", "type": "integer", "optional": true, "description": "Offset in the line to set breakpoint at." },
+                { "name": "options", "$ref": "BreakpointOptions", "optional": true, "description": "Options to apply to this breakpoint to modify its behavior." }
+            ],
+            "returns": [
+                { "name": "breakpointId", "$ref": "BreakpointId", "description": "Id of the created breakpoint for further reference." },
+                { "name": "locations", "type": "array", "items": { "$ref": "Location"}, "description": "List of the locations this breakpoint resolved into upon addition." }
+            ],
+            "description": "Sets JavaScript breakpoint at given location specified either by URL or URL regex. Once this command is issued, all existing parsed scripts will have breakpoints resolved and returned in <code>locations</code> property. Further matching script parsing will result in subsequent <code>breakpointResolved</code> events issued. This logical breakpoint will survive page reloads."
+        },
+        {
+            "name": "setBreakpoint",
+            "parameters": [
+                { "name": "location", "$ref": "Location", "description": "Location to set breakpoint in." },
+                { "name": "options", "$ref": "BreakpointOptions", "optional": true, "description": "Options to apply to this breakpoint to modify its behavior." }
+            ],
+            "returns": [
+                { "name": "breakpointId", "$ref": "BreakpointId", "description": "Id of the created breakpoint for further reference." },
+                { "name": "actualLocation", "$ref": "Location", "description": "Location this breakpoint resolved into." }
+            ],
+            "description": "Sets JavaScript breakpoint at a given location."
+        },
+        {
+            "name": "removeBreakpoint",
+            "parameters": [
+                { "name": "breakpointId", "$ref": "BreakpointId" }
+            ],
+            "description": "Removes JavaScript breakpoint."
+        },
+        {
+            "name": "continueToLocation",
+            "parameters": [
+                { "name": "location", "$ref": "Location", "description": "Location to continue to." }
+            ],
+            "description": "Continues execution until specific location is reached."
+        },
+        {
+            "name": "stepOver",
+            "description": "Steps over the statement."
+        },
+        {
+            "name": "stepInto",
+            "description": "Steps into the function call."
+        },
+        {
+            "name": "stepOut",
+            "description": "Steps out of the function call."
+        },
+        {
+            "name": "pause",
+            "description": "Stops on the next JavaScript statement."
+        },
+        {
+            "name": "resume",
+            "description": "Resumes JavaScript execution."
+        },
+        {
+            "name": "searchInContent",
+            "description": "Searches for given string in script content.",
+            "parameters": [
+                { "name": "scriptId", "$ref": "ScriptId", "description": "Id of the script to search in." },
+                { "name": "query", "type": "string", "description": "String to search for." },
+                { "name": "caseSensitive", "type": "boolean", "optional": true, "description": "If true, search is case sensitive." },
+                { "name": "isRegex", "type": "boolean", "optional": true, "description": "If true, treats string parameter as regex." }
+            ],
+            "returns": [
+                { "name": "result", "type": "array", "items": { "$ref": "GenericTypes.SearchMatch" }, "description": "List of search matches." }
+            ]
+        },
+        {
+            "name": "getScriptSource",
+            "parameters": [
+                { "name": "scriptId", "$ref": "ScriptId", "description": "Id of the script to get source for." }
+            ],
+            "returns": [
+                { "name": "scriptSource", "type": "string", "description": "Script source." }
+            ],
+            "description": "Returns source for the script with given id."
+        },
+        {
+            "name": "getFunctionDetails",
+            "parameters": [
+                { "name": "functionId", "$ref": "Runtime.RemoteObjectId", "description": "Id of the function to get location for." }
+            ],
+            "returns": [
+                { "name": "details", "$ref": "FunctionDetails", "description": "Information about the function." }
+            ],
+            "description": "Returns detailed information on given function."
+        },
+        {
+            "name": "setPauseOnExceptions",
+            "parameters": [
+                { "name": "state", "type": "string", "enum": ["none", "uncaught", "all"], "description": "Pause on exceptions mode." }
+            ],
+            "description": "Defines pause on exceptions state. Can be set to stop on all exceptions, uncaught exceptions or no exceptions. Initial pause on exceptions state is <code>none</code>."
+        },
+        {
+            "name": "evaluateOnCallFrame",
+            "parameters": [
+                { "name": "callFrameId", "$ref": "CallFrameId", "description": "Call frame identifier to evaluate on." },
+                { "name": "expression", "type": "string", "description": "Expression to evaluate." },
+                { "name": "objectGroup", "type": "string", "optional": true, "description": "String object group name to put result into (allows rapid releasing resulting object handles using <code>releaseObjectGroup</code>)." },
+                { "name": "includeCommandLineAPI", "type": "boolean", "optional": true, "description": "Specifies whether command line API should be available to the evaluated expression, defaults to false." },
+                { "name": "doNotPauseOnExceptionsAndMuteConsole", "type": "boolean", "optional": true, "description": "Specifies whether evaluation should stop on exceptions and mute console. Overrides setPauseOnException state." },
+                { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object that should be sent by value." },
+                { "name": "generatePreview", "type": "boolean", "optional": true, "description": "Whether preview should be generated for the result." },
+                { "name": "saveResult", "type": "boolean", "optional": true, "description": "Whether the resulting value should be considered for saving in the $n history." }
+            ],
+            "returns": [
+                { "name": "result", "$ref": "Runtime.RemoteObject", "description": "Object wrapper for the evaluation result." },
+                { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." },
+                { "name": "savedResultIndex", "type": "integer", "optional": true, "description": "If the result was saved, this is the $n index that can be used to access the value." }
+            ],
+            "description": "Evaluates expression on a given call frame."
+        },
+        {
+            "name": "setOverlayMessage",
+            "parameters": [
+                { "name": "message", "type": "string", "optional": true, "description": "Overlay message to display when paused in debugger." }
+            ],
+            "description": "Sets overlay message."
+        }
+    ],
+    "events": [
+        {
+            "name": "globalObjectCleared",
+            "description": "Called when global has been cleared and debugger client should reset its state. Happens upon navigation or reload."
+        },
+        {
+            "name": "scriptParsed",
+            "parameters": [
+                { "name": "scriptId", "$ref": "ScriptId", "description": "Identifier of the script parsed." },
+                { "name": "url", "type": "string", "description": "URL or name of the script parsed (if any)." },
+                { "name": "startLine", "type": "integer", "description": "Line offset of the script within the resource with given URL (for script tags)." },
+                { "name": "startColumn", "type": "integer", "description": "Column offset of the script within the resource with given URL." },
+                { "name": "endLine", "type": "integer", "description": "Last line of the script." },
+                { "name": "endColumn", "type": "integer", "description": "Length of the last line of the script." },
+                { "name": "isContentScript", "type": "boolean", "optional": true, "description": "Determines whether this script is a user extension script." },
+                { "name": "sourceMapURL", "type": "string", "optional": true, "description": "URL of source map associated with script (if any)." },
+                { "name": "hasSourceURL", "type": "boolean", "optional": true, "description": "True, if this script has sourceURL." }
+            ],
+            "description": "Fired when virtual machine parses script. This event is also fired for all known and uncollected scripts upon enabling debugger."
+        },
+        {
+            "name": "scriptFailedToParse",
+            "parameters": [
+                { "name": "url", "type": "string", "description": "URL of the script that failed to parse." },
+                { "name": "scriptSource", "type": "string", "description": "Source text of the script that failed to parse." },
+                { "name": "startLine", "type": "integer", "description": "Line offset of the script within the resource." },
+                { "name": "errorLine", "type": "integer", "description": "Line with error." },
+                { "name": "errorMessage", "type": "string", "description": "Parse error message." }
+            ],
+            "description": "Fired when virtual machine fails to parse the script."
+        },
+        {
+            "name": "breakpointResolved",
+            "parameters": [
+                { "name": "breakpointId", "$ref": "BreakpointId", "description": "Breakpoint unique identifier." },
+                { "name": "location", "$ref": "Location", "description": "Actual breakpoint location." }
+            ],
+            "description": "Fired when breakpoint is resolved to an actual script and location."
+        },
+        {
+            "name": "paused",
+            "parameters": [
+                { "name": "callFrames", "type": "array", "items": { "$ref": "CallFrame" }, "description": "Call stack the virtual machine stopped on." },
+                { "name": "reason", "type": "string", "enum": ["XHR", "DOM", "EventListener", "exception", "assert", "CSPViolation", "DebuggerStatement", "Breakpoint", "PauseOnNextStatement", "other"], "description": "Pause reason." },
+                { "name": "data", "type": "object", "optional": true, "description": "Object containing break-specific auxiliary properties." }
+            ],
+            "description": "Fired when the virtual machine stopped on breakpoint or exception or any other stop criteria."
+        },
+        {
+            "name": "resumed",
+            "description": "Fired when the virtual machine resumed execution."
+        },
+        {
+            "name": "didSampleProbe",
+            "description": "Fires when a new probe sample is collected.",
+            "parameters": [
+                { "name": "sample", "$ref": "ProbeSample", "description": "A collected probe sample." }
+            ]
+        },
+        {
+            "name": "playBreakpointActionSound",
+            "description": "Fired when a \"sound\" breakpoint action is triggered on a breakpoint.",
+            "parameters": [
+                { "name": "breakpointActionId", "$ref": "BreakpointActionIdentifier", "description": "Breakpoint action identifier." }
+            ]
+        }
+    ]
+}
+,
+{
+    "domain": "GenericTypes",
+    "description": "Exposes generic types to be used by any domain.",
+    "types": [
+        {
+            "id": "SearchMatch",
+            "type": "object",
+            "description": "Search match in a resource.",
+            "properties": [
+                { "name": "lineNumber", "type": "number", "description": "Line number in resource content." },
+                { "name": "lineContent", "type": "string", "description": "Line with match content." }
+            ]
+        }
+    ]
+}
+,
+{
+    "domain": "IndexedDB",
+    "featureGuard": "ENABLE(INDEXED_DATABASE)",
+    "availability": "web",
+    "types": [
+        {
+            "id": "DatabaseWithObjectStores",
+            "type": "object",
+            "description": "Database with an array of object stores.",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Database name." },
+                { "name": "version", "type": "number", "description": "Database version." },
+                { "name": "objectStores", "type": "array", "items": { "$ref": "ObjectStore" }, "description": "Object stores in this database." }
+            ]
+        },
+        {
+            "id": "ObjectStore",
+            "type": "object",
+            "description": "Object store.",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Object store name." },
+                { "name": "keyPath", "$ref": "KeyPath", "description": "Object store key path." },
+                { "name": "autoIncrement", "type": "boolean", "description": "If true, object store has auto increment flag set." },
+                { "name": "indexes", "type": "array", "items": { "$ref": "ObjectStoreIndex" }, "description": "Indexes in this object store." }
+            ]
+        },
+        {
+            "id": "ObjectStoreIndex",
+            "type": "object",
+            "description": "Object store index.",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Index name." },
+                { "name": "keyPath", "$ref": "KeyPath", "description": "Index key path." },
+                { "name": "unique", "type": "boolean", "description": "If true, index is unique." },
+                { "name": "multiEntry", "type": "boolean", "description": "If true, index allows multiple entries for a key." }
+            ]
+        },
+        {
+            "id": "Key",
+            "type": "object",
+            "description": "Key.",
+            "properties": [
+                { "name": "type", "type": "string", "enum": ["number", "string", "date", "array"], "description": "Key type." },
+                { "name": "number", "type": "number", "optional": true, "description": "Number value." },
+                { "name": "string", "type": "string", "optional": true, "description": "String value." },
+                { "name": "date", "type": "number", "optional": true, "description": "Date value." },
+                { "name": "array", "type": "array", "optional": true, "items": { "$ref": "Key" }, "description": "Array value." }
+            ]
+        },
+        {
+            "id": "KeyRange",
+            "type": "object",
+            "description": "Key range.",
+            "properties": [
+                { "name": "lower", "$ref": "Key", "optional": true, "description": "Lower bound." },
+                { "name": "upper", "$ref": "Key", "optional": true, "description": "Upper bound." },
+                { "name": "lowerOpen", "type": "boolean", "description": "If true lower bound is open." },
+                { "name": "upperOpen", "type": "boolean", "description": "If true upper bound is open." }
+            ]
+        },
+        {
+            "id": "DataEntry",
+            "type": "object",
+            "description": "Data entry.",
+            "properties": [
+                { "name": "key", "$ref": "Runtime.RemoteObject", "description": "Key." },
+                { "name": "primaryKey", "$ref": "Runtime.RemoteObject", "description": "Primary key." },
+                { "name": "value", "$ref": "Runtime.RemoteObject", "description": "Value." }
+            ]
+        },
+        {
+            "id": "KeyPath",
+            "type": "object",
+            "description": "Key path.",
+            "properties": [
+                { "name": "type", "type": "string", "enum": ["null", "string", "array"], "description": "Key path type." },
+                { "name": "string", "type": "string", "optional": true, "description": "String value." },
+                { "name": "array", "type": "array", "optional": true, "items": { "type": "string" }, "description": "Array value." }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables events from backend."
+        },
+        {
+            "name": "disable",
+            "description": "Disables events from backend."
+        },
+        {
+            "name": "requestDatabaseNames",
+            "async": true,
+            "parameters": [
+                { "name": "securityOrigin", "type": "string", "description": "Security origin." }
+            ],
+            "returns": [
+                { "name": "databaseNames", "type": "array", "items": { "type": "string" }, "description": "Database names for origin." }
+            ],
+            "description": "Requests database names for given security origin."
+        },
+        {
+            "name": "requestDatabase",
+            "async": true,
+            "parameters": [
+                { "name": "securityOrigin", "type": "string", "description": "Security origin." },
+                { "name": "databaseName", "type": "string", "description": "Database name." }
+            ],
+            "returns": [
+                { "name": "databaseWithObjectStores", "$ref": "DatabaseWithObjectStores", "description": "Database with an array of object stores." }
+            ],
+            "description": "Requests database with given name in given frame."
+        },
+        {
+            "name": "requestData",
+            "async": true,
+            "parameters": [
+                { "name": "securityOrigin", "type": "string", "description": "Security origin." },
+                { "name": "databaseName", "type": "string", "description": "Database name." },
+                { "name": "objectStoreName", "type": "string", "description": "Object store name." },
+                { "name": "indexName", "type": "string", "description": "Index name, empty string for object store data requests." },
+                { "name": "skipCount", "type": "integer", "description": "Number of records to skip." },
+                { "name": "pageSize", "type": "integer", "description": "Number of records to fetch." },
+                { "name": "keyRange", "$ref": "KeyRange", "optional": true, "description": "Key range." }
+            ],
+            "returns": [
+                { "name": "objectStoreDataEntries", "type": "array", "items": { "$ref": "DataEntry" }, "description": "Array of object store data entries." },
+                { "name": "hasMore", "type": "boolean", "description": "If true, there are more entries to fetch in the given range." }
+            ],
+            "description": "Requests data from object store or index."
+        },
+        {
+            "name": "clearObjectStore",
+            "async": true,
+            "parameters": [
+                { "name": "securityOrigin", "type": "string", "description": "Security origin." },
+                { "name": "databaseName", "type": "string", "description": "Database name." },
+                { "name": "objectStoreName", "type": "string", "description": "Object store name." }
+            ],
+            "returns": [
+            ],
+            "description": "Clears all entries from an object store."
+        }
+    ]
+}
+,
+{
+    "domain": "Inspector",
+    "types": [],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables inspector domain notifications."
+        },
+        {
+            "name": "disable",
+            "description": "Disables inspector domain notifications."
+        },
+        {
+            "name": "initialized",
+            "description": "Sent by the frontend after all initialization messages have been sent."
+        }
+    ],
+    "events": [
+        {
+            "name": "evaluateForTestInFrontend",
+            "parameters": [
+                { "name": "script", "type": "string" }
+            ]
+        },
+        {
+            "name": "inspect",
+            "parameters": [
+                { "name": "object", "$ref": "Runtime.RemoteObject" },
+                { "name": "hints", "type": "object" }
+            ]
+        },
+        {
+            "name": "detached",
+            "description": "Fired when remote debugging connection is about to be terminated. Contains detach reason.",
+            "parameters": [
+                { "name": "reason", "type": "string", "description": "The reason why connection has been terminated." }
+            ]
+        },
+        {
+            "name": "activateExtraDomains",
+            "description": "Fired when the backend has alternate domains that need to be activated.",
+            "parameters": [
+                { "name": "domains", "type": "array", "items": { "type": "string" }, "description": "Domain names that need activation" }
+            ]
+        },
+        {
+            "name": "targetCrashed",
+            "description": "Fired when debugging target has crashed"
+        }
+    ]
+}
+,
+{
+    "domain": "LayerTree",
+    "availability": "web",
+    "types": [
+        {
+            "id": "LayerId",
+            "type": "string",
+            "description": "Unique RenderLayer identifier."
+        },
+        {
+            "id": "PseudoElementId",
+            "type": "string",
+            "description": "Unique PseudoElement identifier."
+        },
+        {
+            "id": "IntRect",
+            "type": "object",
+            "description": "A rectangle.",
+            "properties": [
+                { "name": "x", "type": "integer", "description": "The x position." },
+                { "name": "y", "type": "integer", "description": "The y position." },
+                { "name": "width", "type": "integer", "description": "The width metric." },
+                { "name": "height", "type": "integer", "description": "The height metric." }
+            ]
+        },
+        {
+            "id": "Layer",
+            "type": "object",
+            "description": "Information about a compositing layer.",
+            "properties": [
+                { "name": "layerId", "$ref": "LayerId", "description": "The unique id for this layer." },
+                { "name": "nodeId", "$ref": "DOM.NodeId", "description": "The id for the node associated with this layer." },
+                { "name": "bounds", "$ref": "IntRect", "description": "Bounds of the layer in absolute page coordinates." },
+                { "name": "paintCount", "type": "integer", "description": "Indicates how many time this layer has painted." },
+                { "name": "memory", "type": "integer", "description": "Estimated memory used by this layer." },
+                { "name": "compositedBounds", "$ref": "IntRect", "description": "The bounds of the composited layer." },
+                { "name": "isInShadowTree", "type": "boolean", "optional": true, "description": "Indicates whether this layer is associated with an element hosted in a shadow tree." },
+                { "name": "isReflection", "type": "boolean", "optional": true, "description": "Indicates whether this layer was used to provide a reflection for the element." },
+                { "name": "isGeneratedContent", "type": "boolean", "optional": true, "description": "Indicates whether the layer is attached to a pseudo element that is CSS generated content." },
+                { "name": "isAnonymous", "type": "boolean", "optional": true, "description": "Indicates whether the layer was created for a CSS anonymous block or box." },
+                { "name": "pseudoElementId", "$ref": "PseudoElementId", "optional": true, "description": "The id for the pseudo element associated with this layer." },
+                { "name": "pseudoElement", "type": "string", "optional": true, "description": "The name of the CSS pseudo-element that prompted the layer to be generated." }
+            ]
+        },
+        {
+            "id": "CompositingReasons",
+            "type": "object",
+            "description": "An object containing the reasons why the layer was composited as properties.",
+            "properties": [
+                { "name": "transform3D", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a CSS 3D transform." },
+                { "name": "video", "type": "boolean", "optional": true, "description": "Composition due to association with a <video> element." },
+                { "name": "canvas", "type": "boolean", "optional": true, "description": "Composition due to the element being a <canvas> element." },
+                { "name": "plugin", "type": "boolean", "optional": true, "description": "Composition due to association with a plugin." },
+                { "name": "iFrame", "type": "boolean", "optional": true, "description": "Composition due to association with an <iframe> element." },
+                { "name": "backfaceVisibilityHidden", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a \"backface-visibility: hidden\" style." },
+                { "name": "clipsCompositingDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with an element clipping compositing descendants." },
+                { "name": "animation", "type": "boolean", "optional": true, "description": "Composition due to association with an animated element." },
+                { "name": "filters", "type": "boolean", "optional": true, "description": "Composition due to association with an element with CSS filters applied." },
+                { "name": "positionFixed", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a \"position: fixed\" style." },
+                { "name": "positionSticky", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a \"position: sticky\" style." },
+                { "name": "overflowScrollingTouch", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a \"overflow-scrolling: touch\" style." },
+                { "name": "stacking", "type": "boolean", "optional": true, "description": "Composition due to association with an element establishing a stacking context." },
+                { "name": "overlap", "type": "boolean", "optional": true, "description": "Composition due to association with an element overlapping other composited elements." },
+                { "name": "negativeZIndexChildren", "type": "boolean", "optional": true, "description": "Composition due to association with an element with descendants that have a negative z-index." },
+                { "name": "transformWithCompositedDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with an element with composited descendants." },
+                { "name": "opacityWithCompositedDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with an element with opacity applied and composited descendants." },
+                { "name": "maskWithCompositedDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with a masked element and composited descendants." },
+                { "name": "reflectionWithCompositedDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a reflection and composited descendants." },
+                { "name": "filterWithCompositedDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with an element with CSS filters applied and composited descendants." },
+                { "name": "blendingWithCompositedDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with an element with CSS blending applied and composited descendants." },
+                { "name": "isolatesCompositedBlendingDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with an element isolating compositing descendants having CSS blending applied." },
+                { "name": "perspective", "type": "boolean", "optional": true, "description": "Composition due to association with an element with perspective applied." },
+                { "name": "preserve3D", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a \"transform-style: preserve-3d\" style." },
+                { "name": "root", "type": "boolean", "optional": true, "description": "Composition due to association with the root element." },
+                { "name": "blending", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a \"blend-mode\" style." }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables compositing tree inspection."
+        },
+        {
+            "name": "disable",
+            "description": "Disables compositing tree inspection."
+        },
+        {
+            "name": "layersForNode",
+            "parameters": [
+                { "name": "nodeId", "$ref": "DOM.NodeId", "description": "Root of the subtree for which we want to gather layers." }                ],
+            "description": "Returns the layer tree structure of the current page.",
+            "returns": [
+                { "name": "layers", "type": "array", "items": { "$ref": "Layer" }, "description": "Child layers." }
+            ]
+        },
+        {
+            "name": "reasonsForCompositingLayer",
+            "parameters": [
+                { "name": "layerId", "$ref": "LayerId", "description": "The id of the layer for which we want to get the reasons it was composited." }
+            ],
+            "description": "Provides the reasons why the given layer was composited.",
+            "returns": [
+                { "name": "compositingReasons", "$ref": "CompositingReasons", "description": "An object containing the reasons why the layer was composited as properties." }
+            ]
+        }
+    ],
+    "events": [
+        {
+            "name": "layerTreeDidChange"
+        }
+    ]
+}
+,
+{
+    "domain": "Network",
+    "description": "Network domain allows tracking network activities of the page. It exposes information about http, file, data and other requests and responses, their headers, bodies, timing, etc.",
+    "availability": "web",
+    "types": [
+        {
+            "id": "LoaderId",
+            "type": "string",
+            "description": "Unique loader identifier."
+        },
+        {
+            "id": "FrameId",
+            "type": "string",
+            "description": "Unique frame identifier."
+        },
+        {
+            "id": "RequestId",
+            "type": "string",
+            "description": "Unique request identifier."
+        },
+        {
+            "id": "Timestamp",
+            "type": "number",
+            "description": "Number of seconds since epoch."
+        },
+        {
+            "id": "Headers",
+            "type": "object",
+            "description": "Request / response headers as keys / values of JSON object."
+        },
+        {
+            "id": "ResourceTiming",
+            "type": "object",
+            "description": "Timing information for the request.",
+            "properties": [
+                { "name": "navigationStart", "type": "number", "description": "Timing's navigationStart is a baseline in seconds, while the other numbers are ticks in milliseconds relatively to this navigationStart." },
+                { "name": "domainLookupStart", "type": "number", "description": "Started DNS address resolve." },
+                { "name": "domainLookupEnd", "type": "number", "description": "Finished DNS address resolve." },
+                { "name": "connectStart", "type": "number", "description": "Started connecting to the remote host." },
+                { "name": "connectEnd", "type": "number", "description": "Connected to the remote host." },
+                { "name": "secureConnectionStart", "type": "number", "description": "Started SSL handshake." },
+                { "name": "requestStart", "type": "number", "description": "Started sending request." },
+                { "name": "responseStart", "type": "number", "description": "Started receiving response headers." }
+            ]
+        },
+        {
+            "id": "Request",
+            "type": "object",
+            "description": "HTTP request data.",
+            "properties": [
+                { "name": "url", "type": "string", "description": "Request URL." },
+                { "name": "method", "type": "string", "description": "HTTP request method." },
+                { "name": "headers", "$ref": "Headers", "description": "HTTP request headers." },
+                { "name": "postData", "type": "string", "optional": true, "description": "HTTP POST request data." }
+            ]
+        },
+        {
+            "id": "Response",
+            "type": "object",
+            "description": "HTTP response data.",
+            "properties": [
+                { "name": "url", "type": "string", "description": "Response URL. This URL can be different from CachedResource.url in case of redirect." },
+                { "name": "status", "type": "number", "description": "HTTP response status code." },
+                { "name": "statusText", "type": "string", "description": "HTTP response status text." },
+                { "name": "headers", "$ref": "Headers", "description": "HTTP response headers." },
+                { "name": "headersText", "type": "string", "optional": true, "description": "HTTP response headers text." },
+                { "name": "mimeType", "type": "string", "description": "Resource mimeType as determined by the browser." },
+                { "name": "requestHeaders", "$ref": "Headers", "optional": true, "description": "Refined HTTP request headers that were actually transmitted over the network." },
+                { "name": "requestHeadersText", "type": "string", "optional": true, "description": "HTTP request headers text." },
+                { "name": "fromDiskCache", "type": "boolean", "optional": true, "description": "Specifies that the request was served from the disk cache." },
+                { "name": "timing", "$ref": "ResourceTiming", "optional": true, "description": "Timing information for the given request." }
+            ]
+        },
+        {
+            "id": "WebSocketRequest",
+            "type": "object",
+            "description": "WebSocket request data.",
+            "properties": [
+                { "name": "headers", "$ref": "Headers", "description": "HTTP response headers." }
+            ]
+        },
+        {
+            "id": "WebSocketResponse",
+            "type": "object",
+            "description": "WebSocket response data.",
+            "properties": [
+                { "name": "status", "type": "number", "description": "HTTP response status code." },
+                { "name": "statusText", "type": "string", "description": "HTTP response status text." },
+                { "name": "headers", "$ref": "Headers", "description": "HTTP response headers." }
+            ]
+        },
+        {
+            "id": "WebSocketFrame",
+            "type": "object",
+            "description": "WebSocket frame data.",
+            "properties": [
+                { "name": "opcode", "type": "number", "description": "WebSocket frame opcode." },
+                { "name": "mask", "type": "boolean", "description": "WebSocket frame mask." },
+                { "name": "payloadData", "type": "string", "description": "WebSocket frame payload data." }
+            ]
+        },
+        {
+            "id": "CachedResource",
+            "type": "object",
+            "description": "Information about the cached resource.",
+            "properties": [
+                { "name": "url", "type": "string", "description": "Resource URL. This is the url of the original network request." },
+                { "name": "type", "$ref": "Page.ResourceType", "description": "Type of this resource." },
+                { "name": "response", "$ref": "Response", "optional": true, "description": "Cached response data." },
+                { "name": "bodySize", "type": "number", "description": "Cached response body size." },
+                { "name": "sourceMapURL", "type": "string", "optional": true, "description": "URL of source map associated with this resource (if any)." }
+            ]
+        },
+        {
+            "id": "Initiator",
+            "type": "object",
+            "description": "Information about the request initiator.",
+            "properties": [
+                { "name": "type", "type": "string", "enum": ["parser", "script", "other"], "description": "Type of this initiator." },
+                { "name": "stackTrace", "$ref": "Console.StackTrace", "optional": true, "description": "Initiator JavaScript stack trace, set for Script only." },
+                { "name": "url", "type": "string", "optional": true, "description": "Initiator URL, set for Parser type only." },
+                { "name": "lineNumber", "type": "number", "optional": true, "description": "Initiator line number, set for Parser type only." }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables network tracking, network events will now be delivered to the client."
+        },
+        {
+            "name": "disable",
+            "description": "Disables network tracking, prevents network events from being sent to the client."
+        },
+        {
+            "name": "setExtraHTTPHeaders",
+            "description": "Specifies whether to always send extra HTTP headers with the requests from this page.",
+            "parameters": [
+                { "name": "headers", "$ref": "Headers", "description": "Map with extra HTTP headers." }
+            ]
+        },
+        {
+            "name": "getResponseBody",
+            "description": "Returns content served for the given request.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Identifier of the network request to get content for." }
+            ],
+            "returns": [
+                { "name": "body", "type": "string", "description": "Response body." },
+                { "name": "base64Encoded", "type": "boolean", "description": "True, if content was sent as base64." }
+            ]
+        },
+        {
+            "name": "setCacheDisabled",
+            "parameters": [
+                { "name": "cacheDisabled", "type": "boolean", "description": "Cache disabled state." }
+            ],
+            "description": "Toggles ignoring cache for each request. If <code>true</code>, cache will not be used."
+        },
+        {
+            "name": "loadResource",
+            "async": true,
+            "parameters": [
+                { "name": "frameId", "$ref": "FrameId", "description": "Frame to load the resource from." },
+                { "name": "url", "type": "string", "description": "URL of the resource to load." }
+            ],
+            "returns": [
+                { "name": "content", "type": "string", "description": "Resource content." },
+                { "name": "mimeType", "type": "string", "description": "Resource mimeType." },
+                { "name": "status", "type": "number", "description": "HTTP response status code." }
+            ],
+            "description": "Loads a resource in the context of a frame on the inspected page without cross origin checks."
+        }
+    ],
+    "events": [
+        {
+            "name": "requestWillBeSent",
+            "description": "Fired when page is about to send HTTP request.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "frameId", "$ref": "FrameId", "description": "Frame identifier." },
+                { "name": "loaderId", "$ref": "LoaderId", "description": "Loader identifier." },
+                { "name": "documentURL", "type": "string", "description": "URL of the document this request is loaded for." },
+                { "name": "request", "$ref": "Request", "description": "Request data." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "initiator", "$ref": "Initiator", "description": "Request initiator." },
+                { "name": "redirectResponse", "optional": true, "$ref": "Response", "description": "Redirect response data." },
+                { "name": "type", "$ref": "Page.ResourceType", "optional": true, "description": "Resource type." }
+            ]
+        },
+        {
+            "name": "requestServedFromCache",
+            "description": "Fired if request ended up loading from cache.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." }
+            ]
+        },
+        {
+            "name": "responseReceived",
+            "description": "Fired when HTTP response is available.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "frameId", "$ref": "FrameId", "description": "Frame identifier." },
+                { "name": "loaderId", "$ref": "LoaderId", "description": "Loader identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "type", "$ref": "Page.ResourceType", "description": "Resource type." },
+                { "name": "response", "$ref": "Response", "description": "Response data." }
+            ]
+        },
+        {
+            "name": "dataReceived",
+            "description": "Fired when data chunk was received over the network.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "dataLength", "type": "integer", "description": "Data chunk length." },
+                { "name": "encodedDataLength", "type": "integer", "description": "Actual bytes received (might be less than dataLength for compressed encodings)." }
+            ]
+        },
+        {
+            "name": "loadingFinished",
+            "description": "Fired when HTTP request has finished loading.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "sourceMapURL", "type": "string", "optional": true, "description": "URL of source map associated with this resource (if any)." }
+            ]
+        },
+        {
+            "name": "loadingFailed",
+            "description": "Fired when HTTP request has failed to load.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "errorText", "type": "string", "description": "User friendly error message." },
+                { "name": "canceled", "type": "boolean", "optional": true, "description": "True if loading was canceled." }
+            ]
+        },
+        {
+            "name": "requestServedFromMemoryCache",
+            "description": "Fired when HTTP request has been served from memory cache.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "frameId", "$ref": "FrameId", "description": "Frame identifier." },
+                { "name": "loaderId", "$ref": "LoaderId", "description": "Loader identifier." },
+                { "name": "documentURL", "type": "string", "description": "URL of the document this request is loaded for." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "initiator", "$ref": "Initiator", "description": "Request initiator." },
+                { "name": "resource", "$ref": "CachedResource", "description": "Cached resource data." }
+            ]
+        },
+        {
+            "name": "webSocketWillSendHandshakeRequest",
+            "description": "Fired when WebSocket is about to initiate handshake.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "request", "$ref": "WebSocketRequest", "description": "WebSocket request data." }
+            ]
+        },
+        {
+            "name": "webSocketHandshakeResponseReceived",
+            "description": "Fired when WebSocket handshake response becomes available.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "response", "$ref": "WebSocketResponse", "description": "WebSocket response data." }
+            ]
+        },
+        {
+            "name": "webSocketCreated",
+            "description": "Fired upon WebSocket creation.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "url", "type": "string", "description": "WebSocket request URL." }
+            ]
+        },
+        {
+            "name": "webSocketClosed",
+            "description": "Fired when WebSocket is closed.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." }
+            ]
+        },
+        {
+            "name": "webSocketFrameReceived",
+            "description": "Fired when WebSocket frame is received.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "response", "$ref": "WebSocketFrame", "description": "WebSocket response data." }
+            ]
+        },
+        {
+            "name": "webSocketFrameError",
+            "description": "Fired when WebSocket frame error occurs.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "errorMessage", "type": "string", "description": "WebSocket frame error message." }
+            ]
+        },
+        {
+            "name": "webSocketFrameSent",
+            "description": "Fired when WebSocket frame is sent.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "response", "$ref": "WebSocketFrame", "description": "WebSocket response data." }
+            ]
+        }
+    ]
+}
+,
+{
+    "domain": "OverlayTypes",
+    "description": "Exposes types to be used by the inspector overlay.",
+    "types": [
+        {
+            "id": "Point",
+            "type": "object",
+            "properties": [
+                { "name": "x", "type": "number" },
+                { "name": "y", "type": "number" }
+            ]
+        },
+        {
+            "id": "Size",
+            "type": "object",
+            "properties": [
+                { "name": "width", "type": "integer" },
+                { "name": "height", "type": "integer" }
+            ]
+        },
+        {
+            "id": "Quad",
+            "description": "A quad is a collection of 4 points. When initialized from a rect, the points are in clockwise order from top left.",
+            "type": "array",
+            "items": { "$ref": "Point" }
+        },
+        {
+            "id": "Rect",
+            "description": "A rectangle specified by a reference coordinate and width/height offsets.",
+            "type": "object",
+            "properties": [
+                { "name": "x", "type": "number" },
+                { "name": "y", "type": "number" },
+                { "name": "width", "type": "number" },
+                { "name": "height", "type": "number" }
+            ]
+        },
+        {
+            "id": "Region",
+            "description": "A single region in a flow thread.",
+            "type": "object",
+            "properties": [
+                { "name": "borderQuad", "$ref": "Quad" },
+                { "name": "incomingQuad", "$ref": "Quad" },
+                { "name": "outgoingQuad", "$ref": "Quad" },
+                { "name": "isHighlighted", "type": "boolean", "optional": true }
+            ]
+        },
+        {
+            "id": "DisplayPath",
+            "description": "A vector path described using SVG path syntax.",
+            "type": "array",
+            "items": { "type": "any" }
+        },
+        {
+            "id": "RegionFlowData",
+            "type": "object",
+            "properties": [
+                { "name": "regions", "type": "array", "items": { "$ref": "Region"} },
+                { "name": "name", "type": "string" }
+            ]
+        },
+        {
+            "id": "ContentFlowData",
+            "type": "object",
+            "properties": [
+                { "name": "name", "type": "string" }
+            ]
+        },
+        {
+            "id": "ShapeOutsideData",
+            "type": "object",
+            "properties": [
+                { "name": "bounds", "$ref": "Quad", "description": "Bounds for the shape-outside paths." },
+                { "name": "shape", "$ref": "DisplayPath", "description": "Path for the element's shape.", "optional": true },
+                { "name": "marginShape", "$ref": "DisplayPath", "description": "Path for the element's margin shape.", "optional": true }
+            ]
+        },
+        {
+            "id": "ElementData",
+            "description": "Data that describes an element to be highlighted.",
+            "type": "object",
+            "properties": [
+                { "name": "tagName", "type": "string" },
+                { "name": "idValue", "type": "string", "description": "The value of the element's 'id' attribute." },
+                { "name": "className", "type": "string", "optional": true },
+                { "name": "size", "$ref": "Size", "optional": true },
+                { "name": "role", "type": "string", "description": "Computed accessibility role for the element.", "optional": true },
+                { "name": "regionFlowData", "$ref": "RegionFlowData", "optional": true },
+                { "name": "contentFlowData", "$ref": "ContentFlowData", "optional": true },
+                { "name": "shapeOutsideData", "$ref": "ShapeOutsideData", "optional": true }
+            ]
+        },
+        {
+            "id": "FragmentHighlightData",
+            "description": "Data required to highlight multiple quads.",
+            "type": "object",
+            "properties": [
+                { "name": "quads", "type": "array", "items": { "$ref": "Quad" }, "description": "Quads for which the highlight should be applied."},
+                { "name": "contentColor", "type": "string" },
+                { "name": "contentOutlineColor", "type": "string" },
+                { "name": "paddingColor", "type": "string" },
+                { "name": "borderColor", "type": "string" },
+                { "name": "marginColor", "type": "string" },
+                { "name": "regionClippingArea", "$ref": "Quad", "optional": true }
+            ]
+        },
+        {
+            "id": "NodeHighlightData",
+            "description": "Data required to highlight a DOM node.",
+            "type": "object",
+            "properties": [
+                { "name": "scrollOffset", "$ref": "Point", "description": "Scroll offset for the MainFrame's FrameView that is shared across all quads." },
+                { "name": "fragments", "type": "array", "items": { "$ref": "FragmentHighlightData" } },
+                { "name": "elementData", "$ref": "ElementData", "optional": true }
+            ]
+        },
+        {
+            "id": "OverlayConfiguration",
+            "description": "Data required to configure the overlay's size and scaling behavior.",
+            "type": "object",
+            "properties": [
+                { "name": "deviceScaleFactor", "type": "number" },
+                { "name": "viewportSize", "$ref": "Size" },
+                { "name": "frameViewFullSize", "$ref": "Size" }
+            ]
+        }
+    ]
+}
+,
+{
+    "domain": "Page",
+    "description": "Actions and events related to the inspected page belong to the page domain.",
+    "availability": "web",
+    "types": [
+        {
+            "id": "ResourceType",
+            "type": "string",
+            "enum": ["Document", "Stylesheet", "Image", "Font", "Script", "XHR", "WebSocket", "Other"],
+            "description": "Resource type as it was perceived by the rendering engine."
+        },
+        {
+            "id": "CoordinateSystem",
+            "type": "string",
+            "enum": ["Viewport", "Page"],
+            "description": "Coordinate system used by supplied coordinates."
+        },
+        {
+            "id": "Frame",
+            "type": "object",
+            "description": "Information about the Frame on the page.",
+            "properties": [
+                { "name": "id", "type": "string", "description": "Frame unique identifier." },
+                { "name": "parentId", "type": "string", "optional": true, "description": "Parent frame identifier." },
+                { "name": "loaderId", "$ref": "Network.LoaderId", "description": "Identifier of the loader associated with this frame." },
+                { "name": "name", "type": "string", "optional": true, "description": "Frame's name as specified in the tag." },
+                { "name": "url", "type": "string", "description": "Frame document's URL." },
+                { "name": "securityOrigin", "type": "string", "description": "Frame document's security origin." },
+                { "name": "mimeType", "type": "string", "description": "Frame document's mimeType as determined by the browser." }
+            ]
+        },
+        {
+            "id": "FrameResource",
+            "type": "object",
+            "properties": [
+                { "name": "url", "type": "string", "description": "Resource URL." },
+                { "name": "type", "$ref": "ResourceType", "description": "Type of this resource." },
+                { "name": "mimeType", "type": "string", "description": "Resource mimeType as determined by the browser." },
+                { "name": "failed", "type": "boolean", "optional": true, "description": "True if the resource failed to load." },
+                { "name": "canceled", "type": "boolean", "optional": true, "description": "True if the resource was canceled during loading." },
+                { "name": "sourceMapURL", "type": "string", "optional": true, "description": "URL of source map associated with this resource (if any)." }
+            ]
+        },
+        {
+            "id": "FrameResourceTree",
+            "type": "object",
+            "description": "Information about the Frame hierarchy along with their cached resources.",
+            "properties": [
+                { "name": "frame", "$ref": "Frame", "description": "Frame information for this tree item." },
+                { "name": "childFrames", "type": "array", "optional": true, "items": { "$ref": "FrameResourceTree" }, "description": "Child frames." },
+                { "name": "resources", "type": "array", "items": { "$ref": "FrameResource" }, "description": "Information about frame resources." }
+            ]
+        },
+        {
+            "id": "SearchResult",
+            "type": "object",
+            "description": "Search result for resource.",
+            "properties": [
+                { "name": "url", "type": "string", "description": "Resource URL." },
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Resource frame id." },
+                { "name": "matchesCount", "type": "number", "description": "Number of matches in the resource content." }
+            ]
+        },
+        {
+            "id": "Cookie",
+            "type": "object",
+            "description": "Cookie object",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Cookie name." },
+                { "name": "value", "type": "string", "description": "Cookie value." },
+                { "name": "domain", "type": "string", "description": "Cookie domain." },
+                { "name": "path", "type": "string", "description": "Cookie path." },
+                { "name": "expires", "type": "number", "description": "Cookie expires." },
+                { "name": "size", "type": "integer", "description": "Cookie size." },
+                { "name": "httpOnly", "type": "boolean", "description": "True if cookie is http-only." },
+                { "name": "secure", "type": "boolean", "description": "True if cookie is secure." },
+                { "name": "session", "type": "boolean", "description": "True in case of session cookie." }
+            ]
+        },
+        {
+            "id": "ScriptIdentifier",
+            "type": "string",
+            "description": "Unique script identifier."
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables page domain notifications."
+        },
+        {
+            "name": "disable",
+            "description": "Disables page domain notifications."
+        },
+        {
+            "name": "addScriptToEvaluateOnLoad",
+            "parameters": [
+                { "name": "scriptSource", "type": "string" }
+            ],
+            "returns": [
+                { "name": "identifier", "$ref": "ScriptIdentifier", "description": "Identifier of the added script." }
+            ]
+        },
+        {
+            "name": "removeScriptToEvaluateOnLoad",
+            "parameters": [
+                { "name": "identifier", "$ref": "ScriptIdentifier" }
+            ]
+        },
+        {
+            "name": "reload",
+            "parameters": [
+                { "name": "ignoreCache", "type": "boolean", "optional": true, "description": "If true, browser cache is ignored (as if the user pressed Shift+refresh)." },
+                { "name": "scriptToEvaluateOnLoad", "type": "string", "optional": true, "description": "If set, the script will be injected into all frames of the inspected page after reload." }
+            ],
+            "description": "Reloads given page optionally ignoring the cache."
+        },
+        {
+            "name": "navigate",
+            "parameters": [
+                { "name": "url", "type": "string", "description": "URL to navigate the page to." }
+            ],
+            "description": "Navigates current page to the given URL."
+        },
+        {
+            "name": "getCookies",
+            "returns": [
+                { "name": "cookies", "type": "array", "items": { "$ref": "Cookie"}, "description": "Array of cookie objects." }
+            ],
+            "description": "Returns all browser cookies. Depending on the backend support, will return detailed cookie information in the <code>cookies</code> field."
+        },
+        {
+            "name": "deleteCookie",
+            "parameters": [
+                { "name": "cookieName", "type": "string", "description": "Name of the cookie to remove." },
+                { "name": "url", "type": "string", "description": "URL to match cooke domain and path." }
+            ],
+            "description": "Deletes browser cookie with given name, domain and path."
+        },
+        {
+            "name": "getResourceTree",
+            "description": "Returns present frame / resource tree structure.",
+            "returns": [
+                { "name": "frameTree", "$ref": "FrameResourceTree", "description": "Present frame / resource tree structure." }
+            ]
+        },
+        {
+            "name": "getResourceContent",
+            "description": "Returns content of the given resource.",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Frame id to get resource for." },
+                { "name": "url", "type": "string", "description": "URL of the resource to get content for." }
+            ],
+            "returns": [
+                { "name": "content", "type": "string", "description": "Resource content." },
+                { "name": "base64Encoded", "type": "boolean", "description": "True, if content was served as base64." }
+            ]
+        },
+        {
+            "name": "searchInResource",
+            "description": "Searches for given string in resource content.",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Frame id for resource to search in." },
+                { "name": "url", "type": "string", "description": "URL of the resource to search in." },
+                { "name": "query", "type": "string", "description": "String to search for." },
+                { "name": "caseSensitive", "type": "boolean", "optional": true, "description": "If true, search is case sensitive." },
+                { "name": "isRegex", "type": "boolean", "optional": true, "description": "If true, treats string parameter as regex." }
+            ],
+            "returns": [
+                { "name": "result", "type": "array", "items": { "$ref": "GenericTypes.SearchMatch" }, "description": "List of search matches." }
+            ]
+        },
+        {
+            "name": "searchInResources",
+            "description": "Searches for given string in frame / resource tree structure.",
+            "parameters": [
+                { "name": "text", "type": "string", "description": "String to search for." },
+                { "name": "caseSensitive", "type": "boolean", "optional": true, "description": "If true, search is case sensitive." },
+                { "name": "isRegex", "type": "boolean", "optional": true, "description": "If true, treats string parameter as regex." }
+            ],
+            "returns": [
+                { "name": "result", "type": "array", "items": { "$ref": "SearchResult" }, "description": "List of search results." }
+            ]
+        },
+        {
+            "name": "setDocumentContent",
+            "description": "Sets given markup as the document's HTML.",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Frame id to set HTML for." },
+                { "name": "html", "type": "string", "description": "HTML content to set."  }
+            ]
+        },
+        {
+            "name": "setShowPaintRects",
+            "description": "Requests that backend shows paint rectangles",
+            "parameters": [
+                { "name": "result", "type": "boolean", "description": "True for showing paint rectangles" }
+            ]
+        },
+        {
+            "name": "getScriptExecutionStatus",
+            "description": "Determines if scripts can be executed in the page.",
+            "returns": [
+                { "name": "result", "type": "string", "enum": ["allowed", "disabled", "forbidden"], "description": "Script execution status: \"allowed\" if scripts can be executed, \"disabled\" if script execution has been disabled through page settings, \"forbidden\" if script execution for the given page is not possible for other reasons." }
+            ]
+        },
+        {
+            "name": "setScriptExecutionDisabled",
+            "description": "Switches script execution in the page.",
+            "parameters": [
+                { "name": "value", "type": "boolean", "description": "Whether script execution should be disabled in the page." }
+            ]
+        },
+        {
+            "name": "setTouchEmulationEnabled",
+            "parameters": [
+                { "name": "enabled", "type": "boolean", "description": "Whether the touch event emulation should be enabled." }
+            ],
+            "description": "Toggles mouse event-based touch event emulation."
+        },
+        {
+            "name": "setEmulatedMedia",
+            "parameters": [
+                { "name": "media", "type": "string", "description": "Media type to emulate. Empty string disables the override." }
+            ],
+            "description": "Emulates the given media for CSS media queries."
+        },
+        {
+            "name": "getCompositingBordersVisible",
+            "description": "Indicates the visibility of compositing borders.",
+            "returns": [
+                { "name": "result", "type": "boolean", "description": "If true, compositing borders are visible." }
+            ]
+        },
+        {
+            "name": "setCompositingBordersVisible",
+            "description": "Controls the visibility of compositing borders.",
+            "parameters": [
+                { "name": "visible", "type": "boolean", "description": "True for showing compositing borders." }
+            ]
+        },
+        {
+            "name": "snapshotNode",
+            "description": "Capture a snapshot of the specified node that does not include unrelated layers.",
+            "parameters": [
+                { "name": "nodeId", "$ref": "DOM.NodeId", "description": "Id of the node to snapshot." }
+            ],
+            "returns": [
+                { "name": "dataURL", "type": "string", "description": "Base64-encoded image data (PNG)." }
+            ]
+        },
+        {
+            "name": "snapshotRect",
+            "description": "Capture a snapshot of the page within the specified rectangle and coordinate system.",
+            "parameters": [
+                { "name": "x", "type": "integer", "description": "X coordinate" },
+                { "name": "y", "type": "integer", "description": "Y coordinate" },
+                { "name": "width", "type": "integer", "description": "Rectangle width" },
+                { "name": "height", "type": "integer", "description": "Rectangle height" },
+                { "name": "coordinateSystem", "$ref": "CoordinateSystem", "description": "Indicates the coordinate system of the supplied rectangle." }
+            ],
+            "returns": [
+                { "name": "dataURL", "type": "string", "description": "Base64-encoded image data (PNG)." }
+            ]
+        },
+        {
+            "name": "handleJavaScriptDialog",
+            "description": "Accepts or dismisses a JavaScript initiated dialog (alert, confirm, prompt, or onbeforeunload).",
+            "parameters": [
+                { "name": "accept", "type": "boolean", "description": "Whether to accept or dismiss the dialog." },
+                { "name": "promptText", "type": "string", "optional": true, "description": "The text to enter into the dialog prompt before accepting. Used only if this is a prompt dialog." }
+            ]
+        },
+        {
+            "name": "archive",
+            "description": "Grab an archive of the page.",
+            "returns": [
+                { "name": "data", "type": "string", "description": "Base64-encoded web archive." }
+            ]
+        }
+    ],
+    "events": [
+        {
+            "name": "domContentEventFired",
+            "parameters": [
+                { "name": "timestamp", "type": "number" }
+            ]
+        },
+        {
+            "name": "loadEventFired",
+            "parameters": [
+                { "name": "timestamp", "type": "number" }
+            ]
+        },
+        {
+            "name": "frameNavigated",
+            "description": "Fired once navigation of the frame has completed. Frame is now associated with the new loader.",
+            "parameters": [
+                { "name": "frame", "$ref": "Frame", "description": "Frame object." }
+            ]
+        },
+        {
+            "name": "frameDetached",
+            "description": "Fired when frame has been detached from its parent.",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Id of the frame that has been detached." }
+            ]
+        },
+        {
+            "name": "frameStartedLoading",
+            "description": "Fired when frame has started loading.",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Id of the frame that has started loading." }
+            ]
+        },
+        {
+            "name": "frameStoppedLoading",
+            "description": "Fired when frame has stopped loading.",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Id of the frame that has stopped loading." }
+            ]
+        },
+        {
+            "name": "frameScheduledNavigation",
+            "description": "Fired when frame schedules a potential navigation.",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Id of the frame that has scheduled a navigation." },
+                { "name": "delay", "type": "number", "description": "Delay (in seconds) until the navigation is scheduled to begin. The navigation is not guaranteed to start." }
+            ]
+        },
+        {
+            "name": "frameClearedScheduledNavigation",
+            "description": "Fired when frame no longer has a scheduled navigation.",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Id of the frame that has cleared its scheduled navigation." }
+            ]
+        },
+        {
+            "name": "javascriptDialogOpening",
+            "description": "Fired when a JavaScript initiated dialog (alert, confirm, prompt, or onbeforeunload) is about to open.",
+            "parameters": [
+                { "name": "message", "type": "string", "description": "Message that will be displayed by the dialog." }
+            ]
+        },
+        {
+            "name": "javascriptDialogClosed",
+            "description": "Fired when a JavaScript initiated dialog (alert, confirm, prompt, or onbeforeunload) has been closed."
+        },
+        {
+            "name": "scriptsEnabled",
+            "description": "Fired when the JavaScript is enabled/disabled on the page",
+            "parameters": [
+                { "name": "isEnabled", "type": "boolean", "description": "Whether script execution is enabled or disabled on the page." }
+            ]
+        }
+    ]
+}
+,
+{
+    "domain": "Runtime",
+    "description": "Runtime domain exposes JavaScript runtime by means of remote evaluation and mirror objects. Evaluation results are returned as mirror object that expose object type, string representation and unique identifier that can be used for further object reference. Original objects are maintained in memory unless they are either explicitly released or are released along with the other objects in their object group.",
+    "types": [
+        {
+            "id": "RemoteObjectId",
+            "type": "string",
+            "description": "Unique object identifier."
+        },
+        {
+            "id": "RemoteObject",
+            "type": "object",
+            "description": "Mirror object referencing original JavaScript object.",
+            "properties": [
+                { "name": "type", "type": "string", "enum": ["object", "function", "undefined", "string", "number", "boolean", "symbol"], "description": "Object type." },
+                { "name": "subtype", "type": "string", "optional": true, "enum": ["array", "null", "node", "regexp", "date", "error", "map", "set", "weakmap", "weakset", "iterator", "class"], "description": "Object subtype hint. Specified for <code>object</code> <code>function</code> (for class) type values only." },
+                { "name": "className", "type": "string", "optional": true, "description": "Object class (constructor) name. Specified for <code>object</code> type values only." },
+                { "name": "value", "type": "any", "optional": true, "description": "Remote object value (in case of primitive values or JSON values if it was requested)." },
+                { "name": "description", "type": "string", "optional": true, "description": "String representation of the object." },
+                { "name": "objectId", "$ref": "RemoteObjectId", "optional": true, "description": "Unique object identifier (for non-primitive values)." },
+                { "name": "size", "type": "integer", "optional": true, "description": "Size of the array/collection. Specified for array/map/set/weakmap/weakset object type values only." },
+                { "name": "classPrototype", "$ref": "RemoteObject", "optional": true, "description": "Remote object for the class prototype. Specified for class object type values only." },
+                { "name": "preview", "$ref": "ObjectPreview", "optional": true, "description": "Preview containing abbreviated property values. Specified for <code>object</code> type values only." }
+            ]
+        },
+        {
+            "id": "ObjectPreview",
+            "type": "object",
+            "description": "Object containing abbreviated remote object value.",
+            "properties": [
+                { "name": "type", "type": "string", "enum": ["object", "function", "undefined", "string", "number", "boolean", "symbol"], "description": "Object type." },
+                { "name": "subtype", "type": "string", "optional": true, "enum": ["array", "null", "node", "regexp", "date", "error", "map", "set", "weakmap", "weakset", "iterator", "class"], "description": "Object subtype hint. Specified for <code>object</code> type values only." },
+                { "name": "description", "type": "string", "optional": true, "description": "String representation of the object." },
+                { "name": "lossless", "type": "boolean", "description": "Determines whether preview is lossless (contains all information of the original object)." },
+                { "name": "overflow", "type": "boolean", "optional": true, "description": "True iff some of the properties of the original did not fit." },
+                { "name": "properties", "type": "array", "items": { "$ref": "PropertyPreview" }, "optional": true, "description": "List of the properties." },
+                { "name": "entries", "type": "array", "items": { "$ref": "EntryPreview" }, "optional": true, "description": "List of the entries. Specified for <code>map</code> and <code>set</code> subtype values only." },
+                { "name": "size", "type": "integer", "optional": true, "description": "Size of the array/collection. Specified for array/map/set/weakmap/weakset object type values only." }
+            ]
+        },
+        {
+            "id": "PropertyPreview",
+            "type": "object",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Property name." },
+                { "name": "type", "type": "string", "enum": ["object", "function", "undefined", "string", "number", "boolean", "symbol", "accessor"], "description": "Object type." },
+                { "name": "subtype", "type": "string", "optional": true, "enum": ["array", "null", "node", "regexp", "date", "error", "map", "set", "weakmap", "weakset", "iterator", "class"], "description": "Object subtype hint. Specified for <code>object</code> type values only." },
+                { "name": "value", "type": "string", "optional": true, "description": "User-friendly property value string." },
+                { "name": "valuePreview", "$ref": "ObjectPreview", "optional": true, "description": "Nested value preview." },
+                { "name": "internal", "type": "boolean", "optional": true, "description": "True if this is an internal property." }
+            ]
+        },
+        {
+            "id": "EntryPreview",
+            "type": "object",
+            "properties": [
+                { "name": "key", "$ref": "ObjectPreview", "optional": true, "description": "Entry key. Specified for map-like collection entries." },
+                { "name": "value", "$ref": "ObjectPreview", "description": "Entry value." }
+            ]
+        },
+        {
+            "id": "CollectionEntry",
+            "type": "object",
+            "properties": [
+                { "name": "key", "$ref": "Runtime.RemoteObject", "optional": true, "description": "Entry key of a map-like collection, otherwise not provided." },
+                { "name": "value", "$ref": "Runtime.RemoteObject", "description": "Entry value." }
+            ]
+        },
+        {
+            "id": "PropertyDescriptor",
+            "type": "object",
+            "description": "Object property descriptor.",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Property name or symbol description." },
+                { "name": "value", "$ref": "RemoteObject", "optional": true, "description": "The value associated with the property." },
+                { "name": "writable", "type": "boolean", "optional": true, "description": "True if the value associated with the property may be changed (data descriptors only)." },
+                { "name": "get", "$ref": "RemoteObject", "optional": true, "description": "A function which serves as a getter for the property, or <code>undefined</code> if there is no getter (accessor descriptors only)." },
+                { "name": "set", "$ref": "RemoteObject", "optional": true, "description": "A function which serves as a setter for the property, or <code>undefined</code> if there is no setter (accessor descriptors only)." },
+                { "name": "configurable", "type": "boolean", "description": "True if the type of this property descriptor may be changed and if the property may be deleted from the corresponding object." },
+                { "name": "enumerable", "type": "boolean", "description": "True if this property shows up during enumeration of the properties on the corresponding object." },
+                { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." },
+                { "name": "isOwn", "optional": true, "type": "boolean", "description": "True if the property is owned for the object." },
+                { "name": "symbol", "optional": true, "$ref": "Runtime.RemoteObject", "description": "Property symbol object, if the property is a symbol." },
+                { "name": "nativeGetter", "optional": true, "type": "boolean", "description": "True if the property value came from a native getter." }
+            ]
+        },
+        {
+            "id": "InternalPropertyDescriptor",
+            "type": "object",
+            "description": "Object internal property descriptor. This property isn't normally visible in JavaScript code.",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Conventional property name." },
+                { "name": "value", "$ref": "RemoteObject", "optional": true, "description": "The value associated with the property." }
+            ]
+        },
+        {
+            "id": "CallArgument",
+            "type": "object",
+            "description": "Represents function call argument. Either remote object id <code>objectId</code> or primitive <code>value</code> or neither of (for undefined) them should be specified.",
+            "properties": [
+                { "name": "value", "type": "any", "optional": true, "description": "Primitive value." },
+                { "name": "objectId", "$ref": "RemoteObjectId", "optional": true, "description": "Remote object handle." }
+            ]
+        },
+        {
+            "id": "ExecutionContextId",
+            "type": "integer",
+            "description": "Id of an execution context."
+        },
+        {
+            "id": "ExecutionContextDescription",
+            "type": "object",
+            "description": "Description of an isolated world.",
+            "properties": [
+                { "name": "id", "$ref": "ExecutionContextId", "description": "Unique id of the execution context. It can be used to specify in which execution context script evaluation should be performed." },
+                { "name": "isPageContext", "type": "boolean", "description": "True if this is a context where inpspected web page scripts run. False if it is a content script isolated context." },
+                { "name": "name", "type": "string", "description": "Human readable name describing given context."},
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Id of the owning frame." }
+            ]
+        },
+        {
+            "id": "SyntaxErrorType",
+            "type": "string",
+            "enum": ["none", "irrecoverable", "unterminated-literal", "recoverable"],
+            "description": "Syntax error type: \"none\" for no error, \"irrecoverable\" for unrecoverable errors, \"unterminated-literal\" for when there is an unterminated literal, \"recoverable\" for when the expression is unfinished but valid so far."
+        },
+        {
+            "id": "ErrorRange",
+            "type": "object",
+            "description": "Range of an error in source code.",
+            "properties": [
+                { "name": "startOffset", "type": "integer", "description": "Start offset of range (inclusive)." },
+                { "name": "endOffset", "type": "integer", "description": "End offset of range (exclusive)." }
+            ]
+        },
+        {
+            "id": "StructureDescription",
+            "type": "object",
+            "properties": [
+                { "name": "fields", "type": "array",  "items": { "type": "string" }, "optional": true, "description": "Array of strings, where the strings represent object properties." },
+                { "name": "optionalFields", "type": "array",  "items": { "type": "string" }, "optional": true, "description": "Array of strings, where the strings represent optional object properties." },
+                { "name": "constructorName", "type": "string", "optional": true, "description": "Name of the constructor." },
+                { "name": "prototypeStructure", "$ref": "StructureDescription", "optional": true, "description": "Pointer to the StructureRepresentation of the protoype if one exists." },
+                { "name": "isImprecise", "type": "boolean", "optional": true, "description": "If true, it indicates that the fields in this StructureDescription may be inaccurate. I.e, there might have been fields that have been deleted before it was profiled or it has fields we haven't profiled." }
+            ]
+        },
+        {
+            "id": "TypeSet",
+            "type": "object",
+            "properties": [
+                { "name": "isFunction", "type": "boolean", "description": "Indicates if this type description has been type Function." },
+                { "name": "isUndefined", "type": "boolean", "description": "Indicates if this type description has been type Undefined." },
+                { "name": "isNull", "type": "boolean", "description": "Indicates if this type description has been type Null." },
+                { "name": "isBoolean", "type": "boolean", "description": "Indicates if this type description has been type Boolean." },
+                { "name": "isInteger", "type": "boolean", "description": "Indicates if this type description has been type Integer." },
+                { "name": "isNumber", "type": "boolean", "description": "Indicates if this type description has been type Number." },
+                { "name": "isString", "type": "boolean", "description": "Indicates if this type description has been type String." },
+                { "name": "isObject", "type": "boolean", "description": "Indicates if this type description has been type Object." },
+                { "name": "isSymbol", "type": "boolean", "description": "Indicates if this type description has been type Symbol." }
+            ]
+        },
+        {
+            "id": "TypeDescription",
+            "type": "object",
+            "description": "Container for type information that has been gathered.",
+            "properties": [
+                { "name": "isValid", "type": "boolean", "description": "If true, we were able to correlate the offset successfuly with a program location. If false, the offset may be bogus or the offset may be from a CodeBlock that hasn't executed." },
+                { "name": "leastCommonAncestor", "type": "string", "optional": true, "description": "Least common ancestor of all Constructors if the TypeDescription has seen any structures. This string is the display name of the shared constructor function." },
+                { "name": "typeSet", "$ref": "TypeSet", "optional": true, "description": "Set of booleans for determining the aggregate type of this type description." },
+                { "name": "structures", "type": "array", "items": { "$ref": "StructureDescription" }, "optional": true, "description": "Array of descriptions for all structures seen for this variable." },
+                { "name": "isTruncated", "type": "boolean", "optional": true, "description": "If true, this indicates that no more structures are being profiled because some maximum threshold has been reached and profiling has stopped because of memory pressure." }
+            ]
+        },
+        {
+            "id": "TypeLocation",
+            "type": "object",
+            "description": "Describes the location of an expression we want type information for.",
+            "properties": [
+                { "name": "typeInformationDescriptor", "type": "integer", "description": "What kind of type information do we want (normal, function return values, 'this' statement)." },
+                { "name": "sourceID", "type": "string", "description": "sourceID uniquely identifying a script" },
+                { "name": "divot", "type": "integer", "description": "character offset for assignment range" }
+            ]
+        },
+        {
+            "id": "BasicBlock",
+            "type": "object",
+            "description": "From Wikipedia: a basic block is a portion of the code within a program with only one entry point and only one exit point. This type gives the location of a basic block and if that basic block has executed.",
+            "properties": [
+                { "name": "startOffset", "type": "integer", "description": "Start offset of the basic block." },
+                { "name": "endOffset", "type": "integer", "description": "End offset of the basic block." },
+                { "name": "hasExecuted", "type": "boolean", "description": "Indicates if the basic block has executed before." }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "parse",
+            "parameters": [
+                { "name": "source", "type": "string", "description": "Source code to parse." }
+            ],
+            "returns": [
+                { "name": "result", "$ref": "SyntaxErrorType", "description": "Parse result." },
+                { "name": "message", "type": "string", "optional": true, "description": "Parse error message." },
+                { "name": "range", "$ref": "ErrorRange", "optional": true, "description": "Range in the source where the error occurred." }
+            ],
+            "description": "Parses JavaScript source code for errors."
+        },
+        {
+            "name": "evaluate",
+            "parameters": [
+                { "name": "expression", "type": "string", "description": "Expression to evaluate." },
+                { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." },
+                { "name": "includeCommandLineAPI", "type": "boolean", "optional": true, "description": "Determines whether Command Line API should be available during the evaluation." },
+                { "name": "doNotPauseOnExceptionsAndMuteConsole", "type": "boolean", "optional": true, "description": "Specifies whether evaluation should stop on exceptions and mute console. Overrides setPauseOnException state." },
+                { "name": "contextId", "$ref": "Runtime.ExecutionContextId", "optional": true, "description": "Specifies in which isolated context to perform evaluation. Each content script lives in an isolated context and this parameter may be used to specify one of those contexts. If the parameter is omitted or 0 the evaluation will be performed in the context of the inspected page." },
+                { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object that should be sent by value." },
+                { "name": "generatePreview", "type": "boolean", "optional": true, "description": "Whether preview should be generated for the result." },
+                { "name": "saveResult", "type": "boolean", "optional": true, "description": "Whether the resulting value should be considered for saving in the $n history." }
+            ],
+            "returns": [
+                { "name": "result", "$ref": "RemoteObject", "description": "Evaluation result." },
+                { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." },
+                { "name": "savedResultIndex", "type": "integer", "optional": true, "description": "If the result was saved, this is the $n index that can be used to access the value." }
+            ],
+            "description": "Evaluates expression on global object."
+        },
+        {
+            "name": "callFunctionOn",
+            "parameters": [
+                { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to call function on." },
+                { "name": "functionDeclaration", "type": "string", "description": "Declaration of the function to call." },
+                { "name": "arguments", "type": "array", "items": { "$ref": "CallArgument", "description": "Call argument." }, "optional": true, "description": "Call arguments. All call arguments must belong to the same JavaScript world as the target object." },
+                { "name": "doNotPauseOnExceptionsAndMuteConsole", "type": "boolean", "optional": true, "description": "Specifies whether function call should stop on exceptions and mute console. Overrides setPauseOnException state." },
+                { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object which should be sent by value." },
+                { "name": "generatePreview", "type": "boolean", "optional": true, "description": "Whether preview should be generated for the result." }
+            ],
+            "returns": [
+                { "name": "result", "$ref": "RemoteObject", "description": "Call result." },
+                { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." }
+            ],
+            "description": "Calls function with given declaration on the given object. Object group of the result is inherited from the target object."
+        },
+        {
+            "name": "getProperties",
+            "parameters": [
+                { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to return properties for." },
+                { "name": "ownProperties", "optional": true, "type": "boolean", "description": "If true, returns properties belonging only to the object itself, not to its prototype chain." },
+                { "name": "generatePreview", "type": "boolean", "optional": true, "description": "Whether preview should be generated for property values." }
+            ],
+            "returns": [
+                { "name": "result", "type": "array", "items": { "$ref": "PropertyDescriptor"}, "description": "Object properties." },
+                { "name": "internalProperties", "optional": true, "type": "array", "items": { "$ref": "InternalPropertyDescriptor"}, "description": "Internal object properties." }
+            ],
+            "description": "Returns properties of a given object. Object group of the result is inherited from the target object."
+        },
+        {
+            "name": "getDisplayableProperties",
+            "parameters": [
+                { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to return properties for." },
+                { "name": "generatePreview", "type": "boolean", "optional": true, "description": "Whether preview should be generated for property values." }
+            ],
+            "returns": [
+                { "name": "properties", "type": "array", "items": { "$ref": "PropertyDescriptor"}, "description": "Object properties." },
+                { "name": "internalProperties", "optional": true, "type": "array", "items": { "$ref": "InternalPropertyDescriptor"}, "description": "Internal object properties." }
+            ],
+            "description": "Returns displayable properties of a given object. Object group of the result is inherited from the target object. Displayable properties are own properties, internal properties, and native getters in the prototype chain (assumed to be bindings and treated like own properties for the frontend)."
+        },
+        {
+            "name": "getCollectionEntries",
+            "description": "Returns entries of given Map / Set collection.",
+            "parameters": [
+                { "name": "objectId", "$ref": "Runtime.RemoteObjectId", "description": "Id of the collection to get entries for." },
+                { "name": "objectGroup", "optional": true, "type": "string", "description": "Symbolic group name that can be used to release multiple. If not provided, it will be the same objectGroup as the RemoteObject determined from <code>objectId</code>. This is useful for WeakMap to release the collection entries." },
+                { "name": "startIndex", "optional": true, "type": "integer", "description": "If provided skip to this index before collecting values. Otherwise, 0." },
+                { "name": "numberToFetch", "optional": true, "type": "integer", "description": "If provided only return <code>numberToFetch</code> values. Otherwise, return values all the way to the end." }
+            ],
+            "returns": [
+                { "name": "entries", "type": "array", "items": { "$ref": "CollectionEntry" }, "description": "Array of collection entries." }
+            ]
+        },
+        {
+            "name": "saveResult",
+            "parameters": [
+                { "name": "value", "$ref": "CallArgument", "description": "Id or value of the object to save." },
+                { "name": "contextId", "optional": true, "$ref": "ExecutionContextId", "description": "Unique id of the execution context. To specify in which execution context script evaluation should be performed. If not provided, determine from the CallArgument's objectId." }
+            ],
+            "returns": [
+                { "name": "savedResultIndex", "type": "integer", "optional": true, "description": "If the value was saved, this is the $n index that can be used to access the value." }
+            ],
+            "description": "Assign a saved result index to this value."
+        },
+        {
+            "name": "releaseObject",
+            "parameters": [
+                { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to release." }
+            ],
+            "description": "Releases remote object with given id."
+        },
+        {
+            "name": "releaseObjectGroup",
+            "parameters": [
+                { "name": "objectGroup", "type": "string", "description": "Symbolic object group name." }
+            ],
+            "description": "Releases all remote objects that belong to a given group."
+        },
+        {
+            "name": "enable",
+            "description": "Enables reporting of execution contexts creation by means of <code>executionContextCreated</code> event. When the reporting gets enabled the event will be sent immediately for each existing execution context."
+        },
+        {
+            "name": "disable",
+            "description": "Disables reporting of execution contexts creation."
+        },
+        {
+            "name": "getRuntimeTypesForVariablesAtOffsets",
+            "parameters": [
+                { "name": "locations", "type": "array", "items": { "$ref": "TypeLocation" }, "description": "An array of type locations we're requesting information for. Results are expected in the same order they're sent in."}
+            ],
+            "returns": [
+                { "name": "types", "type": "array", "items": { "$ref": "TypeDescription", "description": "Types for requested variable." } }
+            ],
+            "description": "Returns detailed informtation on given function."
+        },
+        {
+            "name": "enableTypeProfiler",
+            "description": "Enables type profiling on the VM."
+        },
+        {
+            "name": "disableTypeProfiler",
+            "description": "Disables type profiling on the VM."
+        },
+        {
+            "name": "getBasicBlocks",
+            "parameters": [
+                { "name": "sourceID", "type": "string", "description": "Indicates which sourceID information is requested for." }
+            ],
+            "returns": [
+                { "name": "basicBlocks", "type": "array", "items": { "$ref": "BasicBlock", "description": "Array of basic blocks." } }
+            ],
+            "description": "Returns a list of basic blocks for the given sourceID with information about their text ranges and whether or not they have executed."
+        }
+    ],
+    "events": [
+        {
+            "name": "executionContextCreated",
+            "parameters": [
+                { "name": "context", "$ref": "ExecutionContextDescription", "description": "A newly created execution contex." }
+            ],
+            "description": "Issued when new execution context is created."
+        }
+    ]
+}
+,
+{
+    "domain": "Timeline",
+    "description": "Timeline provides its clients with instrumentation records that are generated during the page runtime. Timeline instrumentation can be started and stopped using corresponding commands. While timeline is started, it is generating timeline event records.",
+    "availability": "web",
+    "types": [
+        {
+            "id": "EventType",
+            "type": "string",
+            "enum": [
+                "EventDispatch",
+                "ScheduleStyleRecalculation",
+                "RecalculateStyles",
+                "InvalidateLayout",
+                "Layout",
+                "Paint",
+                "Composite",
+                "RenderingFrame",
+                "ParseHTML",
+                "TimerInstall",
+                "TimerRemove",
+                "TimerFire",
+                "EvaluateScript",
+                "MarkLoad",
+                "MarkDOMContent",
+                "TimeStamp",
+                "Time",
+                "TimeEnd",
+                "XHRReadyStateChange",
+                "XHRLoad",
+                "FunctionCall",
+                "ProbeSample",
+                "ConsoleProfile",
+                "RequestAnimationFrame",
+                "CancelAnimationFrame",
+                "FireAnimationFrame",
+                "WebSocketCreate",
+                "WebSocketSendHandshakeRequest",
+                "WebSocketReceiveHandshakeResponse",
+                "WebSocketDestroy"
+            ],
+            "description": "Timeline record type."
+        },
+        {
+            "id": "TimelineEvent",
+            "type": "object",
+            "properties": [
+                { "name": "type", "$ref": "EventType", "description": "Event type." },
+                { "name": "data", "type": "object", "description": "Event data." },
+                { "name": "children", "type": "array", "optional": true, "items": { "$ref": "TimelineEvent" }, "description": "Nested records." }
+            ],
+            "description": "Timeline record contains information about the recorded activity."
+        },
+        {
+            "id": "CPUProfileNodeAggregateCallInfo",
+            "type": "object",
+            "description": "Aggregate CPU Profile call info. Holds time information for all the calls that happened on a node.",
+            "properties": [
+                { "name": "callCount", "type": "number", "description": "Total number of calls." },
+                { "name": "startTime", "type": "number", "description": "Start time for the first call." },
+                { "name": "endTime", "type": "number", "description": "End time for the last call." },
+                { "name": "totalTime", "type": "number", "description": "Total execution time for all calls combined." }
+            ]
+        },
+        {
+            "id": "CPUProfileNode",
+            "type": "object",
+            "description": "CPU Profile node. Holds callsite information, execution statistics and child nodes.",
+            "properties": [
+                { "name": "id", "type": "integer", "description": "Unique identifier for this call site." },
+                { "name": "callInfo", "$ref": "CPUProfileNodeAggregateCallInfo", "description": "Aggregate info about all the calls that making up this node." },
+                { "name": "functionName", "type": "string", "optional": true, "description": "Function name." },
+                { "name": "url", "type": "string", "optional": true, "description": "URL." },
+                { "name": "lineNumber", "type": "integer", "optional": true, "description": "Line number." },
+                { "name": "columnNumber", "type": "integer", "optional": true, "description": "Column number." },
+                { "name": "children", "type": "array", "items": { "$ref": "CPUProfileNode" }, "optional": true, "description": "Child nodes." }
+            ]
+        },
+        {
+            "id": "CPUProfile",
+            "type": "object",
+            "description": "Profile.",
+            "properties": [
+                { "name": "rootNodes", "type": "array", "items": { "$ref": "CPUProfileNode" }, "description": "Top level nodes in the stack." },
+                { "name": "idleTime", "type": "number", "optional": true }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "start",
+            "parameters": [
+                { "name": "maxCallStackDepth", "optional": true, "type": "integer", "description": "Samples JavaScript stack traces up to <code>maxCallStackDepth</code>, defaults to 5." }
+            ],
+            "description": "Starts capturing instrumentation events."
+        },
+        {
+            "name": "stop",
+            "description": "Stops capturing instrumentation events."
+        }
+    ],
+    "events": [
+        {
+            "name": "eventRecorded",
+            "parameters": [
+                { "name": "record", "$ref": "TimelineEvent", "description": "Timeline event record data." }
+            ],
+            "description": "Fired for every instrumentation event while timeline is started."
+        },
+        {
+            "name": "recordingStarted",
+            "description": "Fired when recording has started."
+        },
+        {
+            "name": "recordingStopped",
+            "description": "Fired when recording has stopped."
+        }
+    ]
+}
+]}

--- a/source/ProtocolGenerator/Inspector-iOS-9.3.json
+++ b/source/ProtocolGenerator/Inspector-iOS-9.3.json
@@ -1,0 +1,3476 @@
+{"domains":[
+{
+    "domain": "ApplicationCache",
+    "availability": "web",
+    "types": [
+        {
+            "id": "ApplicationCacheResource",
+            "type": "object",
+            "description": "Detailed application cache resource information.",
+            "properties": [
+                { "name": "url", "type": "string", "description": "Resource url." },
+                { "name": "size", "type": "integer", "description": "Resource size." },
+                { "name": "type", "type": "string", "description": "Resource type." }
+            ]
+        },
+        {
+            "id": "ApplicationCache",
+            "type": "object",
+            "description": "Detailed application cache information.",
+            "properties": [
+                { "name": "manifestURL", "type": "string", "description": "Manifest URL." },
+                { "name": "size", "type": "number", "description": "Application cache size." },
+                { "name": "creationTime", "type": "number", "description": "Application cache creation time." },
+                { "name": "updateTime", "type": "number", "description": "Application cache update time." },
+                { "name": "resources", "type": "array", "items": { "$ref": "ApplicationCacheResource" }, "description": "Application cache resources." }
+            ]
+        },
+        {
+            "id": "FrameWithManifest",
+            "type": "object",
+            "description": "Frame identifier - manifest URL pair.",
+            "properties": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Frame identifier." },
+                { "name": "manifestURL", "type": "string", "description": "Manifest URL." },
+                { "name": "status", "type": "integer", "description": "Application cache status." }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "getFramesWithManifests",
+            "returns": [
+                { "name": "frameIds", "type": "array", "items": { "$ref": "FrameWithManifest" }, "description": "Array of frame identifiers with manifest urls for each frame containing a document associated with some application cache." }
+            ],
+            "description": "Returns array of frame identifiers with manifest urls for each frame containing a document associated with some application cache."
+        },
+        {
+            "name": "enable",
+            "description": "Enables application cache domain notifications."
+        },
+        {
+            "name": "getManifestForFrame",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Identifier of the frame containing document whose manifest is retrieved." }
+            ],
+            "returns": [
+                { "name": "manifestURL", "type": "string", "description": "Manifest URL for document in the given frame." }
+            ],
+            "description": "Returns manifest URL for document in the given frame."
+        },
+        {
+            "name": "getApplicationCacheForFrame",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Identifier of the frame containing document whose application cache is retrieved." }
+            ],
+            "returns": [
+                { "name": "applicationCache", "$ref": "ApplicationCache", "description": "Relevant application cache data for the document in given frame." }
+            ],
+            "description": "Returns relevant application cache data for the document in given frame."
+        }
+    ],
+    "events": [
+        {
+            "name": "applicationCacheStatusUpdated",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Identifier of the frame containing document whose application cache updated status." },
+                { "name": "manifestURL", "type": "string", "description": "Manifest URL." },
+                { "name": "status", "type": "integer", "description": "Updated application cache status." }
+            ]
+        },
+        {
+            "name": "networkStateUpdated",
+            "parameters": [
+                { "name": "isNowOnline", "type": "boolean" }
+            ]
+        }
+    ]
+}
+,
+{
+    "domain": "CSS",
+    "description": "This domain exposes CSS read/write operations. All CSS objects, like stylesheets, rules, and styles, have an associated <code>id</code> used in subsequent operations on the related object. Each object type has a specific <code>id</code> structure, and those are not interchangeable between objects of different kinds. CSS objects can be loaded using the <code>get*ForNode()</code> calls (which accept a DOM node id). Alternatively, a client can discover all the existing stylesheets with the <code>getAllStyleSheets()</code> method and subsequently load the required stylesheet contents using the <code>getStyleSheet[Text]()</code> methods.",
+    "availability": "web",
+    "types": [
+        {
+            "id": "StyleSheetId",
+            "type": "string"
+        },
+        {
+            "id": "CSSStyleId",
+            "type": "object",
+            "properties": [
+                { "name": "styleSheetId", "$ref": "StyleSheetId", "description": "Enclosing stylesheet identifier." },
+                { "name": "ordinal", "type": "integer", "description": "The style ordinal within the stylesheet." }
+            ],
+            "description": "This object identifies a CSS style in a unique way."
+        },
+        {
+            "id": "StyleSheetOrigin",
+            "type": "string",
+            "enum": ["user", "user-agent", "inspector", "regular"],
+            "description": "Stylesheet type: \"user\" for user stylesheets, \"user-agent\" for user-agent stylesheets, \"inspector\" for stylesheets created by the inspector (i.e. those holding the \"via inspector\" rules), \"regular\" for regular stylesheets."
+        },
+        {
+            "id": "CSSRuleId",
+            "type": "object",
+            "properties": [
+                { "name": "styleSheetId", "$ref": "StyleSheetId", "description": "Enclosing stylesheet identifier." },
+                { "name": "ordinal", "type": "integer", "description": "The rule ordinal within the stylesheet." }
+            ],
+            "description": "This object identifies a CSS rule in a unique way."
+        },
+        {
+            "id": "PseudoIdMatches",
+            "type": "object",
+            "properties": [
+                { "name": "pseudoId", "type": "integer", "description": "Pseudo style identifier (see <code>enum PseudoId</code> in <code>RenderStyleConstants.h</code>)."},
+                { "name": "matches", "type": "array", "items": { "$ref": "RuleMatch" }, "description": "Matches of CSS rules applicable to the pseudo style."}
+            ],
+            "description": "CSS rule collection for a single pseudo style."
+        },
+        {
+            "id": "InheritedStyleEntry",
+            "type": "object",
+            "properties": [
+                { "name": "inlineStyle", "$ref": "CSSStyle", "optional": true, "description": "The ancestor node's inline style, if any, in the style inheritance chain." },
+                { "name": "matchedCSSRules", "type": "array", "items": { "$ref": "RuleMatch" }, "description": "Matches of CSS rules matching the ancestor node in the style inheritance chain." }
+            ],
+            "description": "CSS rule collection for a single pseudo style."
+        },
+        {
+            "id": "RuleMatch",
+            "type": "object",
+            "properties": [
+                { "name": "rule", "$ref": "CSSRule", "description": "CSS rule in the match." },
+                { "name": "matchingSelectors", "type": "array", "items": { "type": "integer" }, "description": "Matching selector indices in the rule's selectorList selectors (0-based)." }
+            ],
+            "description": "Match data for a CSS rule."
+        },
+        {
+            "id": "CSSSelector",
+            "type": "object",
+            "properties": [
+                { "name": "text", "type": "string", "description": "Canonicalized selector text." },
+                { "name": "specificity", "optional": true, "type": "array", "items": { "type": "integer" }, "description": "Specificity (a, b, c) tuple. Included if the selector is sent in response to CSS.getMatchedStylesForNode which provides a context element." },
+                { "name": "dynamic", "optional": true, "type": "boolean", "description": "Whether or not the specificity can be dynamic. Included if the selector is sent in response to CSS.getMatchedStylesForNode which provides a context element." }
+            ],
+            "description": "CSS selector."
+        },
+        {
+            "id": "SelectorList",
+            "type": "object",
+            "properties": [
+                { "name": "selectors", "type": "array", "items": { "$ref": "CSSSelector" }, "description": "Selectors in the list." },
+                { "name": "text", "type": "string", "description": "Rule selector text." },
+                { "name": "range", "$ref": "SourceRange", "optional": true, "description": "Rule selector range in the underlying resource (if available)." }
+            ],
+            "description": "Selector list data."
+        },
+        {
+            "id": "CSSStyleAttribute",
+            "type": "object",
+            "properties": [
+                { "name": "name", "type": "string", "description": "DOM attribute name (e.g. \"width\")."},
+                { "name": "style", "$ref": "CSSStyle", "description": "CSS style generated by the respective DOM attribute."}
+            ],
+            "description": "CSS style information for a DOM style attribute."
+        },
+        {
+            "id": "CSSStyleSheetHeader",
+            "type": "object",
+            "properties": [
+                { "name": "styleSheetId", "$ref": "StyleSheetId", "description": "The stylesheet identifier."},
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Owner frame identifier."},
+                { "name": "sourceURL", "type": "string", "description": "Stylesheet resource URL."},
+                { "name": "origin", "$ref": "StyleSheetOrigin", "description": "Stylesheet origin."},
+                { "name": "title", "type": "string", "description": "Stylesheet title."},
+                { "name": "disabled", "type": "boolean", "description": "Denotes whether the stylesheet is disabled."},
+                { "name": "isInline", "type": "boolean", "description": "Whether this stylesheet is a <style> tag created by the parser. This is not set for document.written <style> tags." },
+                { "name": "startLine", "type": "number", "description": "Line offset of the stylesheet within the resource (zero based)." },
+                { "name": "startColumn", "type": "number", "description": "Column offset of the stylesheet within the resource (zero based)." }
+            ],
+            "description": "CSS stylesheet metainformation."
+        },
+        {
+            "id": "CSSStyleSheetBody",
+            "type": "object",
+            "properties": [
+                { "name": "styleSheetId", "$ref": "StyleSheetId", "description": "The stylesheet identifier."},
+                { "name": "rules", "type": "array", "items": { "$ref": "CSSRule" }, "description": "Stylesheet resource URL."},
+                { "name": "text", "type": "string", "optional": true, "description": "Stylesheet resource contents (if available)."}
+            ],
+            "description": "CSS stylesheet contents."
+        },
+        {
+            "id": "CSSRule",
+            "type": "object",
+            "properties": [
+                { "name": "ruleId", "$ref": "CSSRuleId", "optional": true, "description": "The CSS rule identifier (absent for user agent stylesheet and user-specified stylesheet rules)."},
+                { "name": "selectorList", "$ref": "SelectorList", "description": "Rule selector data." },
+                { "name": "sourceURL", "type": "string", "optional": true, "description": "Parent stylesheet resource URL (for regular rules)."},
+                { "name": "sourceLine", "type": "integer", "description": "Line ordinal of the rule selector start character in the resource."},
+                { "name": "origin", "$ref": "StyleSheetOrigin", "description": "Parent stylesheet's origin."},
+                { "name": "style", "$ref": "CSSStyle", "description": "Associated style declaration." },
+                { "name": "media", "type": "array", "items": { "$ref": "CSSMedia" }, "optional": true, "description": "Media list array (for rules involving media queries). The array enumerates media queries starting with the innermost one, going outwards." }
+            ],
+            "description": "CSS rule representation."
+        },
+        {
+            "id": "SourceRange",
+            "type": "object",
+            "properties": [
+                { "name": "startLine", "type": "integer", "description": "Start line of range." },
+                { "name": "startColumn", "type": "integer", "description": "Start column of range (inclusive)." },
+                { "name": "endLine", "type": "integer", "description": "End line of range" },
+                { "name": "endColumn", "type": "integer", "description": "End column of range (exclusive)." }
+            ],
+            "description": "Text range within a resource."
+        },
+        {
+            "id": "ShorthandEntry",
+            "type": "object",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Shorthand name." },
+                { "name": "value", "type": "string", "description": "Shorthand value." }
+            ]
+        },
+        {
+            "id": "CSSPropertyInfo",
+            "type": "object",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Property name." },
+                { "name": "longhands", "type": "array", "optional": true, "items": { "type": "string" }, "description": "Longhand property names." },
+                { "name": "values", "type": "array", "optional": true, "items": { "type": "string" }, "description": "Supported values for this property." }
+            ]
+        },
+        {
+            "id": "CSSComputedStyleProperty",
+            "type": "object",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Computed style property name." },
+                { "name": "value", "type": "string", "description": "Computed style property value." }
+            ]
+        },
+        {
+            "id": "CSSStyle",
+            "type": "object",
+            "properties": [
+                { "name": "styleId", "$ref": "CSSStyleId", "optional": true, "description": "The CSS style identifier (absent for attribute styles)." },
+                { "name": "cssProperties", "type": "array", "items": { "$ref": "CSSProperty" }, "description": "CSS properties in the style." },
+                { "name": "shorthandEntries", "type": "array", "items": { "$ref": "ShorthandEntry" }, "description": "Computed values for all shorthands found in the style." },
+                { "name": "cssText", "type": "string", "optional": true, "description": "Style declaration text (if available)." },
+                { "name": "range", "$ref": "SourceRange", "optional": true, "description": "Style declaration range in the enclosing stylesheet (if available)." },
+                { "name": "width", "type": "string", "optional": true, "description": "The effective \"width\" property value from this style." },
+                { "name": "height", "type": "string", "optional": true, "description": "The effective \"height\" property value from this style." }
+            ],
+            "description": "CSS style representation."
+        },
+        {
+            "id": "CSSPropertyStatus",
+	    "type": "string",
+            "enum": ["active", "inactive", "disabled", "style"],
+            "description": "The property status: \"active\" if the property is effective in the style, \"inactive\" if the property is overridden by a same-named property in this style later on, \"disabled\" if the property is disabled by the user, \"style\" (implied if absent) if the property is reported by the browser rather than by the CSS source parser."
+        },
+        {
+            "id": "CSSProperty",
+            "type": "object",
+            "properties": [
+                { "name": "name", "type": "string", "description": "The property name." },
+                { "name": "value", "type": "string", "description": "The property value." },
+                { "name": "priority", "type": "string", "optional": true, "description": "The property priority (implies \"\" if absent)." },
+                { "name": "implicit", "type": "boolean", "optional": true, "description": "Whether the property is implicit (implies <code>false</code> if absent)." },
+                { "name": "text", "type": "string", "optional": true, "description": "The full property text as specified in the style." },
+                { "name": "parsedOk", "type": "boolean", "optional": true, "description": "Whether the property is understood by the browser (implies <code>true</code> if absent)." },
+                { "name": "status", "$ref": "CSSPropertyStatus", "optional": true, "description": "Whether the property is active or disabled." },
+                { "name": "range", "$ref": "SourceRange", "optional": true, "description": "The entire property range in the enclosing style declaration (if available)." }
+            ],
+            "description": "CSS style effective visual dimensions and source offsets."
+        },
+        {
+            "id": "CSSMedia",
+            "type": "object",
+            "properties": [
+                { "name": "text", "type": "string", "description": "Media query text." },
+                { "name": "source", "type": "string", "enum": ["mediaRule", "importRule", "linkedSheet", "inlineSheet"], "description": "Source of the media query: \"mediaRule\" if specified by a @media rule, \"importRule\" if specified by an @import rule, \"linkedSheet\" if specified by a \"media\" attribute in a linked stylesheet's LINK tag, \"inlineSheet\" if specified by a \"media\" attribute in an inline stylesheet's STYLE tag." },
+                { "name": "sourceURL", "type": "string", "optional": true, "description": "URL of the document containing the media query description." },
+                { "name": "sourceLine", "type": "integer", "optional": true, "description": "Line in the document containing the media query (not defined for the \"stylesheet\" source)." }
+            ],
+            "description": "CSS media query descriptor."
+        },
+        {
+            "id": "Region",
+            "type": "object",
+            "properties": [
+                { "name": "regionOverset", "type": "string", "enum": ["overset", "fit", "empty"], "description": "The \"overset\" attribute of a Named Flow." },
+                { "name": "nodeId", "$ref": "DOM.NodeId", "description": "The corresponding DOM node id." }
+            ],
+            "description": "This object represents a region that flows from a Named Flow."
+        },
+        {
+            "id": "NamedFlow",
+            "type": "object",
+            "properties": [
+                { "name": "documentNodeId", "$ref": "DOM.NodeId", "description": "The document node id." },
+                { "name": "name", "type": "string", "description": "Named Flow identifier." },
+                { "name": "overset", "type": "boolean", "description": "The \"overset\" attribute of a Named Flow." },
+                { "name": "content", "type": "array", "items": { "$ref": "DOM.NodeId" }, "description": "An array of nodes that flow into the Named Flow." },
+                { "name": "regions", "type": "array", "items": { "$ref": "Region" }, "description": "An array of regions associated with the Named Flow." }
+            ],
+            "description": "This object represents a Named Flow."
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables the CSS agent for the given page. Clients should not assume that the CSS agent has been enabled until the result of this command is received."
+        },
+        {
+            "name": "disable",
+            "description": "Disables the CSS agent for the given page."
+        },
+        {
+            "name": "getMatchedStylesForNode",
+            "parameters": [
+                { "name": "nodeId", "$ref": "DOM.NodeId" },
+                { "name": "includePseudo", "type": "boolean", "optional": true, "description": "Whether to include pseudo styles (default: true)." },
+                { "name": "includeInherited", "type": "boolean", "optional": true, "description": "Whether to include inherited styles (default: true)." }
+            ],
+            "returns": [
+                { "name": "matchedCSSRules", "type": "array", "items": { "$ref": "RuleMatch" }, "optional": true, "description": "CSS rules matching this node, from all applicable stylesheets." },
+                { "name": "pseudoElements", "type": "array", "items": { "$ref": "PseudoIdMatches" }, "optional": true, "description": "Pseudo style matches for this node." },
+                { "name": "inherited", "type": "array", "items": { "$ref": "InheritedStyleEntry" }, "optional": true, "description": "A chain of inherited styles (from the immediate node parent up to the DOM tree root)." }
+            ],
+            "description": "Returns requested styles for a DOM node identified by <code>nodeId</code>."
+        },
+        {
+            "name": "getInlineStylesForNode",
+            "parameters": [
+                { "name": "nodeId", "$ref": "DOM.NodeId" }
+            ],
+            "returns": [
+                { "name": "inlineStyle", "$ref": "CSSStyle", "optional": true, "description": "Inline style for the specified DOM node." },
+                { "name": "attributesStyle", "$ref": "CSSStyle", "optional": true, "description": "Attribute-defined element style (e.g. resulting from \"width=20 height=100%\")."}
+            ],
+            "description": "Returns the styles defined inline (explicitly in the \"style\" attribute and implicitly, using DOM attributes) for a DOM node identified by <code>nodeId</code>."
+        },
+        {
+            "name": "getComputedStyleForNode",
+            "parameters": [
+                { "name": "nodeId", "$ref": "DOM.NodeId" }
+            ],
+            "returns": [
+                { "name": "computedStyle", "type": "array", "items": { "$ref": "CSSComputedStyleProperty" }, "description": "Computed style for the specified DOM node." }
+            ],
+            "description": "Returns the computed style for a DOM node identified by <code>nodeId</code>."
+        },
+        {
+            "name": "getAllStyleSheets",
+            "returns": [
+                { "name": "headers", "type": "array", "items": { "$ref": "CSSStyleSheetHeader" }, "description": "Descriptor entries for all available stylesheets." }
+            ],
+            "description": "Returns metainfo entries for all known stylesheets."
+        },
+        {
+            "name": "getStyleSheet",
+            "parameters": [
+                { "name": "styleSheetId", "$ref": "StyleSheetId" }
+            ],
+            "returns": [
+                { "name": "styleSheet", "$ref": "CSSStyleSheetBody", "description": "Stylesheet contents for the specified <code>styleSheetId</code>." }
+            ],
+            "description": "Returns stylesheet data for the specified <code>styleSheetId</code>."
+        },
+        {
+            "name": "getStyleSheetText",
+            "parameters": [
+                { "name": "styleSheetId", "$ref": "StyleSheetId" }
+            ],
+            "returns": [
+                { "name": "text", "type": "string", "description": "The stylesheet text." }
+            ],
+            "description": "Returns the current textual content and the URL for a stylesheet."
+        },
+        {
+            "name": "setStyleSheetText",
+            "parameters": [
+                { "name": "styleSheetId", "$ref": "StyleSheetId" },
+                { "name": "text", "type": "string" }
+            ],
+            "description": "Sets the new stylesheet text, thereby invalidating all existing <code>CSSStyleId</code>'s and <code>CSSRuleId</code>'s contained by this stylesheet."
+        },
+        {
+            "name": "setStyleText",
+            "parameters": [
+                { "name": "styleId", "$ref": "CSSStyleId" },
+                { "name": "text", "type": "string" }
+            ],
+            "returns": [
+                { "name": "style", "$ref": "CSSStyle", "description": "The resulting style after the text modification." }
+            ],
+            "description": "Sets the new <code>text</code> for the respective style."
+        },
+        {
+            "name": "setRuleSelector",
+            "parameters": [
+                { "name": "ruleId", "$ref": "CSSRuleId" },
+                { "name": "selector", "type": "string" }
+            ],
+            "returns": [
+                { "name": "rule", "$ref": "CSSRule", "description": "The resulting rule after the selector modification." }
+            ],
+            "description": "Modifies the rule selector."
+        },
+        {
+            "name": "createStyleSheet",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Identifier of the frame where the new \"inspector\" stylesheet should be created." }
+            ],
+            "returns": [
+                { "name": "styleSheetId", "$ref": "StyleSheetId", "description": "Identifier of the created \"inspector\" stylesheet." }
+            ],
+            "description": "Creates a new special \"inspector\" stylesheet in the frame with given <code>frameId</code>."
+        },
+        {
+            "name": "addRule",
+            "parameters": [
+                { "name": "styleSheetId", "$ref": "StyleSheetId" },
+                { "name": "selector", "type": "string" }
+            ],
+            "returns": [
+                { "name": "rule", "$ref": "CSSRule", "description": "The newly created rule." }
+            ],
+            "description": "Creates a new empty rule with the given <code>selector</code> in a stylesheet with given <code>styleSheetId</code>."
+        },
+        {
+            "name": "getSupportedCSSProperties",
+            "returns": [
+                { "name": "cssProperties", "type": "array", "items": { "$ref": "CSSPropertyInfo" }, "description": "Supported property metainfo." }
+            ],
+            "description": "Returns all supported CSS property names."
+        },
+        {
+            "name": "getSupportedSystemFontFamilyNames",
+            "returns": [
+                { "name": "fontFamilyNames", "type": "array", "items": { "type": "string" }, "description": "Supported system font families." }
+            ],
+            "description": "Returns all supported system font family names."
+        },
+        {
+            "name": "forcePseudoState",
+            "parameters": [
+                { "name": "nodeId", "$ref": "DOM.NodeId", "description": "The element id for which to force the pseudo state." },
+                { "name": "forcedPseudoClasses", "type": "array", "items": { "type": "string", "enum": ["active", "focus", "hover", "visited"] }, "description": "Element pseudo classes to force when computing the element's style." }
+            ],
+            "description": "Ensures that the given node will have specified pseudo-classes whenever its style is computed by the browser."
+        },
+        {
+            "name": "getNamedFlowCollection",
+            "parameters": [
+                { "name": "documentNodeId", "$ref": "DOM.NodeId", "description": "The document node id for which to get the Named Flow Collection." }
+            ],
+            "returns": [
+                { "name": "namedFlows", "type": "array", "items": { "$ref": "NamedFlow" }, "description": "An array containing the Named Flows in the document." }
+            ],
+            "description": "Returns the Named Flows from the document."
+        }
+    ],
+    "events": [
+        {
+            "name": "mediaQueryResultChanged",
+            "description": "Fires whenever a MediaQuery result changes (for example, after a browser window has been resized.) The current implementation considers only viewport-dependent media features."
+        },
+        {
+            "name": "styleSheetChanged",
+            "parameters": [
+                { "name": "styleSheetId", "$ref": "StyleSheetId" }
+            ],
+            "description": "Fired whenever a stylesheet is changed as a result of the client operation."
+        },
+        {
+            "name": "styleSheetAdded",
+            "parameters": [
+                { "name": "header", "$ref": "CSSStyleSheetHeader", "description": "Added stylesheet metainfo." }
+            ],
+            "description": "Fired whenever an active document stylesheet is added."
+        },
+        {
+            "name": "styleSheetRemoved",
+            "parameters": [
+                { "name": "styleSheetId", "$ref": "StyleSheetId", "description": "Identifier of the removed stylesheet." }
+            ],
+            "description": "Fired whenever an active document stylesheet is removed."
+        },
+        {
+            "name": "namedFlowCreated",
+            "parameters": [
+                { "name": "namedFlow", "$ref": "NamedFlow", "description": "The new Named Flow." }
+            ],
+            "description": "Fires when a Named Flow is created."
+        },
+        {
+            "name": "namedFlowRemoved",
+            "parameters": [
+                { "name": "documentNodeId", "$ref": "DOM.NodeId", "description": "The document node id." },
+                { "name": "flowName", "type": "string", "description": "Identifier of the removed Named Flow." }
+            ],
+            "description": "Fires when a Named Flow is removed: has no associated content nodes and regions."
+        },
+        {
+            "name": "regionOversetChanged",
+            "parameters": [
+                { "name": "namedFlow", "$ref": "NamedFlow", "description": "The Named Flow containing the regions whose regionOverset values changed." }
+            ],
+            "description": "Fires if any of the regionOverset values changed in a Named Flow's region chain."
+        },
+        {
+            "name": "registeredNamedFlowContentElement",
+            "parameters": [
+                { "name": "documentNodeId", "$ref": "DOM.NodeId", "description": "The document node id." },
+                { "name": "flowName", "type": "string", "description": "Named Flow identifier for which the new content element was registered." },
+                { "name": "contentNodeId", "$ref": "DOM.NodeId", "description": "The node id of the registered content node." },
+                { "name": "nextContentNodeId", "$ref": "DOM.NodeId", "description": "The node id of the element following the registered content node." }
+            ],
+            "description": "Fires when a Named Flow's has been registered with a new content node."
+        },
+        {
+            "name": "unregisteredNamedFlowContentElement",
+            "parameters": [
+                { "name": "documentNodeId", "$ref": "DOM.NodeId", "description": "The document node id." },
+                { "name": "flowName", "type": "string", "description": "Named Flow identifier for which the new content element was unregistered." },
+                { "name": "contentNodeId", "$ref": "DOM.NodeId", "description": "The node id of the unregistered content node." }
+            ],
+            "description": "Fires when a Named Flow's has been registered with a new content node."
+        }
+    ]
+}
+,
+{
+    "domain": "Console",
+    "description": "Console domain defines methods and events for interaction with the JavaScript console. Console collects messages created by means of the <a href='http://getfirebug.com/wiki/index.php/Console_API'>JavaScript Console API</a>. One needs to enable this domain using <code>enable</code> command in order to start receiving the console messages. Browser collects messages issued while console domain is not enabled as well and reports them using <code>messageAdded</code> notification upon enabling.",
+    "types": [
+        {
+            "id": "ConsoleMessage",
+            "type": "object",
+            "description": "Console message.",
+            "properties": [
+                { "name": "source", "type": "string", "enum": ["xml", "javascript", "network", "console-api", "storage", "appcache", "rendering", "css", "security", "content-blocker", "other"], "description": "Message source." },
+                { "name": "level", "type": "string", "enum": ["log", "info", "warning", "error", "debug"], "description": "Message severity." },
+                { "name": "text", "type": "string", "description": "Message text." },
+                { "name": "type", "type": "string", "optional": true, "enum": ["log", "dir", "dirxml", "table", "trace", "clear", "startGroup", "startGroupCollapsed", "endGroup", "assert", "timing", "profile", "profileEnd"], "description": "Console message type." },
+                { "name": "url", "type": "string", "optional": true, "description": "URL of the message origin." },
+                { "name": "line", "type": "integer", "optional": true, "description": "Line number in the resource that generated this message." },
+                { "name": "column", "type": "integer", "optional": true, "description": "Column number on the line in the resource that generated this message." },
+                { "name": "repeatCount", "type": "integer", "optional": true, "description": "Repeat count for repeated messages." },
+                { "name": "parameters", "type": "array", "items": { "$ref": "Runtime.RemoteObject" }, "optional": true, "description": "Message parameters in case of the formatted message." },
+                { "name": "stackTrace", "$ref": "StackTrace", "optional": true, "description": "JavaScript stack trace for assertions and error messages." },
+                { "name": "networkRequestId", "$ref": "Network.RequestId", "optional": true, "description": "Identifier of the network request associated with this message." }
+            ]
+        },
+        {
+            "id": "CallFrame",
+            "type": "object",
+            "description": "Stack entry for console errors and assertions.",
+            "properties": [
+                { "name": "functionName", "type": "string", "description": "JavaScript function name." },
+                { "name": "url", "type": "string", "description": "JavaScript script name or url." },
+                { "name": "lineNumber", "type": "integer", "description": "JavaScript script line number." },
+                { "name": "columnNumber", "type": "integer", "description": "JavaScript script column number." }
+            ]
+        },
+        {
+            "id": "StackTrace",
+            "type": "array",
+            "items": { "$ref": "CallFrame" },
+            "description": "Call frames for assertions or error messages."
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables console domain, sends the messages collected so far to the client by means of the <code>messageAdded</code> notification."
+        },
+        {
+            "name": "disable",
+            "description": "Disables console domain, prevents further console messages from being reported to the client."
+        },
+        {
+            "name": "clearMessages",
+            "description": "Clears console messages collected in the browser."
+        },
+        {
+            "name": "setMonitoringXHREnabled",
+            "parameters": [
+                { "name": "enabled", "type": "boolean", "description": "Monitoring enabled state." }
+            ],
+            "description": "Toggles monitoring of XMLHttpRequest. If <code>true</code>, console will receive messages upon each XHR issued."
+        },
+        {
+            "name": "addInspectedNode",
+            "parameters": [
+                { "name": "nodeId", "$ref": "DOM.NodeId", "description": "DOM node id to be accessible by means of $0 command line API." }
+            ],
+            "description": "Enables console to refer to the node with given id via $0 (see Command Line API for more details)."
+        }
+    ],
+    "events": [
+        {
+            "name": "messageAdded",
+            "parameters": [
+                { "name": "message", "$ref": "ConsoleMessage", "description": "Console message that has been added." }
+            ],
+            "description": "Issued when new console message is added."
+        },
+        {
+            "name": "messageRepeatCountUpdated",
+            "parameters": [
+                { "name": "count", "type": "integer", "description": "New repeat count value." }
+            ],
+            "description": "Issued when subsequent message(s) are equal to the previous one(s)."
+        },
+        {
+            "name": "messagesCleared",
+            "description": "Issued when console is cleared. This happens either upon <code>clearMessages</code> command or after page navigation."
+        }
+    ]
+}
+,
+{
+    "domain": "DOM",
+    "description": "This domain exposes DOM read/write operations. Each DOM Node is represented with its mirror object that has an <code>id</code>. This <code>id</code> can be used to get additional information on the Node, resolve it into the JavaScript object wrapper, etc. It is important that client receives DOM events only for the nodes that are known to the client. Backend keeps track of the nodes that were sent to the client and never sends the same node twice. It is client's responsibility to collect information about the nodes that were sent to the client.<p>Note that <code>iframe</code> owner elements will return corresponding document elements as their child nodes.</p>",
+    "availability": "web",
+    "types": [
+        {
+            "id": "NodeId",
+            "type": "integer",
+            "description": "Unique DOM node identifier."
+        },
+        {
+            "id": "BackendNodeId",
+            "type": "integer",
+            "description": "Unique DOM node identifier used to reference a node that may not have been pushed to the front-end."
+        },
+        {
+            "id": "PseudoType",
+            "type": "string",
+            "enum": ["before", "after"],
+            "description": "Pseudo element type."
+        },
+        {
+            "id": "LiveRegionRelevant",
+            "type": "string",
+            "enum": ["additions", "removals", "text"],
+            "description": "Token values of @aria-relevant attribute."
+        },
+        {
+            "id": "Node",
+            "type": "object",
+            "properties": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Node identifier that is passed into the rest of the DOM messages as the <code>nodeId</code>. Backend will only push node with given <code>id</code> once. It is aware of all requested nodes and will only fire DOM events for nodes known to the client." },
+                { "name": "nodeType", "type": "integer", "description": "<code>Node</code>'s nodeType." },
+                { "name": "nodeName", "type": "string", "description": "<code>Node</code>'s nodeName." },
+                { "name": "localName", "type": "string", "description": "<code>Node</code>'s localName." },
+                { "name": "nodeValue", "type": "string", "description": "<code>Node</code>'s nodeValue." },
+                { "name": "childNodeCount", "type": "integer", "optional": true, "description": "Child count for <code>Container</code> nodes." },
+                { "name": "children", "type": "array", "optional": true, "items": { "$ref": "Node" }, "description": "Child nodes of this node when requested with children." },
+                { "name": "attributes", "type": "array", "optional": true, "items": { "type": "string" }, "description": "Attributes of the <code>Element</code> node in the form of flat array <code>[name1, value1, name2, value2]</code>." },
+                { "name": "documentURL", "type": "string", "optional": true, "description": "Document URL that <code>Document</code> or <code>FrameOwner</code> node points to." },
+                { "name": "baseURL", "type": "string", "optional": true, "description": "Base URL that <code>Document</code> or <code>FrameOwner</code> node uses for URL completion." },
+                { "name": "publicId", "type": "string", "optional": true, "description": "<code>DocumentType</code>'s publicId." },
+                { "name": "systemId", "type": "string", "optional": true, "description": "<code>DocumentType</code>'s systemId." },
+                { "name": "internalSubset", "type": "string", "optional": true, "description": "<code>DocumentType</code>'s internalSubset." },
+                { "name": "xmlVersion", "type": "string", "optional": true, "description": "<code>Document</code>'s XML version in case of XML documents." },
+                { "name": "name", "type": "string", "optional": true, "description": "<code>Attr</code>'s name." },
+                { "name": "value", "type": "string", "optional": true, "description": "<code>Attr</code>'s value." },
+                { "name": "pseudoType", "$ref": "PseudoType", "optional": true, "description": "Pseudo element type for this node." },
+                { "name": "frameId", "$ref": "Network.FrameId", "optional": true, "description": "Frame ID for frame owner elements." },
+                { "name": "contentDocument", "$ref": "Node", "optional": true, "description": "Content document for frame owner elements." },
+                { "name": "shadowRoots", "type": "array", "optional": true, "items": { "$ref": "Node" }, "description": "Shadow root list for given element host." },
+                { "name": "templateContent", "$ref": "Node", "optional": true, "description": "Content document fragment for template elements" },
+                { "name": "pseudoElements", "type": "array", "items": { "$ref": "Node" }, "optional": true, "description": "Pseudo elements associated with this node." },
+                { "name": "role", "type": "string", "optional": true, "description": "Computed value for first recognized role token, default role per element, or overridden role." }
+            ],
+            "description": "DOM interaction is implemented in terms of mirror objects that represent the actual DOM nodes. DOMNode is a base node mirror type."
+        },
+        {
+            "id": "EventListener",
+            "type": "object",
+            "properties": [
+                { "name": "type", "type": "string", "description": "<code>EventListener</code>'s type." },
+                { "name": "useCapture", "type": "boolean", "description": "<code>EventListener</code>'s useCapture." },
+                { "name": "isAttribute", "type": "boolean", "description": "<code>EventListener</code>'s isAttribute." },
+                { "name": "nodeId", "$ref": "NodeId", "description": "Target <code>DOMNode</code> id." },
+                { "name": "handlerBody", "type": "string", "description": "Event handler function body." },
+                { "name": "location", "$ref": "Debugger.Location", "optional": true, "description": "Handler code location." },
+                { "name": "sourceName", "type": "string", "optional": true, "description": "Source script URL." },
+                { "name": "handler", "$ref": "Runtime.RemoteObject", "optional": true, "description": "Event handler function value." }
+            ],
+            "description": "A structure holding event listener properties."
+        },
+        {
+            "id": "AccessibilityProperties",
+            "description": "A structure holding accessibility properties.",
+            "type": "object",
+            "properties": [
+                { "name": "activeDescendantNodeId", "$ref": "NodeId", "optional": true, "description": "<code>DOMNode</code> id of the accessibility object referenced by aria-activedescendant." },
+                { "name": "busy", "type": "boolean", "optional": true, "description": "Value of @aria-busy on current or ancestor node." },
+                { "name": "checked", "type": "string", "optional": true, "enum": ["true", "false", "mixed"], "description": "Checked state of certain form controls." },
+                { "name": "childNodeIds", "type": "array", "items": { "$ref": "NodeId" }, "optional": true, "description": "Array of <code>DOMNode</code> ids of the accessibility tree children if available." },
+                { "name": "controlledNodeIds", "type": "array", "items": { "$ref": "NodeId" }, "optional": true, "description": "Array of <code>DOMNode</code> ids of any nodes referenced via @aria-controls." },
+                { "name": "disabled", "type": "boolean", "optional": true, "description": "Disabled state of form controls." },
+                { "name": "exists", "type": "boolean", "description": "Indicates whether there is an existing AX object for the DOM node. If this is false, all the other properties will be default values." },
+                { "name": "expanded", "type": "boolean", "optional": true, "description": "Expanded state." },
+                { "name": "flowedNodeIds", "type": "array", "items": { "$ref": "NodeId" }, "optional": true, "description": "Array of <code>DOMNode</code> ids of any nodes referenced via @aria-flowto." },
+                { "name": "focused", "type": "boolean", "optional": true, "description": "Focused state. Only defined on focusable elements." },
+                { "name": "ignored", "type": "boolean", "optional": true, "description": "Indicates whether the accessibility of the associated AX object node is ignored, whether heuristically or explicitly." },
+                { "name": "ignoredByDefault", "type": "boolean", "optional": true, "description": "State indicating whether the accessibility of the associated AX object node is ignored by default for node type." },
+                { "name": "invalid", "type": "string", "optional": true, "enum": ["true", "false", "grammar", "spelling"], "description": "Invalid status of form controls." },
+                { "name": "hidden", "type": "boolean", "optional": true, "description": "Hidden state. True if node or an ancestor is hidden via CSS or explicit @aria-hidden, to clarify why the element is ignored." },
+                { "name": "label", "type": "string", "description": "Computed label value for the node, sometimes calculated by referencing other nodes." },
+                { "name": "liveRegionAtomic", "type": "boolean", "optional": true, "description": "Value of @aria-atomic." },
+                { "name": "liveRegionRelevant", "type": "array", "items": { "type": "string" }, "optional": true, "description": "Token value(s) of element's @aria-relevant attribute. Array of string values matching $ref LiveRegionRelevant. FIXME: Enum values blocked by http://webkit.org/b/133711" },
+                { "name": "liveRegionStatus", "type": "string", "optional": true, "enum": ["assertive", "polite", "off"], "description": "Value of element's @aria-live attribute." },
+                { "name": "mouseEventNodeId", "$ref": "NodeId", "optional": true, "description": "<code>DOMNode</code> id of node or closest ancestor node that has a mousedown, mouseup, or click event handler." },
+                { "name": "nodeId", "$ref": "NodeId", "description": "Target <code>DOMNode</code> id." },
+                { "name": "ownedNodeIds", "type": "array", "items": { "$ref": "NodeId" }, "optional": true, "description": "Array of <code>DOMNode</code> ids of any nodes referenced via @aria-owns." },
+                { "name": "parentNodeId", "$ref": "NodeId", "optional": true, "description": "<code>DOMNode</code> id of the accessibility tree parent object if available." },
+                { "name": "pressed", "type": "boolean", "optional": true, "description": "Pressed state for toggle buttons." },
+                { "name": "readonly", "type": "boolean", "optional": true, "description": "Readonly state of text controls." },
+                { "name": "required", "type": "boolean", "optional": true, "description": "Required state of form controls." },
+                { "name": "role", "type": "string", "description": "Computed value for first recognized role token, default role per element, or overridden role." },
+                { "name": "selected", "type": "boolean", "optional": true, "description": "Selected state of certain form controls." },
+                { "name": "selectedChildNodeIds", "type": "array", "items": { "$ref": "NodeId" }, "optional": true, "description": "Array of <code>DOMNode</code> ids of any children marked as selected." }
+            ]
+        },
+        {
+            "id": "RGBAColor",
+            "type": "object",
+            "properties": [
+                { "name": "r", "type": "integer", "description": "The red component, in the [0-255] range." },
+                { "name": "g", "type": "integer", "description": "The green component, in the [0-255] range." },
+                { "name": "b", "type": "integer", "description": "The blue component, in the [0-255] range." },
+                { "name": "a", "type": "number", "optional": true, "description": "The alpha component, in the [0-1] range (default: 1)." }
+            ],
+            "description": "A structure holding an RGBA color."
+        },
+        {
+            "id": "Quad",
+            "type": "array",
+            "items": { "type": "number" },
+            "minItems": 8,
+            "maxItems": 8,
+            "description": "An array of quad vertices, x immediately followed by y for each point, points clock-wise."
+        },
+        {
+            "id": "HighlightConfig",
+            "type": "object",
+            "properties": [
+                { "name": "showInfo", "type": "boolean", "optional": true, "description": "Whether the node info tooltip should be shown (default: false)." },
+                { "name": "contentColor", "$ref": "RGBAColor", "optional": true, "description": "The content box highlight fill color (default: transparent)." },
+                { "name": "paddingColor", "$ref": "RGBAColor", "optional": true, "description": "The padding highlight fill color (default: transparent)." },
+                { "name": "borderColor", "$ref": "RGBAColor", "optional": true, "description": "The border highlight fill color (default: transparent)." },
+                { "name": "marginColor", "$ref": "RGBAColor", "optional": true, "description": "The margin highlight fill color (default: transparent)." }
+            ],
+            "description": "Configuration data for the highlighting of page elements."
+        }
+    ],
+    "commands": [
+        {
+            "name": "getDocument",
+            "returns": [
+                { "name": "root", "$ref": "Node", "description": "Resulting node." }
+            ],
+            "description": "Returns the root DOM node to the caller."
+        },
+        {
+            "name": "requestChildNodes",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to get children for." },
+                { "name": "depth", "type": "integer", "optional": true, "description": "The maximum depth at which children should be retrieved, defaults to 1. Use -1 for the entire subtree or provide an integer larger than 0." }
+            ],
+            "description": "Requests that children of the node with given id are returned to the caller in form of <code>setChildNodes</code> events where not only immediate children are retrieved, but all children down to the specified depth."
+        },
+        {
+            "name": "querySelector",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to query upon." },
+                { "name": "selector", "type": "string", "description": "Selector string." }
+            ],
+            "returns": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Query selector result." }
+            ],
+            "description": "Executes <code>querySelector</code> on a given node."
+        },
+        {
+            "name": "querySelectorAll",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to query upon." },
+                { "name": "selector", "type": "string", "description": "Selector string." }
+            ],
+            "returns": [
+                { "name": "nodeIds", "type": "array", "items": { "$ref": "NodeId" }, "description": "Query selector result." }
+            ],
+            "description": "Executes <code>querySelectorAll</code> on a given node."
+        },
+        {
+            "name": "setNodeName",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to set name for." },
+                { "name": "name", "type": "string", "description": "New node's name." }
+            ],
+            "returns": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "New node's id." }
+            ],
+            "description": "Sets node name for a node with given id."
+        },
+        {
+            "name": "setNodeValue",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to set value for." },
+                { "name": "value", "type": "string", "description": "New node's value." }
+            ],
+            "description": "Sets node value for a node with given id."
+        },
+        {
+            "name": "removeNode",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to remove." }
+            ],
+            "description": "Removes node with given id."
+        },
+        {
+            "name": "setAttributeValue",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the element to set attribute for." },
+                { "name": "name", "type": "string", "description": "Attribute name." },
+                { "name": "value", "type": "string", "description": "Attribute value." }
+            ],
+            "description": "Sets attribute for an element with given id."
+        },
+        {
+            "name": "setAttributesAsText",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the element to set attributes for." },
+                { "name": "text", "type": "string", "description": "Text with a number of attributes. Will parse this text using HTML parser." },
+                { "name": "name", "type": "string", "optional": true, "description": "Attribute name to replace with new attributes derived from text in case text parsed successfully." }
+            ],
+            "description": "Sets attributes on element with given id. This method is useful when user edits some existing attribute value and types in several attribute name/value pairs."
+        },
+        {
+            "name": "removeAttribute",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the element to remove attribute from." },
+                { "name": "name", "type": "string", "description": "Name of the attribute to remove." }
+            ],
+            "description": "Removes attribute with given name from an element with given id."
+        },
+        {
+            "name": "getEventListenersForNode",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to get listeners for." },
+                { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name for handler value. Handler value is not returned without this parameter specified." }
+            ],
+            "returns": [
+                { "name": "listeners", "type": "array", "items": { "$ref": "EventListener"}, "description": "Array of relevant listeners." }
+            ],
+            "description": "Returns event listeners relevant to the node."
+        },
+        {
+            "name": "getAccessibilityPropertiesForNode",
+            "description": "Returns a dictionary of accessibility properties for the node.",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node for which to get accessibility properties." }
+            ],
+            "returns": [
+                { "name": "properties", "$ref": "AccessibilityProperties", "description": "Dictionary of relevant accessibility properties." }
+            ]
+        },
+        {
+            "name": "getOuterHTML",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to get markup for." }
+            ],
+            "returns": [
+                { "name": "outerHTML", "type": "string", "description": "Outer HTML markup." }
+            ],
+            "description": "Returns node's HTML markup."
+        },
+        {
+            "name": "setOuterHTML",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to set markup for." },
+                { "name": "outerHTML", "type": "string", "description": "Outer HTML markup to set." }
+            ],
+            "description": "Sets node HTML markup, returns new node id."
+        },
+        {
+            "name": "performSearch",
+            "parameters": [
+                { "name": "query", "type": "string", "description": "Plain text or query selector or XPath search query." },
+                { "name": "nodeIds", "type": "array", "items": { "$ref": "NodeId" }, "optional": true, "description": "Ids of nodes to use as starting points for the search." }
+            ],
+            "returns": [
+                { "name": "searchId", "type": "string", "description": "Unique search session identifier." },
+                { "name": "resultCount", "type": "integer", "description": "Number of search results." }
+            ],
+            "description": "Searches for a given string in the DOM tree. Use <code>getSearchResults</code> to access search results or <code>cancelSearch</code> to end this search session."
+        },
+        {
+            "name": "getSearchResults",
+            "parameters": [
+                { "name": "searchId", "type": "string", "description": "Unique search session identifier." },
+                { "name": "fromIndex", "type": "integer", "description": "Start index of the search result to be returned." },
+                { "name": "toIndex", "type": "integer", "description": "End index of the search result to be returned." }
+            ],
+            "returns": [
+                { "name": "nodeIds", "type": "array", "items": { "$ref": "NodeId" }, "description": "Ids of the search result nodes." }
+            ],
+            "description": "Returns search results from given <code>fromIndex</code> to given <code>toIndex</code> from the sarch with the given identifier."
+        },
+        {
+            "name": "discardSearchResults",
+            "parameters": [
+                { "name": "searchId", "type": "string", "description": "Unique search session identifier." }
+            ],
+            "description": "Discards search results from the session with the given id. <code>getSearchResults</code> should no longer be called for that search."
+        },
+        {
+            "name": "requestNode",
+            "parameters": [
+                { "name": "objectId", "$ref": "Runtime.RemoteObjectId", "description": "JavaScript object id to convert into node." }
+            ],
+            "returns": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Node id for given object." }
+            ],
+            "description": "Requests that the node is sent to the caller given the JavaScript node object reference. All nodes that form the path from the node to the root are also sent to the client as a series of <code>setChildNodes</code> notifications."
+        },
+        {
+            "name": "setInspectModeEnabled",
+            "parameters": [
+                { "name": "enabled", "type": "boolean", "description": "True to enable inspection mode, false to disable it." },
+                { "name": "highlightConfig", "$ref": "HighlightConfig", "optional": true, "description": "A descriptor for the highlight appearance of hovered-over nodes. May be omitted if <code>enabled == false</code>." }
+            ],
+            "description": "Enters the 'inspect' mode. In this mode, elements that user is hovering over are highlighted. Backend then generates 'inspect' command upon element selection."
+        },
+        {
+            "name": "highlightRect",
+            "parameters": [
+                { "name": "x", "type": "integer", "description": "X coordinate" },
+                { "name": "y", "type": "integer", "description": "Y coordinate" },
+                { "name": "width", "type": "integer", "description": "Rectangle width" },
+                { "name": "height", "type": "integer", "description": "Rectangle height" },
+                { "name": "color", "$ref": "RGBAColor", "optional": true, "description": "The highlight fill color (default: transparent)." },
+                { "name": "outlineColor", "$ref": "RGBAColor", "optional": true, "description": "The highlight outline color (default: transparent)." },
+                { "name": "usePageCoordinates", "type": "boolean", "optional": true, "description": "Indicates whether the provided parameters are in page coordinates or in viewport coordinates (the default)." }
+            ],
+            "description": "Highlights given rectangle. Coordinates are absolute with respect to the main frame viewport."
+        },
+        {
+            "name": "highlightQuad",
+            "parameters": [
+                { "name": "quad", "$ref": "Quad", "description": "Quad to highlight" },
+                { "name": "color", "$ref": "RGBAColor", "optional": true, "description": "The highlight fill color (default: transparent)." },
+                { "name": "outlineColor", "$ref": "RGBAColor", "optional": true, "description": "The highlight outline color (default: transparent)." },
+                { "name": "usePageCoordinates", "type": "boolean", "optional": true, "description": "Indicates whether the provided parameters are in page coordinates or in viewport coordinates (the default)." }
+            ],
+            "description": "Highlights given quad. Coordinates are absolute with respect to the main frame viewport."
+        },
+        {
+            "name": "highlightSelector",
+            "parameters": [
+                { "name": "highlightConfig", "$ref": "HighlightConfig", "description": "A descriptor for the highlight appearance." },
+                { "name": "selectorString", "type": "string", "description": "A CSS selector for finding matching nodes to highlight." },
+                { "name": "frameId", "type": "string", "optional": true, "description": "Identifier of the frame which will be searched using the selector.  If not provided, the main frame will be used." }
+            ],
+            "description": "Highlights all DOM nodes that match a given selector. A string containing a CSS selector must be specified."
+        },
+        {
+            "name": "highlightNode",
+            "parameters": [
+                { "name": "highlightConfig", "$ref": "HighlightConfig", "description": "A descriptor for the highlight appearance." },
+                { "name": "nodeId", "$ref": "NodeId", "optional": true, "description": "Identifier of the node to highlight." },
+                { "name": "objectId", "$ref": "Runtime.RemoteObjectId", "optional": true, "description": "JavaScript object id of the node to be highlighted." }
+            ],
+            "description": "Highlights DOM node with given id or with the given JavaScript object wrapper. Either nodeId or objectId must be specified."
+        },
+        {
+            "name": "hideHighlight",
+            "description": "Hides DOM node highlight."
+        },
+        {
+            "name": "highlightFrame",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Identifier of the frame to highlight." },
+                { "name": "contentColor", "$ref": "RGBAColor", "optional": true, "description": "The content box highlight fill color (default: transparent)." },
+                { "name": "contentOutlineColor", "$ref": "RGBAColor", "optional": true, "description": "The content box highlight outline color (default: transparent)." }
+            ],
+            "description": "Highlights owner element of the frame with given id."
+        },
+        {
+            "name": "pushNodeByPathToFrontend",
+            "parameters": [
+                { "name": "path", "type": "string", "description": "Path to node in the proprietary format." }
+            ],
+            "returns": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node for given path." }
+            ],
+            "description": "Requests that the node is sent to the caller given its path. // FIXME, use XPath"
+        },
+        {
+            "name": "pushNodeByBackendIdToFrontend",
+            "parameters": [
+                { "name": "backendNodeId", "$ref": "BackendNodeId", "description": "The backend node id of the node." }
+            ],
+            "returns": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "The pushed node's id." }
+            ],
+            "description": "Requests that the node is sent to the caller given its backend node id."
+        },
+        {
+            "name": "releaseBackendNodeIds",
+            "parameters": [
+                { "name": "nodeGroup", "type": "string", "description": "The backend node ids group name." }
+            ],
+            "description": "Requests that group of <code>BackendNodeIds</code> is released."
+        },
+        {
+            "name": "resolveNode",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to resolve." },
+                { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." }
+            ],
+            "returns": [
+                { "name": "object", "$ref": "Runtime.RemoteObject", "description": "JavaScript object wrapper for given node." }
+            ],
+            "description": "Resolves JavaScript node object for given node id."
+        },
+        {
+            "name": "getAttributes",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to retrieve attibutes for." }
+            ],
+            "returns": [
+                { "name": "attributes", "type": "array", "items": { "type": "string" }, "description": "An interleaved array of node attribute names and values." }
+            ],
+            "description": "Returns attributes for the specified node."
+        },
+        {
+            "name": "moveTo",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to drop." },
+                { "name": "targetNodeId", "$ref": "NodeId", "description": "Id of the element to drop into." },
+                { "name": "insertBeforeNodeId", "$ref": "NodeId", "optional": true, "description": "Drop node before given one." }
+            ],
+            "returns": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "New id of the moved node." }
+            ],
+            "description": "Moves node into the new container, places it before the given anchor."
+        },
+        {
+            "name": "undo",
+            "description": "Undoes the last performed action."
+        },
+        {
+            "name": "redo",
+            "description": "Re-does the last undone action."
+        },
+        {
+            "name": "markUndoableState",
+            "description": "Marks last undoable state."
+        },
+        {
+            "name": "focus",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node to focus." }
+            ],
+            "description": "Focuses the given element."
+        }
+    ],
+    "events": [
+        {
+            "name": "documentUpdated",
+            "description": "Fired when <code>Document</code> has been totally updated. Node ids are no longer valid."
+        },
+        {
+            "name": "setChildNodes",
+            "parameters": [
+                { "name": "parentId", "$ref": "NodeId", "description": "Parent node id to populate with children." },
+                { "name": "nodes", "type": "array", "items": { "$ref": "Node"}, "description": "Child nodes array." }
+            ],
+            "description": "Fired when backend wants to provide client with the missing DOM structure. This happens upon most of the calls requesting node ids."
+        },
+        {
+            "name": "attributeModified",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                { "name": "name", "type": "string", "description": "Attribute name." },
+                { "name": "value", "type": "string", "description": "Attribute value." }
+            ],
+            "description": "Fired when <code>Element</code>'s attribute is modified."
+        },
+        {
+            "name": "attributeRemoved",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                { "name": "name", "type": "string", "description": "A ttribute name." }
+            ],
+            "description": "Fired when <code>Element</code>'s attribute is removed."
+        },
+        {
+            "name": "inlineStyleInvalidated",
+            "parameters": [
+                { "name": "nodeIds", "type": "array", "items": { "$ref": "NodeId" }, "description": "Ids of the nodes for which the inline styles have been invalidated." }
+            ],
+            "description": "Fired when <code>Element</code>'s inline style is modified via a CSS property modification."
+        },
+        {
+            "name": "characterDataModified",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                { "name": "characterData", "type": "string", "description": "New text value." }
+            ],
+            "description": "Mirrors <code>DOMCharacterDataModified</code> event."
+        },
+        {
+            "name": "childNodeCountUpdated",
+            "parameters": [
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                { "name": "childNodeCount", "type": "integer", "description": "New node count." }
+            ],
+            "description": "Fired when <code>Container</code>'s child node count has changed."
+        },
+        {
+            "name": "childNodeInserted",
+            "parameters": [
+                { "name": "parentNodeId", "$ref": "NodeId", "description": "Id of the node that has changed." },
+                { "name": "previousNodeId", "$ref": "NodeId", "description": "If of the previous siblint." },
+                { "name": "node", "$ref": "Node", "description": "Inserted node data." }
+            ],
+            "description": "Mirrors <code>DOMNodeInserted</code> event."
+        },
+        {
+            "name": "childNodeRemoved",
+            "parameters": [
+                { "name": "parentNodeId", "$ref": "NodeId", "description": "Parent id." },
+                { "name": "nodeId", "$ref": "NodeId", "description": "Id of the node that has been removed." }
+            ],
+            "description": "Mirrors <code>DOMNodeRemoved</code> event."
+        },
+        {
+            "name": "shadowRootPushed",
+            "parameters": [
+                { "name": "hostId", "$ref": "NodeId", "description": "Host element id." },
+                { "name": "root", "$ref": "Node", "description": "Shadow root." }
+            ],
+            "description": "Called when shadow root is pushed into the element."
+        },
+        {
+            "name": "shadowRootPopped",
+            "parameters": [
+                { "name": "hostId", "$ref": "NodeId", "description": "Host element id." },
+                { "name": "rootId", "$ref": "NodeId", "description": "Shadow root id." }
+            ],
+            "description": "Called when shadow root is popped from the element."
+        },
+        {
+            "name": "pseudoElementAdded",
+            "parameters": [
+                { "name": "parentId", "$ref": "NodeId", "description": "Pseudo element's parent element id." },
+                { "name": "pseudoElement", "$ref": "Node", "description": "The added pseudo element." }
+            ],
+            "description": "Called when a pseudo element is added to an element."
+        },
+        {
+            "name": "pseudoElementRemoved",
+            "parameters": [
+                { "name": "parentId", "$ref": "NodeId", "description": "Pseudo element's parent element id." },
+                { "name": "pseudoElementId", "$ref": "NodeId", "description": "The removed pseudo element id." }
+            ],
+            "description": "Called when a pseudo element is removed from an element."
+        }
+    ]
+}
+,
+{
+    "domain": "DOMDebugger",
+    "description": "DOM debugging allows setting breakpoints on particular DOM operations and events. JavaScript execution will stop on these operations as if there was a regular breakpoint set.",
+    "availability": "web",
+    "types": [
+        {
+            "id": "DOMBreakpointType",
+            "type": "string",
+            "enum": ["subtree-modified", "attribute-modified", "node-removed"],
+            "description": "DOM breakpoint type."
+        }
+    ],
+    "commands": [
+        {
+            "name": "setDOMBreakpoint",
+            "parameters": [
+                { "name": "nodeId", "$ref": "DOM.NodeId", "description": "Identifier of the node to set breakpoint on." },
+                { "name": "type", "$ref": "DOMBreakpointType", "description": "Type of the operation to stop upon." }
+            ],
+            "description": "Sets breakpoint on particular operation with DOM."
+        },
+        {
+            "name": "removeDOMBreakpoint",
+            "parameters": [
+                { "name": "nodeId", "$ref": "DOM.NodeId", "description": "Identifier of the node to remove breakpoint from." },
+                { "name": "type", "$ref": "DOMBreakpointType", "description": "Type of the breakpoint to remove." }
+            ],
+            "description": "Removes DOM breakpoint that was set using <code>setDOMBreakpoint</code>."
+        },
+        {
+            "name": "setEventListenerBreakpoint",
+            "parameters": [
+                { "name": "eventName", "type": "string", "description": "DOM Event name to stop on (any DOM event will do)." }
+            ],
+            "description": "Sets breakpoint on particular DOM event."
+        },
+        {
+            "name": "removeEventListenerBreakpoint",
+            "parameters": [
+                { "name": "eventName", "type": "string", "description": "Event name." }
+            ],
+            "description": "Removes breakpoint on particular DOM event."
+        },
+        {
+            "name": "setInstrumentationBreakpoint",
+            "parameters": [
+                { "name": "eventName", "type": "string", "description": "Instrumentation name to stop on." }
+            ],
+            "description": "Sets breakpoint on particular native event."
+        },
+        {
+            "name": "removeInstrumentationBreakpoint",
+            "parameters": [
+                { "name": "eventName", "type": "string", "description": "Instrumentation name to stop on." }
+            ],
+            "description": "Sets breakpoint on particular native event."
+        },
+        {
+            "name": "setXHRBreakpoint",
+            "parameters": [
+                { "name": "url", "type": "string", "description": "Resource URL substring. All XHRs having this substring in the URL will get stopped upon." }
+            ],
+            "description": "Sets breakpoint on XMLHttpRequest."
+        },
+        {
+            "name": "removeXHRBreakpoint",
+            "parameters": [
+                { "name": "url", "type": "string", "description": "Resource URL substring." }
+            ],
+            "description": "Removes breakpoint from XMLHttpRequest."
+        }
+    ]
+}
+,
+{
+    "domain": "DOMStorage",
+    "description": "Query and modify DOM storage.",
+    "availability": "web",
+    "types": [
+        {
+            "id": "StorageId",
+            "type": "object",
+            "description": "DOM Storage identifier.",
+            "properties": [
+                { "name": "securityOrigin", "type": "string", "description": "Security origin for the storage." },
+                { "name": "isLocalStorage", "type": "boolean", "description": "Whether the storage is local storage (not session storage)." }
+            ]
+        },
+        {
+            "id": "Item",
+            "type": "array",
+            "description": "DOM Storage item.",
+            "items": { "type": "string" }
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables storage tracking, storage events will now be delivered to the client."
+        },
+        {
+            "name": "disable",
+            "description": "Disables storage tracking, prevents storage events from being sent to the client."
+        },
+        {
+            "name": "getDOMStorageItems",
+            "parameters": [
+                { "name": "storageId", "$ref": "StorageId" }
+            ],
+            "returns": [
+                { "name": "entries", "type": "array", "items": { "$ref": "Item" } }
+            ]
+        },
+        {
+            "name": "setDOMStorageItem",
+            "parameters": [
+                { "name": "storageId", "$ref": "StorageId" },
+                { "name": "key", "type": "string" },
+                { "name": "value", "type": "string" }
+            ]
+        },
+        {
+            "name": "removeDOMStorageItem",
+            "parameters": [
+                { "name": "storageId", "$ref": "StorageId" },
+                { "name": "key", "type": "string" }
+            ]
+        }
+    ],
+    "events": [
+        {
+            "name": "domStorageItemsCleared",
+            "parameters": [
+                { "name": "storageId", "$ref": "StorageId" }
+            ]
+        },
+        {
+            "name": "domStorageItemRemoved",
+            "parameters": [
+                { "name": "storageId", "$ref": "StorageId" },
+                { "name": "key", "type": "string" }
+            ]
+        },
+        {
+            "name": "domStorageItemAdded",
+            "parameters": [
+                { "name": "storageId", "$ref": "StorageId" },
+                { "name": "key", "type": "string" },
+                { "name": "newValue", "type": "string" }
+            ]
+        },
+        {
+            "name": "domStorageItemUpdated",
+            "parameters": [
+                { "name": "storageId", "$ref": "StorageId" },
+                { "name": "key", "type": "string" },
+                { "name": "oldValue", "type": "string" },
+                { "name": "newValue", "type": "string" }
+            ]
+        }
+    ]
+}
+,
+{
+    "domain": "Database",
+    "availability": "web",
+    "types": [
+        {
+            "id": "DatabaseId",
+            "type": "string",
+            "description": "Unique identifier of Database object."
+        },
+        {
+            "id": "Database",
+            "type": "object",
+            "description": "Database object.",
+            "properties": [
+                { "name": "id", "$ref": "DatabaseId", "description": "Database ID." },
+                { "name": "domain", "type": "string", "description": "Database domain." },
+                { "name": "name", "type": "string", "description": "Database name." },
+                { "name": "version", "type": "string", "description": "Database version." }
+            ]
+        },
+        {
+            "id": "Error",
+            "type": "object",
+            "description": "Database error.",
+            "properties": [
+                { "name": "message", "type": "string", "description": "Error message." },
+                { "name": "code", "type": "integer", "description": "Error code." }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables database tracking, database events will now be delivered to the client."
+        },
+        {
+            "name": "disable",
+            "description": "Disables database tracking, prevents database events from being sent to the client."
+        },
+        {
+            "name": "getDatabaseTableNames",
+            "parameters": [
+                { "name": "databaseId", "$ref": "DatabaseId" }
+            ],
+            "returns": [
+                { "name": "tableNames", "type": "array", "items": { "type": "string" } }
+            ]
+        },
+        {
+            "name": "executeSQL",
+            "async": true,
+            "parameters": [
+                { "name": "databaseId", "$ref": "DatabaseId" },
+                { "name": "query", "type": "string" }
+            ],
+            "returns": [
+                { "name": "columnNames", "type": "array", "optional": true, "items": { "type": "string" } },
+                { "name": "values", "type": "array", "optional": true, "items": { "type": "any" }},
+                { "name": "sqlError", "$ref": "Error", "optional": true }
+            ]
+        }
+    ],
+    "events": [
+        {
+            "name": "addDatabase",
+            "parameters": [
+                { "name": "database", "$ref": "Database" }
+            ]
+        }
+    ]
+}
+,
+{
+    "domain": "Debugger",
+    "description": "Debugger domain exposes JavaScript debugging capabilities. It allows setting and removing breakpoints, stepping through execution, exploring stack traces, etc.",
+    "types": [
+        {
+            "id": "BreakpointId",
+            "type": "string",
+            "description": "Breakpoint identifier."
+        },
+        {
+            "id": "BreakpointActionIdentifier",
+            "type": "integer",
+            "description": "Breakpoint action identifier."
+        },
+        {
+            "id": "ScriptId",
+            "type": "string",
+            "description": "Unique script identifier."
+        },
+        {
+            "id": "CallFrameId",
+            "type": "string",
+            "description": "Call frame identifier."
+        },
+        {
+            "id": "Location",
+            "type": "object",
+            "properties": [
+                { "name": "scriptId", "$ref": "ScriptId", "description": "Script identifier as reported in the <code>Debugger.scriptParsed</code>." },
+                { "name": "lineNumber", "type": "integer", "description": "Line number in the script." },
+                { "name": "columnNumber", "type": "integer", "optional": true, "description": "Column number in the script." }
+            ],
+            "description": "Location in the source code."
+        },
+        {
+            "id": "BreakpointAction",
+            "type": "object",
+            "properties": [
+                { "name": "type", "type": "string", "enum": ["log", "evaluate", "sound", "probe"], "description": "Different kinds of breakpoint actions." },
+                { "name": "data", "type": "string", "optional": true, "description": "Data associated with this breakpoint type (e.g. for type \"eval\" this is the JavaScript string to evalulate)." },
+                { "name": "id", "$ref": "BreakpointActionIdentifier", "optional": true, "description": "A frontend-assigned identifier for this breakpoint action." }
+            ],
+            "description": "Action to perform when a breakpoint is triggered."
+        },
+        {
+            "id": "BreakpointOptions",
+            "type": "object",
+            "properties": [
+                { "name": "condition", "type": "string", "optional": true, "description": "Expression to use as a breakpoint condition. When specified, debugger will only stop on the breakpoint if this expression evaluates to true." },
+                { "name": "actions", "type": "array", "optional": true, "items": { "$ref": "BreakpointAction" }, "description": "Actions to perform automatically when the breakpoint is triggered." },
+                { "name": "autoContinue", "type": "boolean", "optional": true, "description": "Automatically continue after hitting this breakpoint and running actions." },
+                { "name": "ignoreCount", "type": "integer", "optional": true, "description": "Number of times to ignore this breakpoint, before stopping on the breakpoint and running actions." }
+            ],
+            "description": "Extra options that modify breakpoint behavior."
+        },
+        {
+            "id": "FunctionDetails",
+            "type": "object",
+            "properties": [
+                { "name": "location", "$ref": "Location", "description": "Location of the function." },
+                { "name": "name", "type": "string", "optional": true, "description": "Name of the function. Not present for anonymous functions." },
+                { "name": "displayName", "type": "string", "optional": true, "description": "Display name of the function(specified in 'displayName' property on the function object)." },
+                { "name": "inferredName", "type": "string", "optional": true, "description": "Name of the function inferred from its initial assignment." },
+                { "name": "scopeChain", "type": "array", "optional": true, "items": { "$ref": "Scope" }, "description": "Scope chain for this closure." }
+            ],
+            "description": "Information about the function."
+        },
+        {
+            "id": "CallFrame",
+            "type": "object",
+            "properties": [
+                { "name": "callFrameId", "$ref": "CallFrameId", "description": "Call frame identifier. This identifier is only valid while the virtual machine is paused." },
+                { "name": "functionName", "type": "string", "description": "Name of the JavaScript function called on this call frame." },
+                { "name": "location", "$ref": "Location", "description": "Location in the source code." },
+                { "name": "scopeChain", "type": "array", "items": { "$ref": "Scope" }, "description": "Scope chain for this call frame." },
+                { "name": "this", "$ref": "Runtime.RemoteObject", "description": "<code>this</code> object for this call frame." }
+            ],
+            "description": "JavaScript call frame. Array of call frames form the call stack."
+        },
+        {
+            "id": "Scope",
+            "type": "object",
+            "properties": [
+                { "name": "type", "type": "string", "enum": ["global", "local", "with", "closure", "catch", "functionName"], "description": "Scope type." },
+                { "name": "object", "$ref": "Runtime.RemoteObject", "description": "Object representing the scope. For <code>global</code> and <code>with</code> scopes it represents the actual object; for the rest of the scopes, it is artificial transient object enumerating scope variables as its properties." }
+            ],
+            "description": "Scope description."
+        },
+        {
+            "id": "ProbeSample",
+            "description": "A sample collected by evaluating a probe breakpoint action.",
+            "type": "object",
+            "properties": [
+                { "name": "probeId", "$ref": "BreakpointActionIdentifier", "description": "Identifier of the probe breakpoint action that created the sample." },
+                { "name": "sampleId", "type": "integer", "description": "Unique identifier for this sample." },
+                { "name": "batchId", "type": "integer", "description": "A batch identifier which is the same for all samples taken at the same breakpoint hit." },
+                { "name": "timestamp", "type": "number", "description": "Timestamp of when the sample was taken." },
+                { "name": "payload", "$ref": "Runtime.RemoteObject", "description": "Contents of the sample." }
+            ]
+        },
+        {
+            "id": "AssertPauseReason",
+            "description": "The pause reason auxiliary data when paused because of an assertion.",
+            "type": "object",
+            "properties": [
+                { "name": "message", "type": "string", "optional": true, "description": "The console.assert message string if provided." }
+            ]
+        },
+        {
+            "id": "BreakpointPauseReason",
+            "description": "The pause reason auxiliary data when paused because of hitting a breakpoint.",
+            "type": "object",
+            "properties": [
+                { "name": "breakpointId", "type": "string", "description": "The identifier of the breakpoint causing the pause." }
+            ]
+        },
+        {
+            "id": "CSPViolationPauseReason",
+            "description": "The pause reason auxiliary data when paused because of a Content Security Policy directive.",
+            "type": "object",
+            "properties": [
+                { "name": "directive", "type": "string", "description": "The CSP directive that blocked script execution." }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables debugger for the given page. Clients should not assume that the debugging has been enabled until the result for this command is received."
+        },
+        {
+            "name": "disable",
+            "description": "Disables debugger for given page."
+        },
+        {
+            "name": "setBreakpointsActive",
+            "parameters": [
+                { "name": "active", "type": "boolean", "description": "New value for breakpoints active state." }
+            ],
+            "description": "Activates / deactivates all breakpoints on the page."
+        },
+        {
+            "name": "setBreakpointByUrl",
+            "parameters": [
+                { "name": "lineNumber", "type": "integer", "description": "Line number to set breakpoint at." },
+                { "name": "url", "type": "string", "optional": true, "description": "URL of the resources to set breakpoint on." },
+                { "name": "urlRegex", "type": "string", "optional": true, "description": "Regex pattern for the URLs of the resources to set breakpoints on. Either <code>url</code> or <code>urlRegex</code> must be specified." },
+                { "name": "columnNumber", "type": "integer", "optional": true, "description": "Offset in the line to set breakpoint at." },
+                { "name": "options", "$ref": "BreakpointOptions", "optional": true, "description": "Options to apply to this breakpoint to modify its behavior." }
+            ],
+            "returns": [
+                { "name": "breakpointId", "$ref": "BreakpointId", "description": "Id of the created breakpoint for further reference." },
+                { "name": "locations", "type": "array", "items": { "$ref": "Location"}, "description": "List of the locations this breakpoint resolved into upon addition." }
+            ],
+            "description": "Sets JavaScript breakpoint at given location specified either by URL or URL regex. Once this command is issued, all existing parsed scripts will have breakpoints resolved and returned in <code>locations</code> property. Further matching script parsing will result in subsequent <code>breakpointResolved</code> events issued. This logical breakpoint will survive page reloads."
+        },
+        {
+            "name": "setBreakpoint",
+            "parameters": [
+                { "name": "location", "$ref": "Location", "description": "Location to set breakpoint in." },
+                { "name": "options", "$ref": "BreakpointOptions", "optional": true, "description": "Options to apply to this breakpoint to modify its behavior." }
+            ],
+            "returns": [
+                { "name": "breakpointId", "$ref": "BreakpointId", "description": "Id of the created breakpoint for further reference." },
+                { "name": "actualLocation", "$ref": "Location", "description": "Location this breakpoint resolved into." }
+            ],
+            "description": "Sets JavaScript breakpoint at a given location."
+        },
+        {
+            "name": "removeBreakpoint",
+            "parameters": [
+                { "name": "breakpointId", "$ref": "BreakpointId" }
+            ],
+            "description": "Removes JavaScript breakpoint."
+        },
+        {
+            "name": "continueToLocation",
+            "parameters": [
+                { "name": "location", "$ref": "Location", "description": "Location to continue to." }
+            ],
+            "description": "Continues execution until specific location is reached."
+        },
+        {
+            "name": "stepOver",
+            "description": "Steps over the statement."
+        },
+        {
+            "name": "stepInto",
+            "description": "Steps into the function call."
+        },
+        {
+            "name": "stepOut",
+            "description": "Steps out of the function call."
+        },
+        {
+            "name": "pause",
+            "description": "Stops on the next JavaScript statement."
+        },
+        {
+            "name": "resume",
+            "description": "Resumes JavaScript execution."
+        },
+        {
+            "name": "searchInContent",
+            "description": "Searches for given string in script content.",
+            "parameters": [
+                { "name": "scriptId", "$ref": "ScriptId", "description": "Id of the script to search in." },
+                { "name": "query", "type": "string", "description": "String to search for." },
+                { "name": "caseSensitive", "type": "boolean", "optional": true, "description": "If true, search is case sensitive." },
+                { "name": "isRegex", "type": "boolean", "optional": true, "description": "If true, treats string parameter as regex." }
+            ],
+            "returns": [
+                { "name": "result", "type": "array", "items": { "$ref": "GenericTypes.SearchMatch" }, "description": "List of search matches." }
+            ]
+        },
+        {
+            "name": "getScriptSource",
+            "parameters": [
+                { "name": "scriptId", "$ref": "ScriptId", "description": "Id of the script to get source for." }
+            ],
+            "returns": [
+                { "name": "scriptSource", "type": "string", "description": "Script source." }
+            ],
+            "description": "Returns source for the script with given id."
+        },
+        {
+            "name": "getFunctionDetails",
+            "parameters": [
+                { "name": "functionId", "$ref": "Runtime.RemoteObjectId", "description": "Id of the function to get location for." }
+            ],
+            "returns": [
+                { "name": "details", "$ref": "FunctionDetails", "description": "Information about the function." }
+            ],
+            "description": "Returns detailed information on given function."
+        },
+        {
+            "name": "setPauseOnExceptions",
+            "parameters": [
+                { "name": "state", "type": "string", "enum": ["none", "uncaught", "all"], "description": "Pause on exceptions mode." }
+            ],
+            "description": "Defines pause on exceptions state. Can be set to stop on all exceptions, uncaught exceptions or no exceptions. Initial pause on exceptions state is <code>none</code>."
+        },
+        {
+            "name": "evaluateOnCallFrame",
+            "parameters": [
+                { "name": "callFrameId", "$ref": "CallFrameId", "description": "Call frame identifier to evaluate on." },
+                { "name": "expression", "type": "string", "description": "Expression to evaluate." },
+                { "name": "objectGroup", "type": "string", "optional": true, "description": "String object group name to put result into (allows rapid releasing resulting object handles using <code>releaseObjectGroup</code>)." },
+                { "name": "includeCommandLineAPI", "type": "boolean", "optional": true, "description": "Specifies whether command line API should be available to the evaluated expression, defaults to false." },
+                { "name": "doNotPauseOnExceptionsAndMuteConsole", "type": "boolean", "optional": true, "description": "Specifies whether evaluation should stop on exceptions and mute console. Overrides setPauseOnException state." },
+                { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object that should be sent by value." },
+                { "name": "generatePreview", "type": "boolean", "optional": true, "description": "Whether preview should be generated for the result." },
+                { "name": "saveResult", "type": "boolean", "optional": true, "description": "Whether the resulting value should be considered for saving in the $n history." }
+            ],
+            "returns": [
+                { "name": "result", "$ref": "Runtime.RemoteObject", "description": "Object wrapper for the evaluation result." },
+                { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." },
+                { "name": "savedResultIndex", "type": "integer", "optional": true, "description": "If the result was saved, this is the $n index that can be used to access the value." }
+            ],
+            "description": "Evaluates expression on a given call frame."
+        },
+        {
+            "name": "setOverlayMessage",
+            "parameters": [
+                { "name": "message", "type": "string", "optional": true, "description": "Overlay message to display when paused in debugger." }
+            ],
+            "description": "Sets overlay message."
+        }
+    ],
+    "events": [
+        {
+            "name": "globalObjectCleared",
+            "description": "Called when global has been cleared and debugger client should reset its state. Happens upon navigation or reload."
+        },
+        {
+            "name": "scriptParsed",
+            "parameters": [
+                { "name": "scriptId", "$ref": "ScriptId", "description": "Identifier of the script parsed." },
+                { "name": "url", "type": "string", "description": "URL or name of the script parsed (if any)." },
+                { "name": "startLine", "type": "integer", "description": "Line offset of the script within the resource with given URL (for script tags)." },
+                { "name": "startColumn", "type": "integer", "description": "Column offset of the script within the resource with given URL." },
+                { "name": "endLine", "type": "integer", "description": "Last line of the script." },
+                { "name": "endColumn", "type": "integer", "description": "Length of the last line of the script." },
+                { "name": "isContentScript", "type": "boolean", "optional": true, "description": "Determines whether this script is a user extension script." },
+                { "name": "sourceMapURL", "type": "string", "optional": true, "description": "URL of source map associated with script (if any)." },
+                { "name": "hasSourceURL", "type": "boolean", "optional": true, "description": "True, if this script has sourceURL." }
+            ],
+            "description": "Fired when virtual machine parses script. This event is also fired for all known and uncollected scripts upon enabling debugger."
+        },
+        {
+            "name": "scriptFailedToParse",
+            "parameters": [
+                { "name": "url", "type": "string", "description": "URL of the script that failed to parse." },
+                { "name": "scriptSource", "type": "string", "description": "Source text of the script that failed to parse." },
+                { "name": "startLine", "type": "integer", "description": "Line offset of the script within the resource." },
+                { "name": "errorLine", "type": "integer", "description": "Line with error." },
+                { "name": "errorMessage", "type": "string", "description": "Parse error message." }
+            ],
+            "description": "Fired when virtual machine fails to parse the script."
+        },
+        {
+            "name": "breakpointResolved",
+            "parameters": [
+                { "name": "breakpointId", "$ref": "BreakpointId", "description": "Breakpoint unique identifier." },
+                { "name": "location", "$ref": "Location", "description": "Actual breakpoint location." }
+            ],
+            "description": "Fired when breakpoint is resolved to an actual script and location."
+        },
+        {
+            "name": "paused",
+            "parameters": [
+                { "name": "callFrames", "type": "array", "items": { "$ref": "CallFrame" }, "description": "Call stack the virtual machine stopped on." },
+                { "name": "reason", "type": "string", "enum": ["XHR", "DOM", "EventListener", "exception", "assert", "CSPViolation", "DebuggerStatement", "Breakpoint", "PauseOnNextStatement", "other"], "description": "Pause reason." },
+                { "name": "data", "type": "object", "optional": true, "description": "Object containing break-specific auxiliary properties." }
+            ],
+            "description": "Fired when the virtual machine stopped on breakpoint or exception or any other stop criteria."
+        },
+        {
+            "name": "resumed",
+            "description": "Fired when the virtual machine resumed execution."
+        },
+        {
+            "name": "didSampleProbe",
+            "description": "Fires when a new probe sample is collected.",
+            "parameters": [
+                { "name": "sample", "$ref": "ProbeSample", "description": "A collected probe sample." }
+            ]
+        },
+        {
+            "name": "playBreakpointActionSound",
+            "description": "Fired when a \"sound\" breakpoint action is triggered on a breakpoint.",
+            "parameters": [
+                { "name": "breakpointActionId", "$ref": "BreakpointActionIdentifier", "description": "Breakpoint action identifier." }
+            ]
+        }
+    ]
+}
+,
+{
+    "domain": "GenericTypes",
+    "description": "Exposes generic types to be used by any domain.",
+    "types": [
+        {
+            "id": "SearchMatch",
+            "type": "object",
+            "description": "Search match in a resource.",
+            "properties": [
+                { "name": "lineNumber", "type": "number", "description": "Line number in resource content." },
+                { "name": "lineContent", "type": "string", "description": "Line with match content." }
+            ]
+        }
+    ]
+}
+,
+{
+    "domain": "IndexedDB",
+    "featureGuard": "ENABLE(INDEXED_DATABASE)",
+    "availability": "web",
+    "types": [
+        {
+            "id": "DatabaseWithObjectStores",
+            "type": "object",
+            "description": "Database with an array of object stores.",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Database name." },
+                { "name": "version", "type": "number", "description": "Database version." },
+                { "name": "objectStores", "type": "array", "items": { "$ref": "ObjectStore" }, "description": "Object stores in this database." }
+            ]
+        },
+        {
+            "id": "ObjectStore",
+            "type": "object",
+            "description": "Object store.",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Object store name." },
+                { "name": "keyPath", "$ref": "KeyPath", "description": "Object store key path." },
+                { "name": "autoIncrement", "type": "boolean", "description": "If true, object store has auto increment flag set." },
+                { "name": "indexes", "type": "array", "items": { "$ref": "ObjectStoreIndex" }, "description": "Indexes in this object store." }
+            ]
+        },
+        {
+            "id": "ObjectStoreIndex",
+            "type": "object",
+            "description": "Object store index.",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Index name." },
+                { "name": "keyPath", "$ref": "KeyPath", "description": "Index key path." },
+                { "name": "unique", "type": "boolean", "description": "If true, index is unique." },
+                { "name": "multiEntry", "type": "boolean", "description": "If true, index allows multiple entries for a key." }
+            ]
+        },
+        {
+            "id": "Key",
+            "type": "object",
+            "description": "Key.",
+            "properties": [
+                { "name": "type", "type": "string", "enum": ["number", "string", "date", "array"], "description": "Key type." },
+                { "name": "number", "type": "number", "optional": true, "description": "Number value." },
+                { "name": "string", "type": "string", "optional": true, "description": "String value." },
+                { "name": "date", "type": "number", "optional": true, "description": "Date value." },
+                { "name": "array", "type": "array", "optional": true, "items": { "$ref": "Key" }, "description": "Array value." }
+            ]
+        },
+        {
+            "id": "KeyRange",
+            "type": "object",
+            "description": "Key range.",
+            "properties": [
+                { "name": "lower", "$ref": "Key", "optional": true, "description": "Lower bound." },
+                { "name": "upper", "$ref": "Key", "optional": true, "description": "Upper bound." },
+                { "name": "lowerOpen", "type": "boolean", "description": "If true lower bound is open." },
+                { "name": "upperOpen", "type": "boolean", "description": "If true upper bound is open." }
+            ]
+        },
+        {
+            "id": "DataEntry",
+            "type": "object",
+            "description": "Data entry.",
+            "properties": [
+                { "name": "key", "$ref": "Runtime.RemoteObject", "description": "Key." },
+                { "name": "primaryKey", "$ref": "Runtime.RemoteObject", "description": "Primary key." },
+                { "name": "value", "$ref": "Runtime.RemoteObject", "description": "Value." }
+            ]
+        },
+        {
+            "id": "KeyPath",
+            "type": "object",
+            "description": "Key path.",
+            "properties": [
+                { "name": "type", "type": "string", "enum": ["null", "string", "array"], "description": "Key path type." },
+                { "name": "string", "type": "string", "optional": true, "description": "String value." },
+                { "name": "array", "type": "array", "optional": true, "items": { "type": "string" }, "description": "Array value." }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables events from backend."
+        },
+        {
+            "name": "disable",
+            "description": "Disables events from backend."
+        },
+        {
+            "name": "requestDatabaseNames",
+            "async": true,
+            "parameters": [
+                { "name": "securityOrigin", "type": "string", "description": "Security origin." }
+            ],
+            "returns": [
+                { "name": "databaseNames", "type": "array", "items": { "type": "string" }, "description": "Database names for origin." }
+            ],
+            "description": "Requests database names for given security origin."
+        },
+        {
+            "name": "requestDatabase",
+            "async": true,
+            "parameters": [
+                { "name": "securityOrigin", "type": "string", "description": "Security origin." },
+                { "name": "databaseName", "type": "string", "description": "Database name." }
+            ],
+            "returns": [
+                { "name": "databaseWithObjectStores", "$ref": "DatabaseWithObjectStores", "description": "Database with an array of object stores." }
+            ],
+            "description": "Requests database with given name in given frame."
+        },
+        {
+            "name": "requestData",
+            "async": true,
+            "parameters": [
+                { "name": "securityOrigin", "type": "string", "description": "Security origin." },
+                { "name": "databaseName", "type": "string", "description": "Database name." },
+                { "name": "objectStoreName", "type": "string", "description": "Object store name." },
+                { "name": "indexName", "type": "string", "description": "Index name, empty string for object store data requests." },
+                { "name": "skipCount", "type": "integer", "description": "Number of records to skip." },
+                { "name": "pageSize", "type": "integer", "description": "Number of records to fetch." },
+                { "name": "keyRange", "$ref": "KeyRange", "optional": true, "description": "Key range." }
+            ],
+            "returns": [
+                { "name": "objectStoreDataEntries", "type": "array", "items": { "$ref": "DataEntry" }, "description": "Array of object store data entries." },
+                { "name": "hasMore", "type": "boolean", "description": "If true, there are more entries to fetch in the given range." }
+            ],
+            "description": "Requests data from object store or index."
+        },
+        {
+            "name": "clearObjectStore",
+            "async": true,
+            "parameters": [
+                { "name": "securityOrigin", "type": "string", "description": "Security origin." },
+                { "name": "databaseName", "type": "string", "description": "Database name." },
+                { "name": "objectStoreName", "type": "string", "description": "Object store name." }
+            ],
+            "returns": [
+            ],
+            "description": "Clears all entries from an object store."
+        }
+    ]
+}
+,
+{
+    "domain": "Inspector",
+    "types": [],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables inspector domain notifications."
+        },
+        {
+            "name": "disable",
+            "description": "Disables inspector domain notifications."
+        },
+        {
+            "name": "initialized",
+            "description": "Sent by the frontend after all initialization messages have been sent."
+        }
+    ],
+    "events": [
+        {
+            "name": "evaluateForTestInFrontend",
+            "parameters": [
+                { "name": "script", "type": "string" }
+            ]
+        },
+        {
+            "name": "inspect",
+            "parameters": [
+                { "name": "object", "$ref": "Runtime.RemoteObject" },
+                { "name": "hints", "type": "object" }
+            ]
+        },
+        {
+            "name": "detached",
+            "description": "Fired when remote debugging connection is about to be terminated. Contains detach reason.",
+            "parameters": [
+                { "name": "reason", "type": "string", "description": "The reason why connection has been terminated." }
+            ]
+        },
+        {
+            "name": "activateExtraDomains",
+            "description": "Fired when the backend has alternate domains that need to be activated.",
+            "parameters": [
+                { "name": "domains", "type": "array", "items": { "type": "string" }, "description": "Domain names that need activation" }
+            ]
+        },
+        {
+            "name": "targetCrashed",
+            "description": "Fired when debugging target has crashed"
+        }
+    ]
+}
+,
+{
+    "domain": "LayerTree",
+    "availability": "web",
+    "types": [
+        {
+            "id": "LayerId",
+            "type": "string",
+            "description": "Unique RenderLayer identifier."
+        },
+        {
+            "id": "PseudoElementId",
+            "type": "string",
+            "description": "Unique PseudoElement identifier."
+        },
+        {
+            "id": "IntRect",
+            "type": "object",
+            "description": "A rectangle.",
+            "properties": [
+                { "name": "x", "type": "integer", "description": "The x position." },
+                { "name": "y", "type": "integer", "description": "The y position." },
+                { "name": "width", "type": "integer", "description": "The width metric." },
+                { "name": "height", "type": "integer", "description": "The height metric." }
+            ]
+        },
+        {
+            "id": "Layer",
+            "type": "object",
+            "description": "Information about a compositing layer.",
+            "properties": [
+                { "name": "layerId", "$ref": "LayerId", "description": "The unique id for this layer." },
+                { "name": "nodeId", "$ref": "DOM.NodeId", "description": "The id for the node associated with this layer." },
+                { "name": "bounds", "$ref": "IntRect", "description": "Bounds of the layer in absolute page coordinates." },
+                { "name": "paintCount", "type": "integer", "description": "Indicates how many time this layer has painted." },
+                { "name": "memory", "type": "integer", "description": "Estimated memory used by this layer." },
+                { "name": "compositedBounds", "$ref": "IntRect", "description": "The bounds of the composited layer." },
+                { "name": "isInShadowTree", "type": "boolean", "optional": true, "description": "Indicates whether this layer is associated with an element hosted in a shadow tree." },
+                { "name": "isReflection", "type": "boolean", "optional": true, "description": "Indicates whether this layer was used to provide a reflection for the element." },
+                { "name": "isGeneratedContent", "type": "boolean", "optional": true, "description": "Indicates whether the layer is attached to a pseudo element that is CSS generated content." },
+                { "name": "isAnonymous", "type": "boolean", "optional": true, "description": "Indicates whether the layer was created for a CSS anonymous block or box." },
+                { "name": "pseudoElementId", "$ref": "PseudoElementId", "optional": true, "description": "The id for the pseudo element associated with this layer." },
+                { "name": "pseudoElement", "type": "string", "optional": true, "description": "The name of the CSS pseudo-element that prompted the layer to be generated." }
+            ]
+        },
+        {
+            "id": "CompositingReasons",
+            "type": "object",
+            "description": "An object containing the reasons why the layer was composited as properties.",
+            "properties": [
+                { "name": "transform3D", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a CSS 3D transform." },
+                { "name": "video", "type": "boolean", "optional": true, "description": "Composition due to association with a <video> element." },
+                { "name": "canvas", "type": "boolean", "optional": true, "description": "Composition due to the element being a <canvas> element." },
+                { "name": "plugin", "type": "boolean", "optional": true, "description": "Composition due to association with a plugin." },
+                { "name": "iFrame", "type": "boolean", "optional": true, "description": "Composition due to association with an <iframe> element." },
+                { "name": "backfaceVisibilityHidden", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a \"backface-visibility: hidden\" style." },
+                { "name": "clipsCompositingDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with an element clipping compositing descendants." },
+                { "name": "animation", "type": "boolean", "optional": true, "description": "Composition due to association with an animated element." },
+                { "name": "filters", "type": "boolean", "optional": true, "description": "Composition due to association with an element with CSS filters applied." },
+                { "name": "positionFixed", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a \"position: fixed\" style." },
+                { "name": "positionSticky", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a \"position: sticky\" style." },
+                { "name": "overflowScrollingTouch", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a \"overflow-scrolling: touch\" style." },
+                { "name": "stacking", "type": "boolean", "optional": true, "description": "Composition due to association with an element establishing a stacking context." },
+                { "name": "overlap", "type": "boolean", "optional": true, "description": "Composition due to association with an element overlapping other composited elements." },
+                { "name": "negativeZIndexChildren", "type": "boolean", "optional": true, "description": "Composition due to association with an element with descendants that have a negative z-index." },
+                { "name": "transformWithCompositedDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with an element with composited descendants." },
+                { "name": "opacityWithCompositedDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with an element with opacity applied and composited descendants." },
+                { "name": "maskWithCompositedDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with a masked element and composited descendants." },
+                { "name": "reflectionWithCompositedDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a reflection and composited descendants." },
+                { "name": "filterWithCompositedDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with an element with CSS filters applied and composited descendants." },
+                { "name": "blendingWithCompositedDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with an element with CSS blending applied and composited descendants." },
+                { "name": "isolatesCompositedBlendingDescendants", "type": "boolean", "optional": true, "description": "Composition due to association with an element isolating compositing descendants having CSS blending applied." },
+                { "name": "perspective", "type": "boolean", "optional": true, "description": "Composition due to association with an element with perspective applied." },
+                { "name": "preserve3D", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a \"transform-style: preserve-3d\" style." },
+                { "name": "willChange", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a \"will-change\" style." },
+                { "name": "root", "type": "boolean", "optional": true, "description": "Composition due to association with the root element." },
+                { "name": "blending", "type": "boolean", "optional": true, "description": "Composition due to association with an element with a \"blend-mode\" style." }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables compositing tree inspection."
+        },
+        {
+            "name": "disable",
+            "description": "Disables compositing tree inspection."
+        },
+        {
+            "name": "layersForNode",
+            "parameters": [
+                { "name": "nodeId", "$ref": "DOM.NodeId", "description": "Root of the subtree for which we want to gather layers." }                ],
+            "description": "Returns the layer tree structure of the current page.",
+            "returns": [
+                { "name": "layers", "type": "array", "items": { "$ref": "Layer" }, "description": "Child layers." }
+            ]
+        },
+        {
+            "name": "reasonsForCompositingLayer",
+            "parameters": [
+                { "name": "layerId", "$ref": "LayerId", "description": "The id of the layer for which we want to get the reasons it was composited." }
+            ],
+            "description": "Provides the reasons why the given layer was composited.",
+            "returns": [
+                { "name": "compositingReasons", "$ref": "CompositingReasons", "description": "An object containing the reasons why the layer was composited as properties." }
+            ]
+        }
+    ],
+    "events": [
+        {
+            "name": "layerTreeDidChange"
+        }
+    ]
+}
+,
+{
+    "domain": "Network",
+    "description": "Network domain allows tracking network activities of the page. It exposes information about http, file, data and other requests and responses, their headers, bodies, timing, etc.",
+    "availability": "web",
+    "types": [
+        {
+            "id": "LoaderId",
+            "type": "string",
+            "description": "Unique loader identifier."
+        },
+        {
+            "id": "FrameId",
+            "type": "string",
+            "description": "Unique frame identifier."
+        },
+        {
+            "id": "RequestId",
+            "type": "string",
+            "description": "Unique request identifier."
+        },
+        {
+            "id": "Timestamp",
+            "type": "number",
+            "description": "Number of seconds since epoch."
+        },
+        {
+            "id": "Headers",
+            "type": "object",
+            "description": "Request / response headers as keys / values of JSON object."
+        },
+        {
+            "id": "ResourceTiming",
+            "type": "object",
+            "description": "Timing information for the request.",
+            "properties": [
+                { "name": "navigationStart", "type": "number", "description": "Timing's navigationStart is a baseline in seconds, while the other numbers are ticks in milliseconds relatively to this navigationStart." },
+                { "name": "domainLookupStart", "type": "number", "description": "Started DNS address resolve." },
+                { "name": "domainLookupEnd", "type": "number", "description": "Finished DNS address resolve." },
+                { "name": "connectStart", "type": "number", "description": "Started connecting to the remote host." },
+                { "name": "connectEnd", "type": "number", "description": "Connected to the remote host." },
+                { "name": "secureConnectionStart", "type": "number", "description": "Started SSL handshake." },
+                { "name": "requestStart", "type": "number", "description": "Started sending request." },
+                { "name": "responseStart", "type": "number", "description": "Started receiving response headers." }
+            ]
+        },
+        {
+            "id": "Request",
+            "type": "object",
+            "description": "HTTP request data.",
+            "properties": [
+                { "name": "url", "type": "string", "description": "Request URL." },
+                { "name": "method", "type": "string", "description": "HTTP request method." },
+                { "name": "headers", "$ref": "Headers", "description": "HTTP request headers." },
+                { "name": "postData", "type": "string", "optional": true, "description": "HTTP POST request data." }
+            ]
+        },
+        {
+            "id": "Response",
+            "type": "object",
+            "description": "HTTP response data.",
+            "properties": [
+                { "name": "url", "type": "string", "description": "Response URL. This URL can be different from CachedResource.url in case of redirect." },
+                { "name": "status", "type": "number", "description": "HTTP response status code." },
+                { "name": "statusText", "type": "string", "description": "HTTP response status text." },
+                { "name": "headers", "$ref": "Headers", "description": "HTTP response headers." },
+                { "name": "headersText", "type": "string", "optional": true, "description": "HTTP response headers text." },
+                { "name": "mimeType", "type": "string", "description": "Resource mimeType as determined by the browser." },
+                { "name": "requestHeaders", "$ref": "Headers", "optional": true, "description": "Refined HTTP request headers that were actually transmitted over the network." },
+                { "name": "requestHeadersText", "type": "string", "optional": true, "description": "HTTP request headers text." },
+                { "name": "fromDiskCache", "type": "boolean", "optional": true, "description": "Specifies that the request was served from the disk cache." },
+                { "name": "timing", "$ref": "ResourceTiming", "optional": true, "description": "Timing information for the given request." }
+            ]
+        },
+        {
+            "id": "WebSocketRequest",
+            "type": "object",
+            "description": "WebSocket request data.",
+            "properties": [
+                { "name": "headers", "$ref": "Headers", "description": "HTTP response headers." }
+            ]
+        },
+        {
+            "id": "WebSocketResponse",
+            "type": "object",
+            "description": "WebSocket response data.",
+            "properties": [
+                { "name": "status", "type": "number", "description": "HTTP response status code." },
+                { "name": "statusText", "type": "string", "description": "HTTP response status text." },
+                { "name": "headers", "$ref": "Headers", "description": "HTTP response headers." }
+            ]
+        },
+        {
+            "id": "WebSocketFrame",
+            "type": "object",
+            "description": "WebSocket frame data.",
+            "properties": [
+                { "name": "opcode", "type": "number", "description": "WebSocket frame opcode." },
+                { "name": "mask", "type": "boolean", "description": "WebSocket frame mask." },
+                { "name": "payloadData", "type": "string", "description": "WebSocket frame payload data." }
+            ]
+        },
+        {
+            "id": "CachedResource",
+            "type": "object",
+            "description": "Information about the cached resource.",
+            "properties": [
+                { "name": "url", "type": "string", "description": "Resource URL. This is the url of the original network request." },
+                { "name": "type", "$ref": "Page.ResourceType", "description": "Type of this resource." },
+                { "name": "response", "$ref": "Response", "optional": true, "description": "Cached response data." },
+                { "name": "bodySize", "type": "number", "description": "Cached response body size." },
+                { "name": "sourceMapURL", "type": "string", "optional": true, "description": "URL of source map associated with this resource (if any)." }
+            ]
+        },
+        {
+            "id": "Initiator",
+            "type": "object",
+            "description": "Information about the request initiator.",
+            "properties": [
+                { "name": "type", "type": "string", "enum": ["parser", "script", "other"], "description": "Type of this initiator." },
+                { "name": "stackTrace", "$ref": "Console.StackTrace", "optional": true, "description": "Initiator JavaScript stack trace, set for Script only." },
+                { "name": "url", "type": "string", "optional": true, "description": "Initiator URL, set for Parser type only." },
+                { "name": "lineNumber", "type": "number", "optional": true, "description": "Initiator line number, set for Parser type only." }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables network tracking, network events will now be delivered to the client."
+        },
+        {
+            "name": "disable",
+            "description": "Disables network tracking, prevents network events from being sent to the client."
+        },
+        {
+            "name": "setExtraHTTPHeaders",
+            "description": "Specifies whether to always send extra HTTP headers with the requests from this page.",
+            "parameters": [
+                { "name": "headers", "$ref": "Headers", "description": "Map with extra HTTP headers." }
+            ]
+        },
+        {
+            "name": "getResponseBody",
+            "description": "Returns content served for the given request.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Identifier of the network request to get content for." }
+            ],
+            "returns": [
+                { "name": "body", "type": "string", "description": "Response body." },
+                { "name": "base64Encoded", "type": "boolean", "description": "True, if content was sent as base64." }
+            ]
+        },
+        {
+            "name": "canClearBrowserCache",
+            "description": "Tells whether clearing browser cache is supported.",
+            "returns": [
+                { "name": "result", "type": "boolean", "description": "True if browser cache can be cleared." }
+            ]
+        },
+        {
+            "name": "clearBrowserCache",
+            "description": "Clears browser cache."
+        },
+        {
+            "name": "canClearBrowserCookies",
+            "description": "Tells whether clearing browser cookies is supported.",
+            "returns": [
+                { "name": "result", "type": "boolean", "description": "True if browser cookies can be cleared." }
+            ]
+        },
+        {
+            "name": "clearBrowserCookies",
+            "description": "Clears browser cookies."
+        },
+        {
+            "name": "setCacheDisabled",
+            "parameters": [
+                { "name": "cacheDisabled", "type": "boolean", "description": "Cache disabled state." }
+            ],
+            "description": "Toggles ignoring cache for each request. If <code>true</code>, cache will not be used."
+        },
+        {
+            "name": "loadResource",
+            "async": true,
+            "parameters": [
+                { "name": "frameId", "$ref": "FrameId", "description": "Frame to load the resource from." },
+                { "name": "url", "type": "string", "description": "URL of the resource to load." }
+            ],
+            "returns": [
+                { "name": "content", "type": "string", "description": "Resource content." },
+                { "name": "mimeType", "type": "string", "description": "Resource mimeType." },
+                { "name": "status", "type": "number", "description": "HTTP response status code." }
+            ],
+            "description": "Loads a resource in the context of a frame on the inspected page without cross origin checks."
+        }
+    ],
+    "events": [
+        {
+            "name": "requestWillBeSent",
+            "description": "Fired when page is about to send HTTP request.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "frameId", "$ref": "FrameId", "description": "Frame identifier." },
+                { "name": "loaderId", "$ref": "LoaderId", "description": "Loader identifier." },
+                { "name": "documentURL", "type": "string", "description": "URL of the document this request is loaded for." },
+                { "name": "request", "$ref": "Request", "description": "Request data." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "initiator", "$ref": "Initiator", "description": "Request initiator." },
+                { "name": "redirectResponse", "optional": true, "$ref": "Response", "description": "Redirect response data." },
+                { "name": "type", "$ref": "Page.ResourceType", "optional": true, "description": "Resource type." }
+            ]
+        },
+        {
+            "name": "requestServedFromCache",
+            "description": "Fired if request ended up loading from cache.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." }
+            ]
+        },
+        {
+            "name": "responseReceived",
+            "description": "Fired when HTTP response is available.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "frameId", "$ref": "FrameId", "description": "Frame identifier." },
+                { "name": "loaderId", "$ref": "LoaderId", "description": "Loader identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "type", "$ref": "Page.ResourceType", "description": "Resource type." },
+                { "name": "response", "$ref": "Response", "description": "Response data." }
+            ]
+        },
+        {
+            "name": "dataReceived",
+            "description": "Fired when data chunk was received over the network.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "dataLength", "type": "integer", "description": "Data chunk length." },
+                { "name": "encodedDataLength", "type": "integer", "description": "Actual bytes received (might be less than dataLength for compressed encodings)." }
+            ]
+        },
+        {
+            "name": "loadingFinished",
+            "description": "Fired when HTTP request has finished loading.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "sourceMapURL", "type": "string", "optional": true, "description": "URL of source map associated with this resource (if any)." }
+            ]
+        },
+        {
+            "name": "loadingFailed",
+            "description": "Fired when HTTP request has failed to load.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "errorText", "type": "string", "description": "User friendly error message." },
+                { "name": "canceled", "type": "boolean", "optional": true, "description": "True if loading was canceled." }
+            ]
+        },
+        {
+            "name": "requestServedFromMemoryCache",
+            "description": "Fired when HTTP request has been served from memory cache.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "frameId", "$ref": "FrameId", "description": "Frame identifier." },
+                { "name": "loaderId", "$ref": "LoaderId", "description": "Loader identifier." },
+                { "name": "documentURL", "type": "string", "description": "URL of the document this request is loaded for." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "initiator", "$ref": "Initiator", "description": "Request initiator." },
+                { "name": "resource", "$ref": "CachedResource", "description": "Cached resource data." }
+            ]
+        },
+        {
+            "name": "webSocketWillSendHandshakeRequest",
+            "description": "Fired when WebSocket is about to initiate handshake.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "request", "$ref": "WebSocketRequest", "description": "WebSocket request data." }
+            ]
+        },
+        {
+            "name": "webSocketHandshakeResponseReceived",
+            "description": "Fired when WebSocket handshake response becomes available.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "response", "$ref": "WebSocketResponse", "description": "WebSocket response data." }
+            ]
+        },
+        {
+            "name": "webSocketCreated",
+            "description": "Fired upon WebSocket creation.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "url", "type": "string", "description": "WebSocket request URL." }
+            ]
+        },
+        {
+            "name": "webSocketClosed",
+            "description": "Fired when WebSocket is closed.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." }
+            ]
+        },
+        {
+            "name": "webSocketFrameReceived",
+            "description": "Fired when WebSocket frame is received.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "response", "$ref": "WebSocketFrame", "description": "WebSocket response data." }
+            ]
+        },
+        {
+            "name": "webSocketFrameError",
+            "description": "Fired when WebSocket frame error occurs.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "errorMessage", "type": "string", "description": "WebSocket frame error message." }
+            ]
+        },
+        {
+            "name": "webSocketFrameSent",
+            "description": "Fired when WebSocket frame is sent.",
+            "parameters": [
+                { "name": "requestId", "$ref": "RequestId", "description": "Request identifier." },
+                { "name": "timestamp", "$ref": "Timestamp", "description": "Timestamp." },
+                { "name": "response", "$ref": "WebSocketFrame", "description": "WebSocket response data." }
+            ]
+        }
+    ]
+}
+,
+{
+    "domain": "OverlayTypes",
+    "description": "Exposes types to be used by the inspector overlay.",
+    "types": [
+        {
+            "id": "Point",
+            "type": "object",
+            "properties": [
+                { "name": "x", "type": "number" },
+                { "name": "y", "type": "number" }
+            ]
+        },
+        {
+            "id": "Size",
+            "type": "object",
+            "properties": [
+                { "name": "width", "type": "integer" },
+                { "name": "height", "type": "integer" }
+            ]
+        },
+        {
+            "id": "Quad",
+            "description": "A quad is a collection of 4 points. When initialized from a rect, the points are in clockwise order from top left.",
+            "type": "array",
+            "items": { "$ref": "Point" }
+        },
+        {
+            "id": "Rect",
+            "description": "A rectangle specified by a reference coordinate and width/height offsets.",
+            "type": "object",
+            "properties": [
+                { "name": "x", "type": "number" },
+                { "name": "y", "type": "number" },
+                { "name": "width", "type": "number" },
+                { "name": "height", "type": "number" }
+            ]
+        },
+        {
+            "id": "Region",
+            "description": "A single region in a flow thread.",
+            "type": "object",
+            "properties": [
+                { "name": "borderQuad", "$ref": "Quad" },
+                { "name": "incomingQuad", "$ref": "Quad" },
+                { "name": "outgoingQuad", "$ref": "Quad" },
+                { "name": "isHighlighted", "type": "boolean", "optional": true }
+            ]
+        },
+        {
+            "id": "DisplayPath",
+            "description": "A vector path described using SVG path syntax.",
+            "type": "array",
+            "items": { "type": "any" }
+        },
+        {
+            "id": "RegionFlowData",
+            "type": "object",
+            "properties": [
+                { "name": "regions", "type": "array", "items": { "$ref": "Region"} },
+                { "name": "name", "type": "string" }
+            ]
+        },
+        {
+            "id": "ContentFlowData",
+            "type": "object",
+            "properties": [
+                { "name": "name", "type": "string" }
+            ]
+        },
+        {
+            "id": "ShapeOutsideData",
+            "type": "object",
+            "properties": [
+                { "name": "bounds", "$ref": "Quad", "description": "Bounds for the shape-outside paths." },
+                { "name": "shape", "$ref": "DisplayPath", "description": "Path for the element's shape.", "optional": true },
+                { "name": "marginShape", "$ref": "DisplayPath", "description": "Path for the element's margin shape.", "optional": true }
+            ]
+        },
+        {
+            "id": "ElementData",
+            "description": "Data that describes an element to be highlighted.",
+            "type": "object",
+            "properties": [
+                { "name": "tagName", "type": "string" },
+                { "name": "idValue", "type": "string", "description": "The value of the element's 'id' attribute." },
+                { "name": "className", "type": "string", "optional": true },
+                { "name": "size", "$ref": "Size", "optional": true },
+                { "name": "role", "type": "string", "description": "Computed accessibility role for the element.", "optional": true },
+                { "name": "regionFlowData", "$ref": "RegionFlowData", "optional": true },
+                { "name": "contentFlowData", "$ref": "ContentFlowData", "optional": true },
+                { "name": "shapeOutsideData", "$ref": "ShapeOutsideData", "optional": true }
+            ]
+        },
+        {
+            "id": "FragmentHighlightData",
+            "description": "Data required to highlight multiple quads.",
+            "type": "object",
+            "properties": [
+                { "name": "quads", "type": "array", "items": { "$ref": "Quad" }, "description": "Quads for which the highlight should be applied."},
+                { "name": "contentColor", "type": "string" },
+                { "name": "contentOutlineColor", "type": "string" },
+                { "name": "paddingColor", "type": "string" },
+                { "name": "borderColor", "type": "string" },
+                { "name": "marginColor", "type": "string" },
+                { "name": "regionClippingArea", "$ref": "Quad", "optional": true }
+            ]
+        },
+        {
+            "id": "NodeHighlightData",
+            "description": "Data required to highlight a DOM node.",
+            "type": "object",
+            "properties": [
+                { "name": "scrollOffset", "$ref": "Point", "description": "Scroll offset for the MainFrame's FrameView that is shared across all quads." },
+                { "name": "fragments", "type": "array", "items": { "$ref": "FragmentHighlightData" } },
+                { "name": "elementData", "$ref": "ElementData", "optional": true }
+            ]
+        },
+        {
+            "id": "OverlayConfiguration",
+            "description": "Data required to configure the overlay's size and scaling behavior.",
+            "type": "object",
+            "properties": [
+                { "name": "deviceScaleFactor", "type": "number" },
+                { "name": "viewportSize", "$ref": "Size" },
+                { "name": "frameViewFullSize", "$ref": "Size" }
+            ]
+        }
+    ]
+}
+,
+{
+    "domain": "Page",
+    "description": "Actions and events related to the inspected page belong to the page domain.",
+    "availability": "web",
+    "types": [
+        {
+            "id": "ResourceType",
+            "type": "string",
+            "enum": ["Document", "Stylesheet", "Image", "Font", "Script", "XHR", "WebSocket", "Other"],
+            "description": "Resource type as it was perceived by the rendering engine."
+        },
+        {
+            "id": "CoordinateSystem",
+            "type": "string",
+            "enum": ["Viewport", "Page"],
+            "description": "Coordinate system used by supplied coordinates."
+        },
+        {
+            "id": "Frame",
+            "type": "object",
+            "description": "Information about the Frame on the page.",
+            "properties": [
+                { "name": "id", "type": "string", "description": "Frame unique identifier." },
+                { "name": "parentId", "type": "string", "optional": true, "description": "Parent frame identifier." },
+                { "name": "loaderId", "$ref": "Network.LoaderId", "description": "Identifier of the loader associated with this frame." },
+                { "name": "name", "type": "string", "optional": true, "description": "Frame's name as specified in the tag." },
+                { "name": "url", "type": "string", "description": "Frame document's URL." },
+                { "name": "securityOrigin", "type": "string", "description": "Frame document's security origin." },
+                { "name": "mimeType", "type": "string", "description": "Frame document's mimeType as determined by the browser." }
+            ]
+        },
+        {
+            "id": "FrameResource",
+            "type": "object",
+            "properties": [
+                { "name": "url", "type": "string", "description": "Resource URL." },
+                { "name": "type", "$ref": "ResourceType", "description": "Type of this resource." },
+                { "name": "mimeType", "type": "string", "description": "Resource mimeType as determined by the browser." },
+                { "name": "failed", "type": "boolean", "optional": true, "description": "True if the resource failed to load." },
+                { "name": "canceled", "type": "boolean", "optional": true, "description": "True if the resource was canceled during loading." },
+                { "name": "sourceMapURL", "type": "string", "optional": true, "description": "URL of source map associated with this resource (if any)." }
+            ]
+        },
+        {
+            "id": "FrameResourceTree",
+            "type": "object",
+            "description": "Information about the Frame hierarchy along with their cached resources.",
+            "properties": [
+                { "name": "frame", "$ref": "Frame", "description": "Frame information for this tree item." },
+                { "name": "childFrames", "type": "array", "optional": true, "items": { "$ref": "FrameResourceTree" }, "description": "Child frames." },
+                { "name": "resources", "type": "array", "items": { "$ref": "FrameResource" }, "description": "Information about frame resources." }
+            ]
+        },
+        {
+            "id": "SearchResult",
+            "type": "object",
+            "description": "Search result for resource.",
+            "properties": [
+                { "name": "url", "type": "string", "description": "Resource URL." },
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Resource frame id." },
+                { "name": "matchesCount", "type": "number", "description": "Number of matches in the resource content." }
+            ]
+        },
+        {
+            "id": "Cookie",
+            "type": "object",
+            "description": "Cookie object",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Cookie name." },
+                { "name": "value", "type": "string", "description": "Cookie value." },
+                { "name": "domain", "type": "string", "description": "Cookie domain." },
+                { "name": "path", "type": "string", "description": "Cookie path." },
+                { "name": "expires", "type": "number", "description": "Cookie expires." },
+                { "name": "size", "type": "integer", "description": "Cookie size." },
+                { "name": "httpOnly", "type": "boolean", "description": "True if cookie is http-only." },
+                { "name": "secure", "type": "boolean", "description": "True if cookie is secure." },
+                { "name": "session", "type": "boolean", "description": "True in case of session cookie." }
+            ]
+        },
+        {
+            "id": "ScriptIdentifier",
+            "type": "string",
+            "description": "Unique script identifier."
+        }
+    ],
+    "commands": [
+        {
+            "name": "enable",
+            "description": "Enables page domain notifications."
+        },
+        {
+            "name": "disable",
+            "description": "Disables page domain notifications."
+        },
+        {
+            "name": "addScriptToEvaluateOnLoad",
+            "parameters": [
+                { "name": "scriptSource", "type": "string" }
+            ],
+            "returns": [
+                { "name": "identifier", "$ref": "ScriptIdentifier", "description": "Identifier of the added script." }
+            ]
+        },
+        {
+            "name": "removeScriptToEvaluateOnLoad",
+            "parameters": [
+                { "name": "identifier", "$ref": "ScriptIdentifier" }
+            ]
+        },
+        {
+            "name": "reload",
+            "parameters": [
+                { "name": "ignoreCache", "type": "boolean", "optional": true, "description": "If true, browser cache is ignored (as if the user pressed Shift+refresh)." },
+                { "name": "scriptToEvaluateOnLoad", "type": "string", "optional": true, "description": "If set, the script will be injected into all frames of the inspected page after reload." }
+            ],
+            "description": "Reloads given page optionally ignoring the cache."
+        },
+        {
+            "name": "navigate",
+            "parameters": [
+                { "name": "url", "type": "string", "description": "URL to navigate the page to." }
+            ],
+            "description": "Navigates current page to the given URL."
+        },
+        {
+            "name": "getCookies",
+            "returns": [
+                { "name": "cookies", "type": "array", "items": { "$ref": "Cookie"}, "description": "Array of cookie objects." }
+            ],
+            "description": "Returns all browser cookies. Depending on the backend support, will return detailed cookie information in the <code>cookies</code> field."
+        },
+        {
+            "name": "deleteCookie",
+            "parameters": [
+                { "name": "cookieName", "type": "string", "description": "Name of the cookie to remove." },
+                { "name": "url", "type": "string", "description": "URL to match cooke domain and path." }
+            ],
+            "description": "Deletes browser cookie with given name, domain and path."
+        },
+        {
+            "name": "getResourceTree",
+            "description": "Returns present frame / resource tree structure.",
+            "returns": [
+                { "name": "frameTree", "$ref": "FrameResourceTree", "description": "Present frame / resource tree structure." }
+            ]
+        },
+        {
+            "name": "getResourceContent",
+            "description": "Returns content of the given resource.",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Frame id to get resource for." },
+                { "name": "url", "type": "string", "description": "URL of the resource to get content for." }
+            ],
+            "returns": [
+                { "name": "content", "type": "string", "description": "Resource content." },
+                { "name": "base64Encoded", "type": "boolean", "description": "True, if content was served as base64." }
+            ]
+        },
+        {
+            "name": "searchInResource",
+            "description": "Searches for given string in resource content.",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Frame id for resource to search in." },
+                { "name": "url", "type": "string", "description": "URL of the resource to search in." },
+                { "name": "query", "type": "string", "description": "String to search for." },
+                { "name": "caseSensitive", "type": "boolean", "optional": true, "description": "If true, search is case sensitive." },
+                { "name": "isRegex", "type": "boolean", "optional": true, "description": "If true, treats string parameter as regex." }
+            ],
+            "returns": [
+                { "name": "result", "type": "array", "items": { "$ref": "GenericTypes.SearchMatch" }, "description": "List of search matches." }
+            ]
+        },
+        {
+            "name": "searchInResources",
+            "description": "Searches for given string in frame / resource tree structure.",
+            "parameters": [
+                { "name": "text", "type": "string", "description": "String to search for." },
+                { "name": "caseSensitive", "type": "boolean", "optional": true, "description": "If true, search is case sensitive." },
+                { "name": "isRegex", "type": "boolean", "optional": true, "description": "If true, treats string parameter as regex." }
+            ],
+            "returns": [
+                { "name": "result", "type": "array", "items": { "$ref": "SearchResult" }, "description": "List of search results." }
+            ]
+        },
+        {
+            "name": "setDocumentContent",
+            "description": "Sets given markup as the document's HTML.",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Frame id to set HTML for." },
+                { "name": "html", "type": "string", "description": "HTML content to set."  }
+            ]
+        },
+        {
+            "name": "setShowPaintRects",
+            "description": "Requests that backend shows paint rectangles",
+            "parameters": [
+                { "name": "result", "type": "boolean", "description": "True for showing paint rectangles" }
+            ]
+        },
+        {
+            "name": "getScriptExecutionStatus",
+            "description": "Determines if scripts can be executed in the page.",
+            "returns": [
+                { "name": "result", "type": "string", "enum": ["allowed", "disabled", "forbidden"], "description": "Script execution status: \"allowed\" if scripts can be executed, \"disabled\" if script execution has been disabled through page settings, \"forbidden\" if script execution for the given page is not possible for other reasons." }
+            ]
+        },
+        {
+            "name": "setScriptExecutionDisabled",
+            "description": "Switches script execution in the page.",
+            "parameters": [
+                { "name": "value", "type": "boolean", "description": "Whether script execution should be disabled in the page." }
+            ]
+        },
+        {
+            "name": "setTouchEmulationEnabled",
+            "parameters": [
+                { "name": "enabled", "type": "boolean", "description": "Whether the touch event emulation should be enabled." }
+            ],
+            "description": "Toggles mouse event-based touch event emulation."
+        },
+        {
+            "name": "setEmulatedMedia",
+            "parameters": [
+                { "name": "media", "type": "string", "description": "Media type to emulate. Empty string disables the override." }
+            ],
+            "description": "Emulates the given media for CSS media queries."
+        },
+        {
+            "name": "getCompositingBordersVisible",
+            "description": "Indicates the visibility of compositing borders.",
+            "returns": [
+                { "name": "result", "type": "boolean", "description": "If true, compositing borders are visible." }
+            ]
+        },
+        {
+            "name": "setCompositingBordersVisible",
+            "description": "Controls the visibility of compositing borders.",
+            "parameters": [
+                { "name": "visible", "type": "boolean", "description": "True for showing compositing borders." }
+            ]
+        },
+        {
+            "name": "snapshotNode",
+            "description": "Capture a snapshot of the specified node that does not include unrelated layers.",
+            "parameters": [
+                { "name": "nodeId", "$ref": "DOM.NodeId", "description": "Id of the node to snapshot." }
+            ],
+            "returns": [
+                { "name": "dataURL", "type": "string", "description": "Base64-encoded image data (PNG)." }
+            ]
+        },
+        {
+            "name": "snapshotRect",
+            "description": "Capture a snapshot of the page within the specified rectangle and coordinate system.",
+            "parameters": [
+                { "name": "x", "type": "integer", "description": "X coordinate" },
+                { "name": "y", "type": "integer", "description": "Y coordinate" },
+                { "name": "width", "type": "integer", "description": "Rectangle width" },
+                { "name": "height", "type": "integer", "description": "Rectangle height" },
+                { "name": "coordinateSystem", "$ref": "CoordinateSystem", "description": "Indicates the coordinate system of the supplied rectangle." }
+            ],
+            "returns": [
+                { "name": "dataURL", "type": "string", "description": "Base64-encoded image data (PNG)." }
+            ]
+        },
+        {
+            "name": "handleJavaScriptDialog",
+            "description": "Accepts or dismisses a JavaScript initiated dialog (alert, confirm, prompt, or onbeforeunload).",
+            "parameters": [
+                { "name": "accept", "type": "boolean", "description": "Whether to accept or dismiss the dialog." },
+                { "name": "promptText", "type": "string", "optional": true, "description": "The text to enter into the dialog prompt before accepting. Used only if this is a prompt dialog." }
+            ]
+        },
+        {
+            "name": "archive",
+            "description": "Grab an archive of the page.",
+            "returns": [
+                { "name": "data", "type": "string", "description": "Base64-encoded web archive." }
+            ]
+        }
+    ],
+    "events": [
+        {
+            "name": "domContentEventFired",
+            "parameters": [
+                { "name": "timestamp", "type": "number" }
+            ]
+        },
+        {
+            "name": "loadEventFired",
+            "parameters": [
+                { "name": "timestamp", "type": "number" }
+            ]
+        },
+        {
+            "name": "frameNavigated",
+            "description": "Fired once navigation of the frame has completed. Frame is now associated with the new loader.",
+            "parameters": [
+                { "name": "frame", "$ref": "Frame", "description": "Frame object." }
+            ]
+        },
+        {
+            "name": "frameDetached",
+            "description": "Fired when frame has been detached from its parent.",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Id of the frame that has been detached." }
+            ]
+        },
+        {
+            "name": "frameStartedLoading",
+            "description": "Fired when frame has started loading.",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Id of the frame that has started loading." }
+            ]
+        },
+        {
+            "name": "frameStoppedLoading",
+            "description": "Fired when frame has stopped loading.",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Id of the frame that has stopped loading." }
+            ]
+        },
+        {
+            "name": "frameScheduledNavigation",
+            "description": "Fired when frame schedules a potential navigation.",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Id of the frame that has scheduled a navigation." },
+                { "name": "delay", "type": "number", "description": "Delay (in seconds) until the navigation is scheduled to begin. The navigation is not guaranteed to start." }
+            ]
+        },
+        {
+            "name": "frameClearedScheduledNavigation",
+            "description": "Fired when frame no longer has a scheduled navigation.",
+            "parameters": [
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Id of the frame that has cleared its scheduled navigation." }
+            ]
+        },
+        {
+            "name": "javascriptDialogOpening",
+            "description": "Fired when a JavaScript initiated dialog (alert, confirm, prompt, or onbeforeunload) is about to open.",
+            "parameters": [
+                { "name": "message", "type": "string", "description": "Message that will be displayed by the dialog." }
+            ]
+        },
+        {
+            "name": "javascriptDialogClosed",
+            "description": "Fired when a JavaScript initiated dialog (alert, confirm, prompt, or onbeforeunload) has been closed."
+        },
+        {
+            "name": "scriptsEnabled",
+            "description": "Fired when the JavaScript is enabled/disabled on the page",
+            "parameters": [
+                { "name": "isEnabled", "type": "boolean", "description": "Whether script execution is enabled or disabled on the page." }
+            ]
+        }
+    ]
+}
+,
+{
+    "domain": "Runtime",
+    "description": "Runtime domain exposes JavaScript runtime by means of remote evaluation and mirror objects. Evaluation results are returned as mirror object that expose object type, string representation and unique identifier that can be used for further object reference. Original objects are maintained in memory unless they are either explicitly released or are released along with the other objects in their object group.",
+    "types": [
+        {
+            "id": "RemoteObjectId",
+            "type": "string",
+            "description": "Unique object identifier."
+        },
+        {
+            "id": "RemoteObject",
+            "type": "object",
+            "description": "Mirror object referencing original JavaScript object.",
+            "properties": [
+                { "name": "type", "type": "string", "enum": ["object", "function", "undefined", "string", "number", "boolean", "symbol"], "description": "Object type." },
+                { "name": "subtype", "type": "string", "optional": true, "enum": ["array", "null", "node", "regexp", "date", "error", "map", "set", "weakmap", "weakset", "iterator", "class"], "description": "Object subtype hint. Specified for <code>object</code> <code>function</code> (for class) type values only." },
+                { "name": "className", "type": "string", "optional": true, "description": "Object class (constructor) name. Specified for <code>object</code> type values only." },
+                { "name": "value", "type": "any", "optional": true, "description": "Remote object value (in case of primitive values or JSON values if it was requested)." },
+                { "name": "description", "type": "string", "optional": true, "description": "String representation of the object." },
+                { "name": "objectId", "$ref": "RemoteObjectId", "optional": true, "description": "Unique object identifier (for non-primitive values)." },
+                { "name": "size", "type": "integer", "optional": true, "description": "Size of the array/collection. Specified for array/map/set/weakmap/weakset object type values only." },
+                { "name": "classPrototype", "$ref": "RemoteObject", "optional": true, "description": "Remote object for the class prototype. Specified for class object type values only." },
+                { "name": "preview", "$ref": "ObjectPreview", "optional": true, "description": "Preview containing abbreviated property values. Specified for <code>object</code> type values only." }
+            ]
+        },
+        {
+            "id": "ObjectPreview",
+            "type": "object",
+            "description": "Object containing abbreviated remote object value.",
+            "properties": [
+                { "name": "type", "type": "string", "enum": ["object", "function", "undefined", "string", "number", "boolean", "symbol"], "description": "Object type." },
+                { "name": "subtype", "type": "string", "optional": true, "enum": ["array", "null", "node", "regexp", "date", "error", "map", "set", "weakmap", "weakset", "iterator", "class"], "description": "Object subtype hint. Specified for <code>object</code> type values only." },
+                { "name": "description", "type": "string", "optional": true, "description": "String representation of the object." },
+                { "name": "lossless", "type": "boolean", "description": "Determines whether preview is lossless (contains all information of the original object)." },
+                { "name": "overflow", "type": "boolean", "optional": true, "description": "True iff some of the properties of the original did not fit." },
+                { "name": "properties", "type": "array", "items": { "$ref": "PropertyPreview" }, "optional": true, "description": "List of the properties." },
+                { "name": "entries", "type": "array", "items": { "$ref": "EntryPreview" }, "optional": true, "description": "List of the entries. Specified for <code>map</code> and <code>set</code> subtype values only." },
+                { "name": "size", "type": "integer", "optional": true, "description": "Size of the array/collection. Specified for array/map/set/weakmap/weakset object type values only." }
+            ]
+        },
+        {
+            "id": "PropertyPreview",
+            "type": "object",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Property name." },
+                { "name": "type", "type": "string", "enum": ["object", "function", "undefined", "string", "number", "boolean", "symbol", "accessor"], "description": "Object type." },
+                { "name": "subtype", "type": "string", "optional": true, "enum": ["array", "null", "node", "regexp", "date", "error", "map", "set", "weakmap", "weakset", "iterator", "class"], "description": "Object subtype hint. Specified for <code>object</code> type values only." },
+                { "name": "value", "type": "string", "optional": true, "description": "User-friendly property value string." },
+                { "name": "valuePreview", "$ref": "ObjectPreview", "optional": true, "description": "Nested value preview." },
+                { "name": "internal", "type": "boolean", "optional": true, "description": "True if this is an internal property." }
+            ]
+        },
+        {
+            "id": "EntryPreview",
+            "type": "object",
+            "properties": [
+                { "name": "key", "$ref": "ObjectPreview", "optional": true, "description": "Entry key. Specified for map-like collection entries." },
+                { "name": "value", "$ref": "ObjectPreview", "description": "Entry value." }
+            ]
+        },
+        {
+            "id": "CollectionEntry",
+            "type": "object",
+            "properties": [
+                { "name": "key", "$ref": "Runtime.RemoteObject", "optional": true, "description": "Entry key of a map-like collection, otherwise not provided." },
+                { "name": "value", "$ref": "Runtime.RemoteObject", "description": "Entry value." }
+            ]
+        },
+        {
+            "id": "PropertyDescriptor",
+            "type": "object",
+            "description": "Object property descriptor.",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Property name or symbol description." },
+                { "name": "value", "$ref": "RemoteObject", "optional": true, "description": "The value associated with the property." },
+                { "name": "writable", "type": "boolean", "optional": true, "description": "True if the value associated with the property may be changed (data descriptors only)." },
+                { "name": "get", "$ref": "RemoteObject", "optional": true, "description": "A function which serves as a getter for the property, or <code>undefined</code> if there is no getter (accessor descriptors only)." },
+                { "name": "set", "$ref": "RemoteObject", "optional": true, "description": "A function which serves as a setter for the property, or <code>undefined</code> if there is no setter (accessor descriptors only)." },
+                { "name": "configurable", "type": "boolean", "description": "True if the type of this property descriptor may be changed and if the property may be deleted from the corresponding object." },
+                { "name": "enumerable", "type": "boolean", "description": "True if this property shows up during enumeration of the properties on the corresponding object." },
+                { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." },
+                { "name": "isOwn", "optional": true, "type": "boolean", "description": "True if the property is owned for the object." },
+                { "name": "symbol", "optional": true, "$ref": "Runtime.RemoteObject", "description": "Property symbol object, if the property is a symbol." },
+                { "name": "nativeGetter", "optional": true, "type": "boolean", "description": "True if the property value came from a native getter." }
+            ]
+        },
+        {
+            "id": "InternalPropertyDescriptor",
+            "type": "object",
+            "description": "Object internal property descriptor. This property isn't normally visible in JavaScript code.",
+            "properties": [
+                { "name": "name", "type": "string", "description": "Conventional property name." },
+                { "name": "value", "$ref": "RemoteObject", "optional": true, "description": "The value associated with the property." }
+            ]
+        },
+        {
+            "id": "CallArgument",
+            "type": "object",
+            "description": "Represents function call argument. Either remote object id <code>objectId</code> or primitive <code>value</code> or neither of (for undefined) them should be specified.",
+            "properties": [
+                { "name": "value", "type": "any", "optional": true, "description": "Primitive value." },
+                { "name": "objectId", "$ref": "RemoteObjectId", "optional": true, "description": "Remote object handle." }
+            ]
+        },
+        {
+            "id": "ExecutionContextId",
+            "type": "integer",
+            "description": "Id of an execution context."
+        },
+        {
+            "id": "ExecutionContextDescription",
+            "type": "object",
+            "description": "Description of an isolated world.",
+            "properties": [
+                { "name": "id", "$ref": "ExecutionContextId", "description": "Unique id of the execution context. It can be used to specify in which execution context script evaluation should be performed." },
+                { "name": "isPageContext", "type": "boolean", "description": "True if this is a context where inpspected web page scripts run. False if it is a content script isolated context." },
+                { "name": "name", "type": "string", "description": "Human readable name describing given context."},
+                { "name": "frameId", "$ref": "Network.FrameId", "description": "Id of the owning frame." }
+            ]
+        },
+        {
+            "id": "SyntaxErrorType",
+            "type": "string",
+            "enum": ["none", "irrecoverable", "unterminated-literal", "recoverable"],
+            "description": "Syntax error type: \"none\" for no error, \"irrecoverable\" for unrecoverable errors, \"unterminated-literal\" for when there is an unterminated literal, \"recoverable\" for when the expression is unfinished but valid so far."
+        },
+        {
+            "id": "ErrorRange",
+            "type": "object",
+            "description": "Range of an error in source code.",
+            "properties": [
+                { "name": "startOffset", "type": "integer", "description": "Start offset of range (inclusive)." },
+                { "name": "endOffset", "type": "integer", "description": "End offset of range (exclusive)." }
+            ]
+        },
+        {
+            "id": "StructureDescription",
+            "type": "object",
+            "properties": [
+                { "name": "fields", "type": "array",  "items": { "type": "string" }, "optional": true, "description": "Array of strings, where the strings represent object properties." },
+                { "name": "optionalFields", "type": "array",  "items": { "type": "string" }, "optional": true, "description": "Array of strings, where the strings represent optional object properties." },
+                { "name": "constructorName", "type": "string", "optional": true, "description": "Name of the constructor." },
+                { "name": "prototypeStructure", "$ref": "StructureDescription", "optional": true, "description": "Pointer to the StructureRepresentation of the protoype if one exists." },
+                { "name": "isImprecise", "type": "boolean", "optional": true, "description": "If true, it indicates that the fields in this StructureDescription may be inaccurate. I.e, there might have been fields that have been deleted before it was profiled or it has fields we haven't profiled." }
+            ]
+        },
+        {
+            "id": "TypeSet",
+            "type": "object",
+            "properties": [
+                { "name": "isFunction", "type": "boolean", "description": "Indicates if this type description has been type Function." },
+                { "name": "isUndefined", "type": "boolean", "description": "Indicates if this type description has been type Undefined." },
+                { "name": "isNull", "type": "boolean", "description": "Indicates if this type description has been type Null." },
+                { "name": "isBoolean", "type": "boolean", "description": "Indicates if this type description has been type Boolean." },
+                { "name": "isInteger", "type": "boolean", "description": "Indicates if this type description has been type Integer." },
+                { "name": "isNumber", "type": "boolean", "description": "Indicates if this type description has been type Number." },
+                { "name": "isString", "type": "boolean", "description": "Indicates if this type description has been type String." },
+                { "name": "isObject", "type": "boolean", "description": "Indicates if this type description has been type Object." },
+                { "name": "isSymbol", "type": "boolean", "description": "Indicates if this type description has been type Symbol." }
+            ]
+        },
+        {
+            "id": "TypeDescription",
+            "type": "object",
+            "description": "Container for type information that has been gathered.",
+            "properties": [
+                { "name": "isValid", "type": "boolean", "description": "If true, we were able to correlate the offset successfuly with a program location. If false, the offset may be bogus or the offset may be from a CodeBlock that hasn't executed." },
+                { "name": "leastCommonAncestor", "type": "string", "optional": true, "description": "Least common ancestor of all Constructors if the TypeDescription has seen any structures. This string is the display name of the shared constructor function." },
+                { "name": "typeSet", "$ref": "TypeSet", "optional": true, "description": "Set of booleans for determining the aggregate type of this type description." },
+                { "name": "structures", "type": "array", "items": { "$ref": "StructureDescription" }, "optional": true, "description": "Array of descriptions for all structures seen for this variable." },
+                { "name": "isTruncated", "type": "boolean", "optional": true, "description": "If true, this indicates that no more structures are being profiled because some maximum threshold has been reached and profiling has stopped because of memory pressure." }
+            ]
+        },
+        {
+            "id": "TypeLocation",
+            "type": "object",
+            "description": "Describes the location of an expression we want type information for.",
+            "properties": [
+                { "name": "typeInformationDescriptor", "type": "integer", "description": "What kind of type information do we want (normal, function return values, 'this' statement)." },
+                { "name": "sourceID", "type": "string", "description": "sourceID uniquely identifying a script" },
+                { "name": "divot", "type": "integer", "description": "character offset for assignment range" }
+            ]
+        },
+        {
+            "id": "BasicBlock",
+            "type": "object",
+            "description": "From Wikipedia: a basic block is a portion of the code within a program with only one entry point and only one exit point. This type gives the location of a basic block and if that basic block has executed.",
+            "properties": [
+                { "name": "startOffset", "type": "integer", "description": "Start offset of the basic block." },
+                { "name": "endOffset", "type": "integer", "description": "End offset of the basic block." },
+                { "name": "hasExecuted", "type": "boolean", "description": "Indicates if the basic block has executed before." }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "parse",
+            "parameters": [
+                { "name": "source", "type": "string", "description": "Source code to parse." }
+            ],
+            "returns": [
+                { "name": "result", "$ref": "SyntaxErrorType", "description": "Parse result." },
+                { "name": "message", "type": "string", "optional": true, "description": "Parse error message." },
+                { "name": "range", "$ref": "ErrorRange", "optional": true, "description": "Range in the source where the error occurred." }
+            ],
+            "description": "Parses JavaScript source code for errors."
+        },
+        {
+            "name": "evaluate",
+            "parameters": [
+                { "name": "expression", "type": "string", "description": "Expression to evaluate." },
+                { "name": "objectGroup", "type": "string", "optional": true, "description": "Symbolic group name that can be used to release multiple objects." },
+                { "name": "includeCommandLineAPI", "type": "boolean", "optional": true, "description": "Determines whether Command Line API should be available during the evaluation." },
+                { "name": "doNotPauseOnExceptionsAndMuteConsole", "type": "boolean", "optional": true, "description": "Specifies whether evaluation should stop on exceptions and mute console. Overrides setPauseOnException state." },
+                { "name": "contextId", "$ref": "Runtime.ExecutionContextId", "optional": true, "description": "Specifies in which isolated context to perform evaluation. Each content script lives in an isolated context and this parameter may be used to specify one of those contexts. If the parameter is omitted or 0 the evaluation will be performed in the context of the inspected page." },
+                { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object that should be sent by value." },
+                { "name": "generatePreview", "type": "boolean", "optional": true, "description": "Whether preview should be generated for the result." },
+                { "name": "saveResult", "type": "boolean", "optional": true, "description": "Whether the resulting value should be considered for saving in the $n history." }
+            ],
+            "returns": [
+                { "name": "result", "$ref": "RemoteObject", "description": "Evaluation result." },
+                { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." },
+                { "name": "savedResultIndex", "type": "integer", "optional": true, "description": "If the result was saved, this is the $n index that can be used to access the value." }
+            ],
+            "description": "Evaluates expression on global object."
+        },
+        {
+            "name": "callFunctionOn",
+            "parameters": [
+                { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to call function on." },
+                { "name": "functionDeclaration", "type": "string", "description": "Declaration of the function to call." },
+                { "name": "arguments", "type": "array", "items": { "$ref": "CallArgument", "description": "Call argument." }, "optional": true, "description": "Call arguments. All call arguments must belong to the same JavaScript world as the target object." },
+                { "name": "doNotPauseOnExceptionsAndMuteConsole", "type": "boolean", "optional": true, "description": "Specifies whether function call should stop on exceptions and mute console. Overrides setPauseOnException state." },
+                { "name": "returnByValue", "type": "boolean", "optional": true, "description": "Whether the result is expected to be a JSON object which should be sent by value." },
+                { "name": "generatePreview", "type": "boolean", "optional": true, "description": "Whether preview should be generated for the result." }
+            ],
+            "returns": [
+                { "name": "result", "$ref": "RemoteObject", "description": "Call result." },
+                { "name": "wasThrown", "type": "boolean", "optional": true, "description": "True if the result was thrown during the evaluation." }
+            ],
+            "description": "Calls function with given declaration on the given object. Object group of the result is inherited from the target object."
+        },
+        {
+            "name": "getProperties",
+            "parameters": [
+                { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to return properties for." },
+                { "name": "ownProperties", "optional": true, "type": "boolean", "description": "If true, returns properties belonging only to the object itself, not to its prototype chain." },
+                { "name": "generatePreview", "type": "boolean", "optional": true, "description": "Whether preview should be generated for property values." }
+            ],
+            "returns": [
+                { "name": "result", "type": "array", "items": { "$ref": "PropertyDescriptor"}, "description": "Object properties." },
+                { "name": "internalProperties", "optional": true, "type": "array", "items": { "$ref": "InternalPropertyDescriptor"}, "description": "Internal object properties." }
+            ],
+            "description": "Returns properties of a given object. Object group of the result is inherited from the target object."
+        },
+        {
+            "name": "getDisplayableProperties",
+            "parameters": [
+                { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to return properties for." },
+                { "name": "generatePreview", "type": "boolean", "optional": true, "description": "Whether preview should be generated for property values." }
+            ],
+            "returns": [
+                { "name": "properties", "type": "array", "items": { "$ref": "PropertyDescriptor"}, "description": "Object properties." },
+                { "name": "internalProperties", "optional": true, "type": "array", "items": { "$ref": "InternalPropertyDescriptor"}, "description": "Internal object properties." }
+            ],
+            "description": "Returns displayable properties of a given object. Object group of the result is inherited from the target object. Displayable properties are own properties, internal properties, and native getters in the prototype chain (assumed to be bindings and treated like own properties for the frontend)."
+        },
+        {
+            "name": "getCollectionEntries",
+            "description": "Returns entries of given Map / Set collection.",
+            "parameters": [
+                { "name": "objectId", "$ref": "Runtime.RemoteObjectId", "description": "Id of the collection to get entries for." },
+                { "name": "objectGroup", "optional": true, "type": "string", "description": "Symbolic group name that can be used to release multiple. If not provided, it will be the same objectGroup as the RemoteObject determined from <code>objectId</code>. This is useful for WeakMap to release the collection entries." },
+                { "name": "startIndex", "optional": true, "type": "integer", "description": "If provided skip to this index before collecting values. Otherwise, 0." },
+                { "name": "numberToFetch", "optional": true, "type": "integer", "description": "If provided only return <code>numberToFetch</code> values. Otherwise, return values all the way to the end." }
+            ],
+            "returns": [
+                { "name": "entries", "type": "array", "items": { "$ref": "CollectionEntry" }, "description": "Array of collection entries." }
+            ]
+        },
+        {
+            "name": "saveResult",
+            "parameters": [
+                { "name": "value", "$ref": "CallArgument", "description": "Id or value of the object to save." },
+                { "name": "contextId", "optional": true, "$ref": "ExecutionContextId", "description": "Unique id of the execution context. To specify in which execution context script evaluation should be performed. If not provided, determine from the CallArgument's objectId." }
+            ],
+            "returns": [
+                { "name": "savedResultIndex", "type": "integer", "optional": true, "description": "If the value was saved, this is the $n index that can be used to access the value." }
+            ],
+            "description": "Assign a saved result index to this value."
+        },
+        {
+            "name": "releaseObject",
+            "parameters": [
+                { "name": "objectId", "$ref": "RemoteObjectId", "description": "Identifier of the object to release." }
+            ],
+            "description": "Releases remote object with given id."
+        },
+        {
+            "name": "releaseObjectGroup",
+            "parameters": [
+                { "name": "objectGroup", "type": "string", "description": "Symbolic object group name." }
+            ],
+            "description": "Releases all remote objects that belong to a given group."
+        },
+        {
+            "name": "run",
+            "description": "Tells inspected instance(worker or page) that it can run in case it was started paused."
+        },
+        {
+            "name": "enable",
+            "description": "Enables reporting of execution contexts creation by means of <code>executionContextCreated</code> event. When the reporting gets enabled the event will be sent immediately for each existing execution context."
+        },
+        {
+            "name": "disable",
+            "description": "Disables reporting of execution contexts creation."
+        },
+        {
+            "name": "getRuntimeTypesForVariablesAtOffsets",
+            "parameters": [
+                { "name": "locations", "type": "array", "items": { "$ref": "TypeLocation" }, "description": "An array of type locations we're requesting information for. Results are expected in the same order they're sent in."}
+            ],
+            "returns": [
+                { "name": "types", "type": "array", "items": { "$ref": "TypeDescription", "description": "Types for requested variable." } }
+            ],
+            "description": "Returns detailed informtation on given function."
+        },
+        {
+            "name": "enableTypeProfiler",
+            "description": "Enables type profiling on the VM."
+        },
+        {
+            "name": "disableTypeProfiler",
+            "description": "Disables type profiling on the VM."
+        },
+        {
+            "name": "getBasicBlocks",
+            "parameters": [
+                { "name": "sourceID", "type": "string", "description": "Indicates which sourceID information is requested for." }
+            ],
+            "returns": [
+                { "name": "basicBlocks", "type": "array", "items": { "$ref": "BasicBlock", "description": "Array of basic blocks." } }
+            ],
+            "description": "Returns a list of basic blocks for the given sourceID with information about their text ranges and whether or not they have executed."
+        }
+    ],
+    "events": [
+        {
+            "name": "executionContextCreated",
+            "parameters": [
+                { "name": "context", "$ref": "ExecutionContextDescription", "description": "A newly created execution contex." }
+            ],
+            "description": "Issued when new execution context is created."
+        }
+    ]
+}
+,
+{
+    "domain": "Timeline",
+    "description": "Timeline provides its clients with instrumentation records that are generated during the page runtime. Timeline instrumentation can be started and stopped using corresponding commands. While timeline is started, it is generating timeline event records.",
+    "availability": "web",
+    "types": [
+        {
+            "id": "EventType",
+            "type": "string",
+            "enum": [
+                "EventDispatch",
+                "ScheduleStyleRecalculation",
+                "RecalculateStyles",
+                "InvalidateLayout",
+                "Layout",
+                "Paint",
+                "Composite",
+                "RenderingFrame",
+                "ScrollLayer",
+                "ParseHTML",
+                "TimerInstall",
+                "TimerRemove",
+                "TimerFire",
+                "EvaluateScript",
+                "MarkLoad",
+                "MarkDOMContent",
+                "TimeStamp",
+                "Time",
+                "TimeEnd",
+                "XHRReadyStateChange",
+                "XHRLoad",
+                "FunctionCall",
+                "ProbeSample",
+                "ConsoleProfile",
+                "GCEvent",
+                "RequestAnimationFrame",
+                "CancelAnimationFrame",
+                "FireAnimationFrame",
+                "WebSocketCreate",
+                "WebSocketSendHandshakeRequest",
+                "WebSocketReceiveHandshakeResponse",
+                "WebSocketDestroy"
+            ],
+            "description": "Timeline record type."
+        },
+        {
+            "id": "TimelineEvent",
+            "type": "object",
+            "properties": [
+                { "name": "type", "$ref": "EventType", "description": "Event type." },
+                { "name": "data", "type": "object", "description": "Event data." },
+                { "name": "children", "type": "array", "optional": true, "items": { "$ref": "TimelineEvent" }, "description": "Nested records." }
+            ],
+            "description": "Timeline record contains information about the recorded activity."
+        },
+        {
+            "id": "CPUProfileNodeAggregateCallInfo",
+            "type": "object",
+            "description": "Aggregate CPU Profile call info. Holds time information for all the calls that happened on a node.",
+            "properties": [
+                { "name": "callCount", "type": "number", "description": "Total number of calls." },
+                { "name": "startTime", "type": "number", "description": "Start time for the first call." },
+                { "name": "endTime", "type": "number", "description": "End time for the last call." },
+                { "name": "totalTime", "type": "number", "description": "Total execution time for all calls combined." }
+            ]
+        },
+        {
+            "id": "CPUProfileNode",
+            "type": "object",
+            "description": "CPU Profile node. Holds callsite information, execution statistics and child nodes.",
+            "properties": [
+                { "name": "id", "type": "integer", "description": "Unique identifier for this call site." },
+                { "name": "callInfo", "$ref": "CPUProfileNodeAggregateCallInfo", "description": "Aggregate info about all the calls that making up this node." },
+                { "name": "functionName", "type": "string", "optional": true, "description": "Function name." },
+                { "name": "url", "type": "string", "optional": true, "description": "URL." },
+                { "name": "lineNumber", "type": "integer", "optional": true, "description": "Line number." },
+                { "name": "columnNumber", "type": "integer", "optional": true, "description": "Column number." },
+                { "name": "children", "type": "array", "items": { "$ref": "CPUProfileNode" }, "optional": true, "description": "Child nodes." }
+            ]
+        },
+        {
+            "id": "CPUProfile",
+            "type": "object",
+            "description": "Profile.",
+            "properties": [
+                { "name": "rootNodes", "type": "array", "items": { "$ref": "CPUProfileNode" }, "description": "Top level nodes in the stack." },
+                { "name": "idleTime", "type": "number", "optional": true }
+            ]
+        }
+    ],
+    "commands": [
+        {
+            "name": "start",
+            "parameters": [
+                { "name": "maxCallStackDepth", "optional": true, "type": "integer", "description": "Samples JavaScript stack traces up to <code>maxCallStackDepth</code>, defaults to 5." }
+            ],
+            "description": "Starts capturing instrumentation events."
+        },
+        {
+            "name": "stop",
+            "description": "Stops capturing instrumentation events."
+        }
+    ],
+    "events": [
+        {
+            "name": "eventRecorded",
+            "parameters": [
+                { "name": "record", "$ref": "TimelineEvent", "description": "Timeline event record data." }
+            ],
+            "description": "Fired for every instrumentation event while timeline is started."
+        },
+        {
+            "name": "recordingStarted",
+            "parameters": [
+                { "name": "startTime", "type": "number", "description": "Start time of this new recording." }
+            ],
+            "description": "Fired when recording has started."
+        },
+        {
+            "name": "recordingStopped",
+            "parameters": [
+                { "name": "endTime", "type": "number", "description": "End time of this recording." }
+            ],
+            "description": "Fired when recording has stopped."
+        }
+    ]
+}
+,
+{
+    "domain": "Worker",
+    "types": [],
+    "availability": "web",
+    "commands": [
+        {
+            "name": "enable"
+        },
+        {
+            "name": "disable"
+        },
+        {
+            "name": "sendMessageToWorker",
+            "parameters": [
+                { "name": "workerId", "type": "integer" },
+                { "name": "message", "type": "object" }
+            ]
+        },
+        {
+            "name": "canInspectWorkers",
+            "description": "Tells whether browser supports workers inspection.",
+            "returns": [
+                { "name": "result", "type": "boolean", "description": "True if browser has workers support." }
+            ]
+        },
+        {
+            "name": "connectToWorker",
+            "parameters": [
+                { "name": "workerId", "type": "integer" }
+            ]
+        },
+        {
+            "name": "disconnectFromWorker",
+            "parameters": [
+                { "name": "workerId", "type": "integer" }
+            ]
+        },
+        {
+            "name": "setAutoconnectToWorkers",
+            "parameters": [
+                { "name": "value", "type": "boolean" }
+            ]
+        }
+    ],
+    "events": [
+        {
+            "name": "workerCreated",
+            "parameters": [
+                { "name": "workerId", "type": "integer" },
+                { "name": "url", "type": "string" },
+                { "name": "inspectorConnected", "type": "boolean" }
+            ]
+        },
+        {
+            "name": "workerTerminated",
+            "parameters": [
+                { "name": "workerId", "type": "integer" }
+            ]
+        },
+        {
+            "name": "dispatchMessageFromWorker",
+            "parameters": [
+                { "name": "workerId", "type": "integer" },
+                { "name": "message", "type": "object" }
+            ]
+        },
+        {
+            "name": "disconnectedFromWorker"
+        }
+    ]
+}
+]}

--- a/source/ProtocolGenerator/MasterDevs.ChromeDevTools.ProtocolGenerator.csproj
+++ b/source/ProtocolGenerator/MasterDevs.ChromeDevTools.ProtocolGenerator.csproj
@@ -50,14 +50,43 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Command.cs" />
+    <Compile Include="Domain.cs" />
+    <Compile Include="Event.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="Property.cs" />
+    <Compile Include="Protocol.cs" />
+    <Compile Include="ProtocolItem.cs" />
+    <Compile Include="Type.cs" />
+    <Compile Include="Version.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="App.config" />
+    <None Include="Inspector-0.1.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Inspector-1.0.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Inspector-1.1.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Inspector-iOS-7.0.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Inspector-iOS-8.0.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Inspector-iOS-9.0.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="Inspector-iOS-9.3.json">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
     <None Include="packages.config" />
     <None Include="protocol.json">
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />

--- a/source/ProtocolGenerator/Program.cs
+++ b/source/ProtocolGenerator/Program.cs
@@ -23,6 +23,16 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
         private static Dictionary<string, List<string>> _DomainEvents = new Dictionary<string, List<string>>();
         private static Dictionary<string, string> _SimpleTypes = new Dictionary<string, string>();
 
+        private static Protocol LoadProtocol(string path)
+        {
+            string json = File.ReadAllText(path);
+            JsonSerializerSettings settings = new JsonSerializerSettings();
+            settings.MissingMemberHandling = MissingMemberHandling.Error;
+            settings.MetadataPropertyHandling = MetadataPropertyHandling.Ignore;
+            Protocol p = JsonConvert.DeserializeObject<Protocol>(json, settings);
+            return p;
+        }
+
         private static void Main(string[] args)
         {
             var filePath = "protocol.json";

--- a/source/ProtocolGenerator/Program.cs
+++ b/source/ProtocolGenerator/Program.cs
@@ -36,13 +36,9 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
         private static void Main(string[] args)
         {
             var filePath = "protocol.json";
-            JObject protocolObject = null;
-            using (var fileStream = File.OpenText(filePath))
-            using (var reader = new JsonTextReader(fileStream))
-            {
-                protocolObject = (JObject)JToken.ReadFrom(reader);
-            }
-            var outputFolder = "OutputProtocol";
+            var protocolObject = LoadProtocol(filePath);
+
+            var outputFolder = args[0];
             if (Directory.Exists(outputFolder))
             {
                 Directory.Delete(outputFolder, true);
@@ -51,19 +47,19 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
             WriteProtocolClasses(protocolObject, outputDirectoryInfo);
         }
 
-        private static void WriteProtocolClasses(JObject protocolObject, DirectoryInfo directory)
+        private static void WriteProtocolClasses(Protocol protocolObject, DirectoryInfo directory)
         {
-            var domains = protocolObject["domains"] as JArray;
+            var domains = protocolObject.Domains;
             foreach (var domain in domains)
             {
-                AddPropertyTypes(domain["domain"].ToString(), domain["types"] as JArray);
+                AddPropertyTypes(domain.Name, domain.Types);
             }
             foreach (var domain in domains)
             {
-                var domainName = domain["domain"].ToString();
-                var types = domain["types"] as JArray;
-                var commands = domain["commands"] as JArray;
-                var events = domain["events"] as JArray;
+                var domainName = domain.Name;
+                var types = domain.Types;
+                var commands = domain.Commands;
+                var events = domain.Events;
                 _DomainCommands[domainName] = new List<string>();
                 _DomainEvents[domainName] = new List<string>();
                 WriteProtocolClasses(directory, domainName, types, commands, events);
@@ -71,16 +67,16 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
             WriteMethodConstants(directory);
         }
 
-        private static void AddPropertyTypes(string domain, JArray types)
+        private static void AddPropertyTypes(string domain, IEnumerable<Type> types)
         {
             var domainDictionary = new Dictionary<string, string>();
             _DomainPropertyTypes[domain] = domainDictionary;
-            foreach (var type in types ?? new JArray())
+            foreach (var type in types)
             {
-                var propertyType = type["type"].ToString();
-                var typeName = GetString(type["id"]);
-                if (null != type["enum"]
-                    || null != type["properties"]
+                var propertyType = type.Kind;
+                var typeName = type.Name;
+                if (type.Enum.Any()
+                    || type.Properties.Any()
                     || "object" == propertyType)
                 {
                     propertyType = domain + "." + typeName;
@@ -100,32 +96,32 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
             }
         }
 
-        private static void AddArrayPropertyType(Dictionary<string, string> domainDictionary, string domain, JToken type)
+        private static void AddArrayPropertyType(Dictionary<string, string> domainDictionary, string domain, Type type)
         {
-            var items = type["items"];
+            var items = type.Items;
             if (null == items) return;
-            var itemsType = GeneratePropertyType(GetString(items["type"]));
+            var itemsType = GeneratePropertyType(items.Kind);
             if (String.IsNullOrEmpty(itemsType))
             {
-                itemsType = GetString(items["$ref"]);
+                itemsType = items.TypeReference;
             }
-            domainDictionary[type["id"].ToString()] = domain + "." + itemsType + "[]";
+            domainDictionary[type.Name] = domain + "." + itemsType + "[]";
         }
 
-        private static void WriteProtocolClasses(DirectoryInfo directory, string domainName, JArray types, JArray commands, JArray events)
+        private static void WriteProtocolClasses(DirectoryInfo directory, string domainName, IEnumerable<Type> types, IEnumerable<Command> commands, IEnumerable<Event> events)
         {
             var domainDirectoryInfo = CreateDomainFolder(directory, domainName);
-            foreach (var type in types ?? new JArray())
+            foreach (var type in types)
             {
-                WriteType(domainDirectoryInfo, type as JObject);
+                WriteType(domainDirectoryInfo, type);
             }
-            foreach (var command in commands ?? new JArray())
+            foreach (var command in commands)
             {
-                WriteCommand(domainDirectoryInfo, command as JObject);
+                WriteCommand(domainDirectoryInfo, command);
             }
-            foreach (var evnt in events ?? new JArray())
+            foreach (var evnt in events)
             {
-                WriteEvent(domainDirectoryInfo, evnt as JObject);
+                WriteEvent(domainDirectoryInfo, evnt);
             }
         }
 
@@ -175,18 +171,18 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
             WriteToFile(domainDirectoryInfo, ProtocolNameClass, sb.ToString());
         }
 
-        private static void WriteEvent(DirectoryInfo domainDirectoryInfo, JObject evnt)
+        private static void WriteEvent(DirectoryInfo domainDirectoryInfo, Event evnt)
         {
             if (null == evnt) return;
-            var eventName = evnt["name"].ToString();
-            var description = GetString(evnt["description"]);
-            var parameters = evnt["parameters"] as JArray;
+            var eventName = evnt.Name;
+            var description = evnt.Description;
+            var parameters = evnt.Parameters;
             // ignoreing "handlers" ... i'm not sure what they are for yet
             _DomainEvents[domainDirectoryInfo.Name].Add(eventName);
             WriteEvent(domainDirectoryInfo, eventName, description, parameters);
         }
 
-        private static void WriteEvent(DirectoryInfo domainDirectoryInfo, string eventName, string description, JArray parameters)
+        private static void WriteEvent(DirectoryInfo domainDirectoryInfo, string eventName, string description, IEnumerable<Property> parameters)
         {
             var className = ToCamelCase(eventName) + EventSubclass;
             var sb = new StringBuilder();
@@ -208,33 +204,28 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
             sb.AppendFormat("\tpublic class {0}", className);
             sb.AppendLine();
             sb.AppendLine("\t{");
-            foreach (var parameterProperty in parameters ?? new JArray())
+            foreach (var parameterProperty in parameters)
             {
-                WriteProperty(sb, domainDirectoryInfo.Name, className, parameterProperty as JObject);
+                WriteProperty(sb, domainDirectoryInfo.Name, className, parameterProperty);
             }
             sb.AppendLine("\t}");
             sb.AppendLine("}");
             WriteToFile(domainDirectoryInfo, className, sb.ToString());
         }
 
-        private static void WriteCommand(DirectoryInfo domainDirectoryInfo, JObject command)
+        private static void WriteCommand(DirectoryInfo domainDirectoryInfo, Command command)
         {
             if (null == command) return;
-            var commandName = command["name"].ToString();
-            var description = GetString(command["description"]);
-            var parameters = command["parameters"] as JArray;
-            var returnObject = command["returns"] as JArray;
+            var commandName = command.Name;
+            var description = command.Description;
+            var parameters = command.Parameters;
+            var returnObject = command.Returns;
             _DomainCommands[domainDirectoryInfo.Name].Add(commandName);
             WriteCommand(domainDirectoryInfo, commandName, description, parameters);
             WriteCommandResponse(domainDirectoryInfo, commandName, description, returnObject);
         }
 
-        private static string GetString(JToken jToken)
-        {
-            return null == jToken ? null : jToken.ToString();
-        }
-
-        private static void WriteCommandResponse(DirectoryInfo domainDirectoryInfo, string commandName, string description, JArray returnObject)
+        private static void WriteCommandResponse(DirectoryInfo domainDirectoryInfo, string commandName, string description, IEnumerable<Property> returnObject)
         {
             var className = ToCamelCase(commandName) + CommandResponseSubclass;
             var sb = new StringBuilder();
@@ -257,16 +248,16 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
             sb.AppendFormat("\tpublic class {0}", className);
             sb.AppendLine();
             sb.AppendLine("\t{");
-            foreach (var returnObjectProperty in returnObject ?? new JArray())
+            foreach (var returnObjectProperty in returnObject)
             {
-                WriteProperty(sb, domainDirectoryInfo.Name, className, returnObjectProperty as JObject);
+                WriteProperty(sb, domainDirectoryInfo.Name, className, returnObjectProperty);
             }
             sb.AppendLine("\t}");
             sb.AppendLine("}");
             WriteToFile(domainDirectoryInfo, className, sb.ToString());
         }
 
-        private static void WriteCommand(DirectoryInfo domainDirectoryInfo, string commandName, string description, JArray parameters)
+        private static void WriteCommand(DirectoryInfo domainDirectoryInfo, string commandName, string description, IEnumerable<Property> parameters)
         {
             var className = ToCamelCase(commandName) + CommandSubclass;
             var sb = new StringBuilder();
@@ -290,32 +281,32 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
             sb.AppendFormat("\tpublic class {0}", className);
             sb.AppendLine();
             sb.AppendLine("\t{");
-            foreach (var parameterProperty in parameters ?? new JArray())
+            foreach (var parameterProperty in parameters)
             {
-                WriteProperty(sb, domainDirectoryInfo.Name, className, parameterProperty as JObject);
+                WriteProperty(sb, domainDirectoryInfo.Name, className, parameterProperty);
             }
             sb.AppendLine("\t}");
             sb.AppendLine("}");
             WriteToFile(domainDirectoryInfo, className, sb.ToString());
         }
 
-        private static void WriteType(DirectoryInfo domainDirectoryInfo, JObject type)
+        private static void WriteType(DirectoryInfo domainDirectoryInfo, Type type)
         {
             if (null == type) return;
-            if (null != type["enum"]) WriteTypeEnum(domainDirectoryInfo, type);
-            if (null != type["properties"]) WriteTypeClass(domainDirectoryInfo, type);
+            if (type.Enum.Any()) WriteTypeEnum(domainDirectoryInfo, type);
+            if (type.Properties.Any()) WriteTypeClass(domainDirectoryInfo, type);
             WriteTypeSimple(domainDirectoryInfo, type);
         }
 
-        private static void WriteTypeSimple(DirectoryInfo domainDirectoryInfo, JObject type)
+        private static void WriteTypeSimple(DirectoryInfo domainDirectoryInfo, Type type)
         {
-            _SimpleTypes[type["id"].ToString()] = type["type"].ToString();
+            _SimpleTypes[type.Name] = type.Kind;
         }
 
-        private static void WriteTypeClass(DirectoryInfo domainDirectoryInfo, JObject type)
+        private static void WriteTypeClass(DirectoryInfo domainDirectoryInfo, Type type)
         {
-            if ("object" != type["type"].ToString()) return;
-            var className = type["id"].ToString();
+            if ("object" != type.Kind) return;
+            var className = type.Name;
             var sb = new StringBuilder();
             sb.AppendFormat("using MasterDevs.ChromeDevTools;");
             sb.AppendLine();
@@ -326,39 +317,39 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
             sb.AppendLine();
             sb.AppendLine("{");
             sb.AppendLine("\t/// <summary>");
-            sb.AppendFormat("\t/// {0}", type["description"]);
+            sb.AppendFormat("\t/// {0}", type.Description);
             sb.AppendLine();
             sb.AppendLine("\t/// </summary>");
             sb.AppendFormat("\tpublic class {0}", className);
             sb.AppendLine();
             sb.AppendLine("\t{");
-            foreach (var propertyDescription in type["properties"] as JArray ?? new JArray())
+            foreach (var propertyDescription in type.Properties)
             {
-                WriteProperty(sb, domainDirectoryInfo.Name, className, propertyDescription as JObject);
+                WriteProperty(sb, domainDirectoryInfo.Name, className, propertyDescription);
             }
             sb.AppendLine("\t}");
             sb.AppendLine("}");
             WriteToFile(domainDirectoryInfo, className, sb.ToString());
         }
 
-        private static void WriteProperty(StringBuilder sb, string domain, string className, JObject property)
+        private static void WriteProperty(StringBuilder sb, string domain, string className, Property property)
         {
-            var propertyName = GeneratePropertyName(property["name"].ToString());
-            string propertyType = GetString(property["type"]);
-            if (null != property["$ref"])
+            var propertyName = GeneratePropertyName(property.Name);
+            string propertyType = property.Kind;
+            if (null != property.TypeReference)
             {
-                propertyType = GeneratePropertyTypeFromReference(domain, property["$ref"].ToString());
+                propertyType = GeneratePropertyTypeFromReference(domain, property.TypeReference);
             }
             else if ("array" == propertyType)
             {
-                var arrayDescription = property["items"] as JObject;
-                if (null != arrayDescription["$ref"])
+                var arrayDescription = property.Items;
+                if (null != arrayDescription.TypeReference)
                 {
-                    propertyType = GeneratePropertyTypeFromReference(domain, arrayDescription["$ref"].ToString()) + "[]";
+                    propertyType = GeneratePropertyTypeFromReference(domain, arrayDescription.TypeReference) + "[]";
                 }
                 else
                 {
-                    var arrayType = GetString(arrayDescription["type"]);
+                    var arrayType = arrayDescription.Kind;
                     if ("object" == arrayType)
                     {
                         var internalClassName = ToCamelCase(propertyName) + "Array";
@@ -366,16 +357,16 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
                         sb.AppendFormat("\t\tpublic class {0}", internalClassName);
                         sb.AppendLine();
                         sb.AppendLine("\t\t{");
-                        foreach (var internalProperty in arrayDescription["properties"] as JArray ?? new JArray())
+                        foreach (var internalProperty in arrayDescription.Properties)
                         {
-                            WriteProperty(sb, domain, internalClassName, internalProperty as JObject);
+                            WriteProperty(sb, domain, internalClassName, internalProperty);
                         }
                         sb.AppendLine("\t\t}");
                         sb.AppendLine();
                     }
                     else
                     {
-                        propertyType = GeneratePropertyType(GetString(arrayDescription["type"])) + "[]";
+                        propertyType = GeneratePropertyType(arrayDescription.Kind) + "[]";
                     }
                 }
             }
@@ -384,12 +375,12 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
                 propertyType = GeneratePropertyType(propertyType.ToString());
             }
             sb.AppendLine("\t\t/// <summary>");
-            sb.AppendFormat("\t\t/// Gets or sets {0}", property["description"] ?? propertyName);
+            sb.AppendFormat("\t\t/// Gets or sets {0}", property.Description ?? propertyName);
             sb.AppendLine();
             sb.AppendLine("\t\t/// </summary>");
             if (className == propertyName)
             {
-                sb.AppendFormat("\t\t[JsonProperty(\"{0}\")]", property["name"]);
+                sb.AppendFormat("\t\t[JsonProperty(\"{0}\")]", property.Name);
                 sb.AppendLine();
                 propertyName += "Child";
             }
@@ -446,9 +437,9 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
             return Char.ToUpper(propertyName[0]).ToString() + propertyName.Substring(1);
         }
 
-        private static void WriteTypeEnum(DirectoryInfo domainDirectoryInfo, JObject type)
+        private static void WriteTypeEnum(DirectoryInfo domainDirectoryInfo, Type type)
         {
-            var enumName = type["id"].ToString();
+            var enumName = type.Name;
             StringBuilder sb = new StringBuilder();
             sb.AppendFormat("using MasterDevs.ChromeDevTools;");
             sb.AppendLine();
@@ -456,15 +447,15 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
             sb.AppendFormat("namespace {0}.{1}", RootNamespace, domainDirectoryInfo.Name);
             sb.AppendLine("{");
             sb.AppendLine("\t/// <summary>");
-            sb.AppendFormat("\t/// {0}", type["description"]);
+            sb.AppendFormat("\t/// {0}", type.Description);
             sb.AppendLine();
             sb.AppendLine("\t/// </summary>");
             sb.AppendFormat("\tpublic enum {0}", enumName);
             sb.AppendLine();
             sb.AppendLine("\t{");
-            foreach (var enumValueName in type["enum"] as JArray ?? new JArray())
+            foreach (var enumValueName in type.Enum)
             {
-                sb.AppendFormat("\t\t\t{0},", ToCamelCase(enumValueName.ToString().Replace("-", "_")));
+                sb.AppendFormat("\t\t\t{0},", ToCamelCase(enumValueName.Replace("-", "_")));
                 sb.AppendLine();
             }
             sb.AppendLine("\t}");

--- a/source/ProtocolGenerator/Property.cs
+++ b/source/ProtocolGenerator/Property.cs
@@ -1,0 +1,20 @@
+﻿using Newtonsoft.Json;
+
+namespace MasterDevs.ChromeDevTools.ProtocolGenerator
+{
+    class Property : Type
+    {
+        [JsonProperty("name")]
+        public override string Name
+        {
+            get;
+            set;
+        }
+
+        public bool Optional
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/source/ProtocolGenerator/Protocol.cs
+++ b/source/ProtocolGenerator/Protocol.cs
@@ -1,0 +1,25 @@
+﻿using System.Collections.ObjectModel;
+
+namespace MasterDevs.ChromeDevTools.ProtocolGenerator
+{
+    class Protocol
+    {
+        public Collection<string> Compatible
+        {
+            get;
+            set;
+        }
+
+        public Version Version
+        {
+            get;
+            set;
+        }
+
+        public Collection<Domain> Domains
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/source/ProtocolGenerator/ProtocolItem.cs
+++ b/source/ProtocolGenerator/ProtocolItem.cs
@@ -1,0 +1,28 @@
+﻿namespace MasterDevs.ChromeDevTools.ProtocolGenerator
+{
+    abstract class ProtocolItem
+    {
+        public virtual string Description
+        {
+            get;
+            set;
+        }
+
+        public virtual bool Hidden
+        {
+            get;
+            set;
+        }
+
+        public virtual string Name
+        {
+            get;
+            set;
+        }
+
+        public override string ToString()
+        {
+            return this.Name;
+        }
+    }
+}

--- a/source/ProtocolGenerator/README.md
+++ b/source/ProtocolGenerator/README.md
@@ -1,0 +1,22 @@
+# What about these .json files?
+
+The .json files describe the remote debugging protocol. They originate from Webkit (which Safari uses), which was forked
+by Chromium (which Chrome uses).
+
+Hence, the protocols are similar, but not the same. Plus, both Webkit and Chromium have released multiple versions of the
+protocol.
+
+## iOS
+There are versions of protocol.json for iOS 7, 8, 9 and 9.3
+
+You can find them on the:
+* [Official SVN repository](http://trac.webkit.org/browser/trunk/Source/WebInspectorUI/Versions/)
+* [GitHub mirror](https://github.com/WebKit/webkit/tree/master/Source/WebInspectorUI/Versions)
+
+## Chrome
+Chrome maintains three versions 0.1, 1.0 and 1.1; plus an additional "tip of the head" version simply known
+as `protocol.json`.
+
+You can find them on the:
+* [Official SVN repository](https://src.chromium.org/viewvc/blink/trunk/Source/devtools/)
+* [GitHub mirror](https://github.com/nwjs/blink/tree/nw12/Source/devtools)

--- a/source/ProtocolGenerator/Type.cs
+++ b/source/ProtocolGenerator/Type.cs
@@ -5,6 +5,12 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
 {
     class Type : ProtocolItem
     {
+        public Type()
+        {
+            this.Enum = new Collection<string>();
+            this.Properties = new Collection<Property>();
+        }
+
         [JsonProperty(PropertyName = "Id")]
         public override string Name
         {

--- a/source/ProtocolGenerator/Type.cs
+++ b/source/ProtocolGenerator/Type.cs
@@ -1,0 +1,59 @@
+﻿using Newtonsoft.Json;
+using System.Collections.ObjectModel;
+
+namespace MasterDevs.ChromeDevTools.ProtocolGenerator
+{
+    class Type : ProtocolItem
+    {
+        [JsonProperty(PropertyName = "Id")]
+        public override string Name
+        {
+            get;
+            set;
+        }
+
+        [JsonProperty(PropertyName ="type")]
+        public string Kind
+        {
+            get;
+            set;
+        }
+
+        public Collection<string> Enum
+        {
+            get;
+            set;
+        }
+
+        public Collection<Property> Properties
+        {
+            get;
+            set;
+        }
+
+        public Type Items
+        {
+            get;
+            set;
+        }
+
+        public int MinItems
+        {
+            get;
+            set;
+        }
+
+        public int MaxItems
+        {
+            get;
+            set;
+        }
+
+        [JsonProperty("$ref")]
+        public string TypeReference
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/source/ProtocolGenerator/Version.cs
+++ b/source/ProtocolGenerator/Version.cs
@@ -1,0 +1,22 @@
+﻿namespace MasterDevs.ChromeDevTools.ProtocolGenerator
+{
+    class Version
+    {
+        public string Major
+        {
+            get;
+            set;
+        }
+
+        public string Minor
+        {
+            get;
+            set;
+        }
+
+        public override string ToString()
+        {
+            return $"{this.Major}.{this.Minor}";
+        }
+    }
+}


### PR DESCRIPTION
Hi there!

I've stumbled upon your ChromeDevTools which work great for me - thanks!

However, I hit the need to support multiple versions of the WebKit remote debugger protocol at the same time. While I'm not 100% sure which is the best way to go and do that (any ideas are welcome), I thought a first good step would be to generate the classes for the various versions of the protocol (especially also including Safari on iOS) and start comparing the differences.

This seems to involve some work in the ProtocolGenerator project and I noticed you mentioned it is 

> A really ugly (seriously, one of my more ugly works of art) console application which parses the protocol.json file and generates all of the classes in the Protocol

I thought a first step in making the code slightly more readable was to use .NET POCO's for the various elements in the protocol.json DOM. This PR adds just that.

Hope this helps, all feedback is welcome.