### PR TITLE
[RFC] Supporting multiple versions of the Chrome Debugger Protocol

### DIFF
--- a/source/ChromeDevTools/MasterDevs.ChromeDevTools.csproj
+++ b/source/ChromeDevTools/MasterDevs.ChromeDevTools.csproj
@@ -880,6 +880,7 @@
     <Compile Include="Protocol\Worker\WorkerCreatedEvent.cs" />
     <Compile Include="Protocol\Worker\WorkerTerminatedEvent.cs" />
     <Compile Include="Serialization\MessageContractResolver.cs" />
+    <Compile Include="SupportedByAttribute.cs" />
   </ItemGroup>
   <ItemGroup>
     <Service Include="{508349B6-6B84-4DF5-91F0-309BEEBAD82D}" />

--- a/source/ChromeDevTools/SupportedByAttribute.cs
+++ b/source/ChromeDevTools/SupportedByAttribute.cs
@@ -1,0 +1,24 @@
+﻿using System;
+
+namespace MasterDevs.ChromeDevTools
+{
+    [AttributeUsage(AttributeTargets.Class)]
+    public class SupportedByAttribute : Attribute
+    {
+        public SupportedByAttribute(string browser)
+        {
+            if (browser == null)
+            {
+                throw new ArgumentNullException(nameof(browser));
+            }
+
+            this.Browser = browser;
+        }
+
+        public string Browser
+        {
+            get;
+            set;
+        }
+    }
+}

--- a/source/MasterDevs.ChromeDevTools.sln
+++ b/source/MasterDevs.ChromeDevTools.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
+VisualStudioVersion = 14.0.25123.0
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = ".nuget", ".nuget", "{0D43D20B-6D51-4CBC-BD30-F17B8CA65678}"
 	ProjectSection(SolutionItems) = preProject
@@ -22,6 +22,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MasterDevs.ChromeDevTools.P
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MasterDevs.ChromeDevTools.Sample", "Sample\MasterDevs.ChromeDevTools.Sample.csproj", "{36138327-0A72-44E3-B9DB-C4E6155AAFD5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MasterDevs.ChromeDevTools.ProtocolGenerator.Tests", "ProtocolGenerator.Tests\MasterDevs.ChromeDevTools.ProtocolGenerator.Tests.csproj", "{4C3A1910-79C5-43C0-8599-89921482B38B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -40,6 +42,10 @@ Global
 		{36138327-0A72-44E3-B9DB-C4E6155AAFD5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{36138327-0A72-44E3-B9DB-C4E6155AAFD5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{36138327-0A72-44E3-B9DB-C4E6155AAFD5}.Release|Any CPU.Build.0 = Release|Any CPU
+		{4C3A1910-79C5-43C0-8599-89921482B38B}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{4C3A1910-79C5-43C0-8599-89921482B38B}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{4C3A1910-79C5-43C0-8599-89921482B38B}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{4C3A1910-79C5-43C0-8599-89921482B38B}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/source/ProtocolGenerator.Tests/CommandTests.cs
+++ b/source/ProtocolGenerator.Tests/CommandTests.cs
@@ -11,31 +11,25 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator.Tests
     public class CommandTests
     {
         [TestMethod]
-        [DeploymentItem(DeploymentItems.Inspector10)]
+        [DeploymentItem(DeploymentItems.Inspector11)]
         [DeploymentItem(DeploymentItems.Protocol)]
         public void EqualsTest()
         {
-            var inspector10 = ProtocolProcessor.LoadProtocol(DeploymentItems.Inspector10, "inspector-1.0");
+            var inspector11 = ProtocolProcessor.LoadProtocol(DeploymentItems.Inspector11, "inspector-1.1");
             var protocol = ProtocolProcessor.LoadProtocol(DeploymentItems.Protocol, "protocol");
 
-            ProtocolProcessor.ResolveTypeReferences(inspector10);
+            ProtocolProcessor.ResolveTypeReferences(inspector11);
             ProtocolProcessor.ResolveTypeReferences(protocol);
 
-            var searchInResource10 = inspector10.GetDomain("Page").GetCommand("searchInResource");
-            var searchInResourceTip = protocol.GetDomain("Page").GetCommand("searchInResource");
+            var stopScreencast10 = inspector11.GetDomain("Page").GetCommand("stopScreencast");
+            var stopScreencastTip = protocol.GetDomain("Page").GetCommand("stopScreencast");
 
             // Quick fact check: both methods have the same string equivalent,
-            // ([] result) searchInResource(string frameId, string url, string query, boolean caseSensitive, boolean isRegex)
-            Assert.AreEqual<string>(searchInResource10.ToString(), searchInResourceTip.ToString());
+            // void stopScreencast()
+            Assert.AreEqual<string>(stopScreencast10.ToString(), stopScreencastTip.ToString());
 
-            // The result is a type, check whether the type has the same properties
-            var result10 = searchInResource10.Returns.Single();
-            var resultTip = searchInResourceTip.Returns.Single();
-
-            Assert.IsTrue(result10.Equals(resultTip));
-
-            Assert.IsTrue(searchInResource10.Equals(searchInResourceTip));
-            Assert.IsTrue(searchInResourceTip.Equals(searchInResource10));
+            Assert.IsTrue(stopScreencast10.Equals(stopScreencastTip));
+            Assert.IsTrue(stopScreencastTip.Equals(stopScreencast10));
         }
     }
 }

--- a/source/ProtocolGenerator.Tests/CommandTests.cs
+++ b/source/ProtocolGenerator.Tests/CommandTests.cs
@@ -1,0 +1,41 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MasterDevs.ChromeDevTools.ProtocolGenerator.Tests
+{
+    [TestClass]
+    public class CommandTests
+    {
+        [TestMethod]
+        [DeploymentItem(DeploymentItems.Inspector10)]
+        [DeploymentItem(DeploymentItems.Protocol)]
+        public void EqualsTest()
+        {
+            var inspector10 = ProtocolProcessor.LoadProtocol(DeploymentItems.Inspector10, "inspector-1.0");
+            var protocol = ProtocolProcessor.LoadProtocol(DeploymentItems.Protocol, "protocol");
+
+            ProtocolProcessor.ResolveTypeReferences(inspector10);
+            ProtocolProcessor.ResolveTypeReferences(protocol);
+
+            var searchInResource10 = inspector10.GetDomain("Page").GetCommand("searchInResource");
+            var searchInResourceTip = protocol.GetDomain("Page").GetCommand("searchInResource");
+
+            // Quick fact check: both methods have the same string equivalent,
+            // ([] result) searchInResource(string frameId, string url, string query, boolean caseSensitive, boolean isRegex)
+            Assert.AreEqual<string>(searchInResource10.ToString(), searchInResourceTip.ToString());
+
+            // The result is a type, check whether the type has the same properties
+            var result10 = searchInResource10.Returns.Single();
+            var resultTip = searchInResourceTip.Returns.Single();
+
+            Assert.IsTrue(result10.Equals(resultTip));
+
+            Assert.IsTrue(searchInResource10.Equals(searchInResourceTip));
+            Assert.IsTrue(searchInResourceTip.Equals(searchInResource10));
+        }
+    }
+}

--- a/source/ProtocolGenerator.Tests/CommandTests.cs
+++ b/source/ProtocolGenerator.Tests/CommandTests.cs
@@ -18,8 +18,8 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator.Tests
             var inspector11 = ProtocolProcessor.LoadProtocol(DeploymentItems.Inspector11, "inspector-1.1");
             var protocol = ProtocolProcessor.LoadProtocol(DeploymentItems.Protocol, "protocol");
 
-            ProtocolProcessor.ResolveTypeReferences(inspector11);
-            ProtocolProcessor.ResolveTypeReferences(protocol);
+            ProtocolProcessor.ResolveTypeReferences(inspector11, new Dictionary<string, string>());
+            ProtocolProcessor.ResolveTypeReferences(protocol, new Dictionary<string, string>());
 
             var stopScreencast10 = inspector11.GetDomain("Page").GetCommand("stopScreencast");
             var stopScreencastTip = protocol.GetDomain("Page").GetCommand("stopScreencast");

--- a/source/ProtocolGenerator.Tests/DeploymentItems.cs
+++ b/source/ProtocolGenerator.Tests/DeploymentItems.cs
@@ -9,6 +9,7 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator.Tests
     class DeploymentItems
     {
         public const string Inspector10 = "Inspector-1.0.json";
+        public const string Inspector11 = "Inspector-1.1.json";
         public const string Protocol = "protocol.json";
     }
 }

--- a/source/ProtocolGenerator.Tests/DeploymentItems.cs
+++ b/source/ProtocolGenerator.Tests/DeploymentItems.cs
@@ -1,0 +1,14 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MasterDevs.ChromeDevTools.ProtocolGenerator.Tests
+{
+    class DeploymentItems
+    {
+        public const string Inspector10 = "Inspector-1.0.json";
+        public const string Protocol = "protocol.json";
+    }
+}

--- a/source/ProtocolGenerator.Tests/DeploymentItems.cs
+++ b/source/ProtocolGenerator.Tests/DeploymentItems.cs
@@ -11,5 +11,6 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator.Tests
         public const string Inspector10 = "Inspector-1.0.json";
         public const string Inspector11 = "Inspector-1.1.json";
         public const string Protocol = "protocol.json";
+        public const string InspectoriOS8 = "Inspector-ios-8.0.json";
     }
 }

--- a/source/ProtocolGenerator.Tests/MasterDevs.ChromeDevTools.ProtocolGenerator.Tests.csproj
+++ b/source/ProtocolGenerator.Tests/MasterDevs.ChromeDevTools.ProtocolGenerator.Tests.csproj
@@ -67,6 +67,9 @@
       <Link>Inspector-1.0.json</Link>
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
+    <None Include="..\ProtocolGenerator\Inspector-iOS-8.0.json">
+      <Link>Inspector-iOS-8.0.json</Link>
+    </None>
     <None Include="..\ProtocolGenerator\protocol.json">
       <Link>protocol.json</Link>
     </None>

--- a/source/ProtocolGenerator.Tests/MasterDevs.ChromeDevTools.ProtocolGenerator.Tests.csproj
+++ b/source/ProtocolGenerator.Tests/MasterDevs.ChromeDevTools.ProtocolGenerator.Tests.csproj
@@ -1,0 +1,100 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectGuid>{4C3A1910-79C5-43C0-8599-89921482B38B}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <AppDesignerFolder>Properties</AppDesignerFolder>
+    <RootNamespace>MasterDevs.ChromeDevTools.ProtocolGenerator.Tests</RootNamespace>
+    <AssemblyName>MasterDevs.ChromeDevTools.ProtocolGenerator.Tests</AssemblyName>
+    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <FileAlignment>512</FileAlignment>
+    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
+    <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
+    <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
+    <IsCodedUITest>False</IsCodedUITest>
+    <TestProjectType>UnitTest</TestProjectType>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug\</OutputPath>
+    <DefineConstants>DEBUG;TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>pdbonly</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release\</OutputPath>
+    <DefineConstants>TRACE</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+  </ItemGroup>
+  <Choose>
+    <When Condition="('$(VisualStudioVersion)' == '10.0' or '$(VisualStudioVersion)' == '') and '$(TargetFrameworkVersion)' == 'v3.5'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework, Version=10.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL" />
+      </ItemGroup>
+    </When>
+    <Otherwise>
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.UnitTestFramework" />
+      </ItemGroup>
+    </Otherwise>
+  </Choose>
+  <ItemGroup>
+    <Compile Include="CommandTests.cs" />
+    <Compile Include="DeploymentItems.cs" />
+    <Compile Include="ProtocolProcessorTests.cs" />
+    <Compile Include="Properties\AssemblyInfo.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\ProtocolGenerator\MasterDevs.ChromeDevTools.ProtocolGenerator.csproj">
+      <Project>{97c7fcf5-1964-4878-b7cd-63448ca403b1}</Project>
+      <Name>MasterDevs.ChromeDevTools.ProtocolGenerator</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="..\ProtocolGenerator\Inspector-1.0.json">
+      <Link>Inspector-1.0.json</Link>
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </None>
+    <None Include="..\ProtocolGenerator\protocol.json">
+      <Link>protocol.json</Link>
+    </None>
+  </ItemGroup>
+  <Choose>
+    <When Condition="'$(VisualStudioVersion)' == '10.0' And '$(IsCodedUITest)' == 'True'">
+      <ItemGroup>
+        <Reference Include="Microsoft.VisualStudio.QualityTools.CodedUITestFramework, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Common, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITest.Extension, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+        <Reference Include="Microsoft.VisualStudio.TestTools.UITesting, Version=10.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+          <Private>False</Private>
+        </Reference>
+      </ItemGroup>
+    </When>
+  </Choose>
+  <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
+  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
+  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
+       Other similar extension points exist, see Microsoft.Common.targets.
+  <Target Name="BeforeBuild">
+  </Target>
+  <Target Name="AfterBuild">
+  </Target>
+  -->
+</Project>

--- a/source/ProtocolGenerator.Tests/MasterDevs.ChromeDevTools.ProtocolGenerator.Tests.csproj
+++ b/source/ProtocolGenerator.Tests/MasterDevs.ChromeDevTools.ProtocolGenerator.Tests.csproj
@@ -54,6 +54,7 @@
     <Compile Include="DeploymentItems.cs" />
     <Compile Include="ProtocolProcessorTests.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="TypeTests.cs" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\ProtocolGenerator\MasterDevs.ChromeDevTools.ProtocolGenerator.csproj">

--- a/source/ProtocolGenerator.Tests/Properties/AssemblyInfo.cs
+++ b/source/ProtocolGenerator.Tests/Properties/AssemblyInfo.cs
@@ -1,0 +1,36 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+using System.Runtime.InteropServices;
+
+// General Information about an assembly is controlled through the following 
+// set of attributes. Change these attribute values to modify the information
+// associated with an assembly.
+[assembly: AssemblyTitle("MasterDevs.ChromeDevTools.ProtocolGenerator.Tests")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("MasterDevs.ChromeDevTools.ProtocolGenerator.Tests")]
+[assembly: AssemblyCopyright("Copyright ©  2016")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// Setting ComVisible to false makes the types in this assembly not visible 
+// to COM components.  If you need to access a type in this assembly from 
+// COM, set the ComVisible attribute to true on that type.
+[assembly: ComVisible(false)]
+
+// The following GUID is for the ID of the typelib if this project is exposed to COM
+[assembly: Guid("4c3a1910-79c5-43c0-8599-89921482b38b")]
+
+// Version information for an assembly consists of the following four values:
+//
+//      Major Version
+//      Minor Version 
+//      Build Number
+//      Revision
+//
+// You can specify all the values or you can default the Build and Revision Numbers 
+// by using the '*' as shown below:
+// [assembly: AssemblyVersion("1.0.*")]
+[assembly: AssemblyVersion("1.0.0.0")]
+[assembly: AssemblyFileVersion("1.0.0.0")]

--- a/source/ProtocolGenerator.Tests/ProtocolProcessorTests.cs
+++ b/source/ProtocolGenerator.Tests/ProtocolProcessorTests.cs
@@ -1,0 +1,26 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace MasterDevs.ChromeDevTools.ProtocolGenerator.Tests
+{
+    [TestClass]
+    public class ProtocolProcessorTests
+    {
+        /// <summary>
+        /// Loads the Chrome-1.0 protocol and makes sure the type <c>Network.FrameId</c> type reference in the
+        /// <c>Runtime.Evaluate</c> command is resolved correctly to the <c>string</c> primitive.
+        /// </summary>
+        [TestMethod]
+        [DeploymentItem(DeploymentItems.Inspector10)]
+        public void ResolveTypeReferencesTest()
+        {
+            Protocol p = ProtocolProcessor.LoadProtocol(DeploymentItems.Inspector10, "Chrome-1.0");
+            ProtocolProcessor.ResolveTypeReferences(p);
+
+            var evaluateCommand = p.GetDomain("Runtime").GetCommand("evaluate");
+            var frameIdParameter = evaluateCommand.GetParameter("frameId");
+
+            Assert.AreEqual("string", frameIdParameter.TypeName);
+        }
+    }
+}

--- a/source/ProtocolGenerator.Tests/ProtocolProcessorTests.cs
+++ b/source/ProtocolGenerator.Tests/ProtocolProcessorTests.cs
@@ -1,5 +1,7 @@
 ﻿using System;
+using System.Linq;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System.Collections.Generic;
 
 namespace MasterDevs.ChromeDevTools.ProtocolGenerator.Tests
 {
@@ -12,15 +14,60 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator.Tests
         /// </summary>
         [TestMethod]
         [DeploymentItem(DeploymentItems.Inspector10)]
-        public void ResolveTypeReferencesTest()
+        public void ResolveTypeReferencesCommandParameterTest()
         {
             Protocol p = ProtocolProcessor.LoadProtocol(DeploymentItems.Inspector10, "Chrome-1.0");
-            ProtocolProcessor.ResolveTypeReferences(p);
+            ProtocolProcessor.ResolveTypeReferences(p, new Dictionary<string, string>());
 
             var evaluateCommand = p.GetDomain("Runtime").GetCommand("evaluate");
             var frameIdParameter = evaluateCommand.GetParameter("frameId");
 
             Assert.AreEqual("string", frameIdParameter.TypeName);
+        }
+
+        [TestMethod]
+        [DeploymentItem(DeploymentItems.Inspector10)]
+        public void ResolveTypeReferencesCommandParameterTest2()
+        {
+            Protocol p = ProtocolProcessor.LoadProtocol(DeploymentItems.Inspector10, "Chrome-1.0");
+            ProtocolProcessor.ResolveTypeReferences(p, new Dictionary<string, string>());
+
+            var addInspectedNodeCommand = p.GetDomain("Console").GetCommand("addInspectedNode");
+            var nodeId = addInspectedNodeCommand.GetParameter("nodeId");
+
+            Assert.AreEqual("integer", nodeId.TypeName);
+        }
+
+        [TestMethod]
+        [DeploymentItem(DeploymentItems.InspectoriOS8)]
+        public void ResolveTypeReferencesCommandReturnValueTest()
+        {
+            Dictionary<string, string> explicitMappings = new Dictionary<string, string>();
+            explicitMappings.Add("Page.Cookie", "Network.Cookie");
+
+            Protocol p = ProtocolProcessor.LoadProtocol(DeploymentItems.InspectoriOS8, "iOS-8.0");
+            ProtocolProcessor.ResolveTypeReferences(p, explicitMappings);
+
+            var getCookiesCommand = p.GetDomain("Page").GetCommand("getCookies");
+            var cookieArray = getCookiesCommand.Returns.Single();
+
+            Assert.AreEqual("Network.Cookie[]", cookieArray.TypeName);
+        }
+
+        [TestMethod]
+        [DeploymentItem(DeploymentItems.InspectoriOS8)]
+        public void ResolveTypeReferencesCommandReturnValueTest2()
+        {
+            Dictionary<string, string> explicitMappings = new Dictionary<string, string>();
+            explicitMappings.Add("GenericTypes.SearchMatch", "Debugger.SearchMatch");
+
+            Protocol p = ProtocolProcessor.LoadProtocol(DeploymentItems.InspectoriOS8, "iOS-8.0");
+            ProtocolProcessor.ResolveTypeReferences(p, explicitMappings);
+
+            var searchInResourceCommand = p.GetDomain("Page").GetCommand("searchInResource");
+            var searchMatchArray = searchInResourceCommand.Returns.Single();
+
+            Assert.AreEqual("Debugger.SearchMatch[]", searchMatchArray.TypeName);
         }
     }
 }

--- a/source/ProtocolGenerator.Tests/TypeTests.cs
+++ b/source/ProtocolGenerator.Tests/TypeTests.cs
@@ -1,0 +1,39 @@
+﻿using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MasterDevs.ChromeDevTools.ProtocolGenerator.Tests
+{
+    [TestClass]
+    public class TypeTests
+    {
+
+        [TestMethod]
+        [DeploymentItem(DeploymentItems.Inspector10)]
+        public void TypeNameTest()
+        {
+            Protocol p = ProtocolProcessor.LoadProtocol(DeploymentItems.Inspector10, "Chrome-1.0");
+
+            var evaluateCommand = p.GetDomain("Page").GetCommand("searchInResource");
+            var result = evaluateCommand.Returns.Single();
+
+            Assert.AreEqual("SearchMatch[]", result.TypeName.ToString());
+        }
+
+        [TestMethod]
+        [DeploymentItem(DeploymentItems.Inspector10)]
+        public void ToStringTest()
+        {
+            Protocol p = ProtocolProcessor.LoadProtocol(DeploymentItems.Inspector10, "Chrome-1.0");
+
+            var evaluateCommand = p.GetDomain("Page").GetCommand("searchInResource");
+            var result = evaluateCommand.Returns.Single();
+            var items = result.Items;
+
+            Assert.AreEqual("SearchMatch", items.ToString());
+        }
+    }
+}

--- a/source/ProtocolGenerator/CollectionExtensions.cs
+++ b/source/ProtocolGenerator/CollectionExtensions.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MasterDevs.ChromeDevTools.ProtocolGenerator
+{
+    static class CollectionExtensions
+    {
+        public static bool CollectionEqual<T>(this ICollection<T> x, ICollection<T> y)
+        {
+            if (x == null || y == null)
+            {
+                return false;
+            }
+
+            if(x.Count != y.Count)
+            {
+                return false;
+            }
+
+            return x.All(e => y.Contains(e));
+        }
+
+        public static int GetCollectionHashCode<T>(this ICollection<T> x)
+        {
+            int hash = 17;
+
+            unchecked
+            {
+                foreach (var e in x)
+                {
+                    hash = hash * 23 + e.GetHashCode();
+                }
+            }
+
+            return hash;
+        }
+    }
+}

--- a/source/ProtocolGenerator/Command.cs
+++ b/source/ProtocolGenerator/Command.cs
@@ -2,10 +2,11 @@
 using System.Collections.ObjectModel;
 using System.Text;
 using System.Linq;
+using System;
 
 namespace MasterDevs.ChromeDevTools.ProtocolGenerator
 {
-    class Command : ProtocolItem
+    public class Command : ProtocolItem
     {
         public Command()
         {
@@ -141,6 +142,11 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
             name.Append(")");
 
             return name.ToString();
+        }
+
+        public Property GetParameter(string name)
+        {
+            return this.Parameters.SingleOrDefault(p => string.Equals(p.Name, name, StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/source/ProtocolGenerator/Command.cs
+++ b/source/ProtocolGenerator/Command.cs
@@ -1,4 +1,7 @@
-﻿using System.Collections.ObjectModel;
+﻿using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Text;
+using System.Linq;
 
 namespace MasterDevs.ChromeDevTools.ProtocolGenerator
 {
@@ -45,6 +48,99 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
         {
             get;
             set;
+        }
+
+        public override bool Equals(object obj)
+        {
+            var other = obj as Command;
+
+            if (other == null)
+            {
+                return false;
+            }
+
+            bool equals = base.Equals(obj);
+            equals &= this.Returns.SequenceEqual(other.Returns);
+            equals &= Property.Equals(this.Error, other.Error);
+            equals &= this.Handlers.CollectionEqual(other.Handlers);
+            equals &= this.Parameters.SequenceEqual(other.Parameters);
+            return equals;
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = base.GetHashCode();
+                hash = hash * 23 + this.Redirect.GetHashCode();
+
+                if (this.Error != null)
+                {
+                    hash = hash * 23 + this.Error.GetHashCode();
+                }
+
+                hash = hash * 23 + this.Handlers.GetCollectionHashCode();
+                hash = hash * 23 + this.Parameters.GetCollectionHashCode();
+                return hash;
+            }
+        }
+
+        public override string ToString()
+        {
+            StringBuilder name = new StringBuilder();
+
+            if (this.Returns.Count > 0)
+            {
+                name.Append("(");
+                bool isFirst = true;
+
+                foreach (var p in this.Returns)
+                {
+                    if (isFirst)
+                    {
+                        isFirst = false;
+                    }
+                    else
+                    {
+                        name.Append(", ");
+                    }
+
+                    name.Append(p.TypeName);
+                    name.Append(" ");
+                    name.Append(p.Name);
+                }
+
+                name.Append(") ");
+            }
+            else
+            {
+                name.Append("void ");
+            }
+
+            name.Append(this.Name);
+
+            name.Append("(");
+
+            bool isFirstParam = true;
+            foreach (var p in this.Parameters)
+            {
+                if (isFirstParam)
+                {
+                    isFirstParam = false;
+                }
+                else
+                {
+                    name.Append(", ");
+                }
+
+                name.Append(p.TypeName);
+                name.Append(" ");
+                name.Append(p.Name);
+            }
+
+            name.Append(")");
+
+            return name.ToString();
         }
     }
 }

--- a/source/ProtocolGenerator/Command.cs
+++ b/source/ProtocolGenerator/Command.cs
@@ -27,6 +27,9 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
             set;
         }
 
+        /// <remarks>
+        /// This property is currently ignored.
+        /// </remarks>
         public Collection<string> Handlers
         {
             get;
@@ -63,7 +66,6 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
             bool equals = base.Equals(obj);
             equals &= this.Returns.SequenceEqual(other.Returns);
             equals &= Property.Equals(this.Error, other.Error);
-            equals &= this.Handlers.CollectionEqual(other.Handlers);
             equals &= this.Parameters.SequenceEqual(other.Parameters);
             return equals;
         }
@@ -79,8 +81,7 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
                 {
                     hash = hash * 23 + this.Error.GetHashCode();
                 }
-
-                hash = hash * 23 + this.Handlers.GetCollectionHashCode();
+                
                 hash = hash * 23 + this.Parameters.GetCollectionHashCode();
                 return hash;
             }

--- a/source/ProtocolGenerator/Domain.cs
+++ b/source/ProtocolGenerator/Domain.cs
@@ -1,9 +1,11 @@
 ﻿using Newtonsoft.Json;
+using System;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace MasterDevs.ChromeDevTools.ProtocolGenerator
 {
-    class Domain : ProtocolItem
+    public class Domain : ProtocolItem
     {
         public Domain()
         {
@@ -47,6 +49,16 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
         {
             get;
             set;
+        }
+
+        public Command GetCommand(string name)
+        {
+            return this.Commands.SingleOrDefault(c => string.Equals(c.Name, name, StringComparison.OrdinalIgnoreCase));
+        }
+
+        public Type GetType(string name)
+        {
+            return this.Types.SingleOrDefault(t => string.Equals(t.Name, name, StringComparison.OrdinalIgnoreCase));
         }
     }
 }

--- a/source/ProtocolGenerator/Event.cs
+++ b/source/ProtocolGenerator/Event.cs
@@ -2,7 +2,7 @@
 
 namespace MasterDevs.ChromeDevTools.ProtocolGenerator
 {
-    class Event : ProtocolItem
+    public class Event : ProtocolItem
     {
         public Event()
         {

--- a/source/ProtocolGenerator/MasterDevs.ChromeDevTools.ProtocolGenerator.csproj
+++ b/source/ProtocolGenerator/MasterDevs.ChromeDevTools.ProtocolGenerator.csproj
@@ -61,6 +61,7 @@
     <Compile Include="Protocol.cs" />
     <Compile Include="ProtocolItem.cs" />
     <Compile Include="ProtocolMerger.cs" />
+    <Compile Include="ProtocolProcessor.cs" />
     <Compile Include="Type.cs" />
     <Compile Include="Version.cs" />
   </ItemGroup>

--- a/source/ProtocolGenerator/MasterDevs.ChromeDevTools.ProtocolGenerator.csproj
+++ b/source/ProtocolGenerator/MasterDevs.ChromeDevTools.ProtocolGenerator.csproj
@@ -50,14 +50,17 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="CollectionExtensions.cs" />
     <Compile Include="Command.cs" />
     <Compile Include="Domain.cs" />
     <Compile Include="Event.cs" />
+    <Compile Include="NameEqualityComparer.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Property.cs" />
     <Compile Include="Protocol.cs" />
     <Compile Include="ProtocolItem.cs" />
+    <Compile Include="ProtocolMerger.cs" />
     <Compile Include="Type.cs" />
     <Compile Include="Version.cs" />
   </ItemGroup>

--- a/source/ProtocolGenerator/NameEqualityComparer.cs
+++ b/source/ProtocolGenerator/NameEqualityComparer.cs
@@ -1,0 +1,34 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MasterDevs.ChromeDevTools.ProtocolGenerator
+{
+    class NameEqualityComparer : EqualityComparer<ProtocolItem>
+    {
+        public static NameEqualityComparer Instance
+        { get; } = new NameEqualityComparer();
+
+        public override bool Equals(ProtocolItem x, ProtocolItem y)
+        {
+            if (x == null || y == null)
+            {
+                return false;
+            }
+
+            return string.Equals(x.Name, y.Name, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override int GetHashCode(ProtocolItem obj)
+        {
+            if (obj == null)
+            {
+                throw new ArgumentNullException(nameof(obj));
+            }
+
+            return StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Name);
+        }
+    }
+}

--- a/source/ProtocolGenerator/NameEqualityComparer.cs
+++ b/source/ProtocolGenerator/NameEqualityComparer.cs
@@ -6,12 +6,13 @@ using System.Threading.Tasks;
 
 namespace MasterDevs.ChromeDevTools.ProtocolGenerator
 {
-    class NameEqualityComparer : EqualityComparer<ProtocolItem>
+    class NameEqualityComparer<T> : EqualityComparer<T>
+        where T : ProtocolItem
     {
-        public static NameEqualityComparer Instance
-        { get; } = new NameEqualityComparer();
+        public static NameEqualityComparer<T> Instance
+        { get; } = new NameEqualityComparer<T>();
 
-        public override bool Equals(ProtocolItem x, ProtocolItem y)
+        public override bool Equals(T x, T y)
         {
             if (x == null || y == null)
             {
@@ -21,7 +22,7 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
             return string.Equals(x.Name, y.Name, StringComparison.OrdinalIgnoreCase);
         }
 
-        public override int GetHashCode(ProtocolItem obj)
+        public override int GetHashCode(T obj)
         {
             if (obj == null)
             {

--- a/source/ProtocolGenerator/Program.cs
+++ b/source/ProtocolGenerator/Program.cs
@@ -27,22 +27,33 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
 
         private static void Main(string[] args)
         {
+            // At this point in time, we only process the most recent Chrome
+            // and iOS (Safari) protocols.
             Dictionary<string, string> protocolFiles = new Dictionary<string, string>();
-            protocolFiles.Add("Chrome-0.1", "Inspector-0.1.json");
-            protocolFiles.Add("Chrome-1.0", "Inspector-1.0.json");
-            protocolFiles.Add("Chrome-1.1", "Inspector-1.1.json");
+            //protocolFiles.Add("Chrome-0.1", "Inspector-0.1.json");
+            //protocolFiles.Add("Chrome-1.0", "Inspector-1.0.json");
+            //protocolFiles.Add("Chrome-1.1", "Inspector-1.1.json");
             protocolFiles.Add("Chrome-Tip", "protocol.json");
-            protocolFiles.Add("iOS-7.0", "Inspector-iOS-7.0.json");
-            protocolFiles.Add("iOS-8.0", "Inspector-iOS-8.0.json");
-            protocolFiles.Add("iOS-9.0", "Inspector-iOS-9.0.json");
+            //protocolFiles.Add("iOS-7.0", "Inspector-iOS-7.0.json");
+            //protocolFiles.Add("iOS-8.0", "Inspector-iOS-8.0.json");
+            //protocolFiles.Add("iOS-9.0", "Inspector-iOS-9.0.json");
             protocolFiles.Add("iOS-9.3", "Inspector-iOS-9.3.json");
 
             Collection<Protocol> protocols = new Collection<Protocol>();
-            
-            foreach(var protocolFile in protocolFiles)
+
+            // "Explicit mappings" allow us to map one type reference to another. This is a
+            // rather hard-coded way of doing things, and is only used when the same type
+            // has different names accross different versions of the dev tools - e.g. the RGBA
+            // type which is named RGBAColor for Safari.
+            Dictionary<string, string> explicitMappings = new Dictionary<string, string>();
+            explicitMappings.Add("DOM.RGBAColor", "RGBA");
+            explicitMappings.Add("Page.Cookie", "Network.Cookie");
+            explicitMappings.Add("GenericTypes.SearchMatch", "Debugger.SearchMatch");
+
+            foreach (var protocolFile in protocolFiles)
             {
                 Protocol p = ProtocolProcessor.LoadProtocol(protocolFile.Value, protocolFile.Key);
-                ProtocolProcessor.ResolveTypeReferences(p);
+                ProtocolProcessor.ResolveTypeReferences(p, explicitMappings);
                 protocols.Add(p);
             }
 

--- a/source/ProtocolGenerator/Property.cs
+++ b/source/ProtocolGenerator/Property.cs
@@ -2,7 +2,7 @@
 
 namespace MasterDevs.ChromeDevTools.ProtocolGenerator
 {
-    class Property : Type
+    public class Property : Type
     {
         [JsonProperty("name")]
         public override string Name

--- a/source/ProtocolGenerator/Protocol.cs
+++ b/source/ProtocolGenerator/Protocol.cs
@@ -1,8 +1,9 @@
 ﻿using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace MasterDevs.ChromeDevTools.ProtocolGenerator
 {
-    class Protocol
+    public class Protocol
     {
         public Protocol()
         {
@@ -38,6 +39,23 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
         {
             get;
             set;
+        }
+
+        public Domain GetDomain(string name)
+        {
+            return this.Domains.SingleOrDefault(d => string.Equals(d.Name, name, System.StringComparison.OrdinalIgnoreCase));
+        }
+
+        public override string ToString()
+        {
+            if(this.SourceFile != null)
+            {
+                return $"{this.Alias} ({this.SourceFile})";
+            }
+            else
+            {
+                return this.Alias;
+            }
         }
     }
 }

--- a/source/ProtocolGenerator/Protocol.cs
+++ b/source/ProtocolGenerator/Protocol.cs
@@ -4,6 +4,12 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
 {
     class Protocol
     {
+        public Protocol()
+        {
+            this.Compatible = new Collection<string>();
+            this.Domains = new Collection<Domain>();
+        }
+
         public Collection<string> Compatible
         {
             get;
@@ -17,6 +23,18 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
         }
 
         public Collection<Domain> Domains
+        {
+            get;
+            set;
+        }
+
+        public string SourceFile
+        {
+            get;
+            set;
+        }
+
+        public string Alias
         {
             get;
             set;

--- a/source/ProtocolGenerator/ProtocolItem.cs
+++ b/source/ProtocolGenerator/ProtocolItem.cs
@@ -4,7 +4,7 @@ using System.Collections.ObjectModel;
 
 namespace MasterDevs.ChromeDevTools.ProtocolGenerator
 {
-    abstract class ProtocolItem
+    public abstract class ProtocolItem
     {
         public ProtocolItem()
         {

--- a/source/ProtocolGenerator/ProtocolItem.cs
+++ b/source/ProtocolGenerator/ProtocolItem.cs
@@ -1,7 +1,16 @@
-﻿namespace MasterDevs.ChromeDevTools.ProtocolGenerator
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+
+namespace MasterDevs.ChromeDevTools.ProtocolGenerator
 {
     abstract class ProtocolItem
     {
+        public ProtocolItem()
+        {
+            this.SupportedBy = new Collection<string>();
+        }
+
         public virtual string Description
         {
             get;
@@ -20,9 +29,64 @@
             set;
         }
 
+        public Collection<string> SupportedBy
+        {
+            get;
+        }
+
         public override string ToString()
         {
             return this.Name;
+        }
+
+        public static bool Equals(ProtocolItem a, ProtocolItem b)
+        {
+            if (a == null && b == null)
+            {
+                return true;
+            }
+
+            if (a == null || b == null)
+            {
+                return false;
+            }
+
+            if (a.GetType() != b.GetType())
+            {
+                return false;
+            }
+
+            return a.Equals(b);
+        }
+
+        public override bool Equals(object obj)
+        {
+            // In the Equals method, we only include properties which would impact how 
+            // messages are serialized over the wire. E.g.: because the description does not
+            // impact this, but the name does, the description is ignored but the name is included.
+            var other = obj as ProtocolItem;
+
+            if (other == null)
+            {
+                return false;
+            }
+
+            return string.Equals(other.Name, this.Name, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = 17;
+
+                if (this.Name != null)
+                {
+                    hash = hash * 23 + StringComparer.OrdinalIgnoreCase.GetHashCode(this.Name);
+                }
+
+                return hash;
+            }
         }
     }
 }

--- a/source/ProtocolGenerator/ProtocolMerger.cs
+++ b/source/ProtocolGenerator/ProtocolMerger.cs
@@ -1,0 +1,75 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MasterDevs.ChromeDevTools.ProtocolGenerator
+{
+    class ProtocolMerger
+    {
+        public static void Merge(Protocol source, Protocol target)
+        {
+            foreach (var domain in source.Domains)
+            {
+                if (!target.Domains.Contains(domain, NameEqualityComparer.Instance))
+                {
+                    target.Domains.Add(domain);
+                }
+                else
+                {
+                    Merge(domain, target.Domains.Single(t => NameEqualityComparer.Instance.Equals(domain, t)));
+                }
+            }
+        }
+
+        static void Merge(Domain source, Domain target)
+        {
+            foreach (var command in source.Commands)
+            {
+                if (!target.Commands.Contains(command, NameEqualityComparer.Instance))
+                {
+                    target.Commands.Add(command);
+                }
+                else
+                {
+                    var targetCommand = target.Commands.Single(t => NameEqualityComparer.Instance.Equals(command, t));
+
+                    if(!targetCommand.Equals(command))
+                    {
+                        Console.WriteLine($"{source.Name}:{command},{targetCommand}");
+                    }
+                    else
+                    {
+                        foreach (var v in command.SupportedBy)
+                        {
+                            targetCommand.SupportedBy.Add(v);
+                        }
+                    }
+                }
+            }
+
+            foreach (var @event in source.Events)
+            {
+                if (!target.Events.Contains(@event, NameEqualityComparer.Instance))
+                {
+                    target.Events.Add(@event);
+                }
+                else
+                {
+                }
+            }
+
+            foreach (var type in source.Types)
+            {
+                if (!target.Types.Contains(type, NameEqualityComparer.Instance))
+                {
+                    target.Types.Add(type);
+                }
+                else
+                {
+                }
+            }
+        }
+    }
+}

--- a/source/ProtocolGenerator/ProtocolMerger.cs
+++ b/source/ProtocolGenerator/ProtocolMerger.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Collections.ObjectModel;
 using System.Linq;
 using System.Text;
 using System.Threading.Tasks;
@@ -12,62 +13,48 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
         {
             foreach (var domain in source.Domains)
             {
-                if (!target.Domains.Contains(domain, NameEqualityComparer.Instance))
+                if (!target.Domains.Contains(domain, NameEqualityComparer<Domain>.Instance))
                 {
                     target.Domains.Add(domain);
                 }
                 else
                 {
-                    Merge(source, domain, target.Domains.Single(t => NameEqualityComparer.Instance.Equals(domain, t)));
+                    Merge(source, domain, target.Domains.Single(t => NameEqualityComparer<Domain>.Instance.Equals(domain, t)));
                 }
             }
         }
 
         static void Merge(Protocol protocol, Domain source, Domain target)
         {
-            foreach (var command in source.Commands)
+            Merge(protocol, source, source.Commands, target.Commands);
+            Merge(protocol, source, source.Events, target.Events);
+            Merge(protocol, source, source.Types, target.Types);
+        }
+
+        static void Merge<T>(Protocol protocol, Domain domain, Collection<T> source, Collection<T> target)
+            where T : ProtocolItem
+        {
+            foreach (var item in source)
             {
-                if (!target.Commands.Contains(command, NameEqualityComparer.Instance))
+                if (!target.Contains(item, NameEqualityComparer<T>.Instance))
                 {
-                    target.Commands.Add(command);
+                    target.Add(item);
                 }
                 else
                 {
-                    var targetCommand = target.Commands.Single(t => NameEqualityComparer.Instance.Equals(command, t));
+                    var targetItem = target.Single(t => NameEqualityComparer<T>.Instance.Equals(item, t));
 
-                    if(!targetCommand.Equals(command))
+                    if (!targetItem.Equals(item))
                     {
-                        Console.WriteLine($"{protocol.Alias};{source.Name};{command.Name};{command};{targetCommand}");
+                        Console.WriteLine($"{protocol.Alias};{domain.Name};{item.Name};{item};{targetItem};{typeof(T).Name}");
                     }
                     else
                     {
-                        foreach (var v in command.SupportedBy)
+                        foreach (var v in item.SupportedBy)
                         {
-                            targetCommand.SupportedBy.Add(v);
+                            targetItem.SupportedBy.Add(v);
                         }
                     }
-                }
-            }
-
-            foreach (var @event in source.Events)
-            {
-                if (!target.Events.Contains(@event, NameEqualityComparer.Instance))
-                {
-                    target.Events.Add(@event);
-                }
-                else
-                {
-                }
-            }
-
-            foreach (var type in source.Types)
-            {
-                if (!target.Types.Contains(type, NameEqualityComparer.Instance))
-                {
-                    target.Types.Add(type);
-                }
-                else
-                {
                 }
             }
         }

--- a/source/ProtocolGenerator/ProtocolMerger.cs
+++ b/source/ProtocolGenerator/ProtocolMerger.cs
@@ -18,12 +18,12 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
                 }
                 else
                 {
-                    Merge(domain, target.Domains.Single(t => NameEqualityComparer.Instance.Equals(domain, t)));
+                    Merge(source, domain, target.Domains.Single(t => NameEqualityComparer.Instance.Equals(domain, t)));
                 }
             }
         }
 
-        static void Merge(Domain source, Domain target)
+        static void Merge(Protocol protocol, Domain source, Domain target)
         {
             foreach (var command in source.Commands)
             {
@@ -37,7 +37,7 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
 
                     if(!targetCommand.Equals(command))
                     {
-                        Console.WriteLine($"{source.Name}:{command},{targetCommand}");
+                        Console.WriteLine($"{protocol.Alias};{source.Name};{command.Name};{command};{targetCommand}");
                     }
                     else
                     {

--- a/source/ProtocolGenerator/ProtocolProcessor.cs
+++ b/source/ProtocolGenerator/ProtocolProcessor.cs
@@ -1,0 +1,107 @@
+﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace MasterDevs.ChromeDevTools.ProtocolGenerator
+{
+    public class ProtocolProcessor
+    {
+        public static void ResolveTypeReferences(Protocol protocol)
+        {
+            foreach (var domain in protocol.Domains)
+            {
+                ResolveTypeReferences(protocol, domain);
+            }
+        }
+
+        public static void ResolveTypeReferences(Protocol protocol, Domain domain)
+        {
+            foreach (var command in domain.Commands)
+            {
+                ResolveTypeReferences(protocol, domain, command);
+            }
+        }
+
+        public static void ResolveTypeReferences(Protocol protocol, Domain domain, Command command)
+        {
+            foreach (var parameter in command.Parameters)
+            {
+                ResolveTypeReferences(protocol, domain, parameter);
+            }
+
+            foreach (var returnValue in command.Returns)
+            {
+                ResolveTypeReferences(protocol, domain, returnValue);
+            }
+        }
+
+        public static void ResolveTypeReferences(Protocol protocol, Domain domain, Property property)
+        {
+            if (property.TypeReference != null)
+            {
+                // Find the type which is being referenced
+                var referenceParts = property.TypeReference.Split(new char[] { '.' }, StringSplitOptions.RemoveEmptyEntries);
+
+                Domain referencedDomain = null;
+                Type referencedType = null;
+
+                if (referenceParts.Length == 1)
+                {
+                    referencedDomain = domain;
+                    referencedType = domain.GetType(referenceParts[0]);
+                }
+                else if (referenceParts.Length == 2)
+                {
+                    referencedDomain = protocol.GetDomain(referenceParts[0]);
+                    referencedType = referencedDomain.GetType(referenceParts[1]);
+                }
+                else
+                {
+                    throw new ArgumentOutOfRangeException();
+                }
+
+                // If it is a string, it can be resolved easily
+                if(referencedType.IsString())
+                {
+                    property.Kind = "string";
+                    property.TypeReference = null;
+                }
+            }
+        }
+
+        public static Protocol LoadProtocol(string path, string alias)
+        {
+            string json = File.ReadAllText(path);
+            JsonSerializerSettings settings = new JsonSerializerSettings();
+            settings.MissingMemberHandling = MissingMemberHandling.Error;
+            settings.MetadataPropertyHandling = MetadataPropertyHandling.Ignore;
+            Protocol p = JsonConvert.DeserializeObject<Protocol>(json, settings);
+            p.SourceFile = path;
+            p.Alias = alias;
+
+            foreach (var domain in p.Domains)
+            {
+                foreach (var command in domain.Commands)
+                {
+                    command.SupportedBy.Add(alias);
+                }
+
+                foreach (var @event in domain.Events)
+                {
+                    @event.SupportedBy.Add(alias);
+                }
+
+                foreach (var type in domain.Types)
+                {
+                    type.SupportedBy.Add(alias);
+                }
+            }
+
+            return p;
+        }
+    }
+}

--- a/source/ProtocolGenerator/Type.cs
+++ b/source/ProtocolGenerator/Type.cs
@@ -75,7 +75,7 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
                 }
                 else if (this.Items != null)
                 {
-                    return this.Items.Name + "[]";
+                    return this.Items.TypeName + "[]";
                 }
                 else if (this.Kind != null && this.Kind != "object")
                 {
@@ -157,6 +157,11 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
         public bool IsObject()
         {
             return string.Equals(this.Kind, "object", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override string ToString()
+        {
+            return this.TypeName;
         }
     }
 }

--- a/source/ProtocolGenerator/Type.cs
+++ b/source/ProtocolGenerator/Type.cs
@@ -2,10 +2,11 @@
 using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
+using System.Linq;
 
 namespace MasterDevs.ChromeDevTools.ProtocolGenerator
 {
-    class Type : ProtocolItem
+    public class Type : ProtocolItem
     {
         public Type()
         {
@@ -76,7 +77,7 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
                 {
                     return this.Items.Name + "[]";
                 }
-                else if(this.Kind != null && this.Kind != "object")
+                else if (this.Kind != null && this.Kind != "object")
                 {
                     return this.Kind;
                 }
@@ -95,14 +96,16 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
                 return false;
             }
 
-            return base.Equals(obj)
-                && string.Equals(this.Kind, other.Kind, StringComparison.OrdinalIgnoreCase)
-                && this.Enum.SetEquals(other.Enum)
-                && this.Properties.SetEquals(other.Properties)
-                && Type.Equals(this.Items, other.Items)
-                && this.MinItems == other.MinItems
-                && this.MaxItems == other.MaxItems
-                && string.Equals(this.TypeReference, other.TypeReference, StringComparison.OrdinalIgnoreCase);
+            bool equals = base.Equals(obj);
+            equals &= string.Equals(this.Kind, other.Kind, StringComparison.OrdinalIgnoreCase);
+            equals &= this.Enum.SetEquals(other.Enum);
+            equals &= this.Properties.SetEquals(other.Properties);
+            equals &= Type.Equals(this.Items, other.Items);
+            equals &= this.MinItems == other.MinItems;
+            equals &= this.MaxItems == other.MaxItems;
+            equals &= string.Equals(this.TypeReference, other.TypeReference, StringComparison.OrdinalIgnoreCase);
+
+            return equals;
         }
 
         public override int GetHashCode()
@@ -134,6 +137,26 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
 
                 return hash;
             }
+        }
+
+        public bool IsString()
+        {
+            return string.Equals(this.Kind, "string", StringComparison.OrdinalIgnoreCase);
+        }
+
+        public bool IsEnum()
+        {
+            return this.Enum.Any();
+        }
+
+        public bool IsClass()
+        {
+            return this.Properties.Any();
+        }
+
+        public bool IsObject()
+        {
+            return string.Equals(this.Kind, "object", StringComparison.OrdinalIgnoreCase);
         }
     }
 }

--- a/source/ProtocolGenerator/Type.cs
+++ b/source/ProtocolGenerator/Type.cs
@@ -144,6 +144,11 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
             return string.Equals(this.Kind, "string", StringComparison.OrdinalIgnoreCase);
         }
 
+        public bool IsInteger()
+        {
+            return string.Equals(this.Kind, "integer", StringComparison.OrdinalIgnoreCase);
+        }
+
         public bool IsEnum()
         {
             return this.Enum.Any();

--- a/source/ProtocolGenerator/Type.cs
+++ b/source/ProtocolGenerator/Type.cs
@@ -1,4 +1,6 @@
 ﻿using Newtonsoft.Json;
+using System;
+using System.Collections.Generic;
 using System.Collections.ObjectModel;
 
 namespace MasterDevs.ChromeDevTools.ProtocolGenerator
@@ -7,8 +9,8 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
     {
         public Type()
         {
-            this.Enum = new Collection<string>();
-            this.Properties = new Collection<Property>();
+            this.Enum = new HashSet<string>();
+            this.Properties = new HashSet<Property>();
         }
 
         [JsonProperty(PropertyName = "Id")]
@@ -18,20 +20,20 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
             set;
         }
 
-        [JsonProperty(PropertyName ="type")]
+        [JsonProperty(PropertyName = "type")]
         public string Kind
         {
             get;
             set;
         }
 
-        public Collection<string> Enum
+        public HashSet<string> Enum
         {
             get;
             set;
         }
 
-        public Collection<Property> Properties
+        public HashSet<Property> Properties
         {
             get;
             set;
@@ -60,6 +62,78 @@ namespace MasterDevs.ChromeDevTools.ProtocolGenerator
         {
             get;
             set;
+        }
+
+        public string TypeName
+        {
+            get
+            {
+                if (this.TypeReference != null)
+                {
+                    return this.TypeReference;
+                }
+                else if (this.Items != null)
+                {
+                    return this.Items.Name + "[]";
+                }
+                else if(this.Kind != null && this.Kind != "object")
+                {
+                    return this.Kind;
+                }
+                else
+                {
+                    return this.Name;
+                }
+            }
+        }
+        public override bool Equals(object obj)
+        {
+            var other = obj as Type;
+
+            if (other == null)
+            {
+                return false;
+            }
+
+            return base.Equals(obj)
+                && string.Equals(this.Kind, other.Kind, StringComparison.OrdinalIgnoreCase)
+                && this.Enum.SetEquals(other.Enum)
+                && this.Properties.SetEquals(other.Properties)
+                && Type.Equals(this.Items, other.Items)
+                && this.MinItems == other.MinItems
+                && this.MaxItems == other.MaxItems
+                && string.Equals(this.TypeReference, other.TypeReference, StringComparison.OrdinalIgnoreCase);
+        }
+
+        public override int GetHashCode()
+        {
+            unchecked
+            {
+                int hash = base.GetHashCode();
+
+                if (this.Kind != null)
+                {
+                    hash = hash * 23 + StringComparer.OrdinalIgnoreCase.GetHashCode(this.Kind);
+                }
+
+                hash = hash * 23 + this.Enum.GetCollectionHashCode();
+                hash = hash * 23 + this.Properties.GetCollectionHashCode();
+
+                if (this.Items != null)
+                {
+                    hash = hash * 23 + this.Items.GetHashCode();
+                }
+
+                hash = hash * 23 + this.MinItems.GetHashCode();
+                hash = hash * 23 + this.MaxItems.GetHashCode();
+
+                if (this.TypeReference != null)
+                {
+                    hash = hash * 23 + StringComparer.OrdinalIgnoreCase.GetHashCode(this.TypeReference);
+                }
+
+                return hash;
+            }
         }
     }
 }

--- a/source/ProtocolGenerator/Version.cs
+++ b/source/ProtocolGenerator/Version.cs
@@ -1,6 +1,6 @@
 ﻿namespace MasterDevs.ChromeDevTools.ProtocolGenerator
 {
-    class Version
+    public class Version
     {
         public string Major
         {


### PR DESCRIPTION
Hi Kevin,

Thanks for accepting my earlier pull request!

So, I went ahead and tried to implement code which can support the generation of the debugger protocol for multiple protocol versions, with special interest on my side to be able to support both the latest version of Chrome and Safari on iOS.

This PR is a first attempt to do so. It takes the various `protocol.json` files, and tries to merge all these files together.

It works rather nicely, but there are some edge cases which need to be taken care of and for which I'd like to consult with you. Overall, there are about 805 classes being generated in the current version of ChromeDevTools. With the 'multi protocol version'-support, I've encountered issues for 74 of them.

Basically they break down into these categories. 
* __Commands to which parameters have been added__. Take, for example, `void continueToLocation(Location location, boolean interstatementLocation)` vs. `void continueToLocation(Location location)` (in the debugger namespace). I could think of these ways to handle them:
 * Add the new `interstatementLocation` parameter as a property to the `ContinueToLocation` command. But how do you let the user know that this parameter is available on one version of the debugger tools and not the other?
  * Create two commands, and suffix them with (say) the number of parameters - `ContinueToLocation1` and `ContinueToLocation2`.But how would a user know which one is the correct one?
* __Commands where the same parameter conflicts__. Take, for example, `void connectToWorker(string workerId)` vs `void connectToWorker(integer workerId)`.
* __Methods a diverging set of parameters__. For example, `(...) getMatchedStylesForNode(integer nodeId, boolean excludePseudo, boolean excludeInherited)` vs `getMatchedStylesForNode(integer nodeId, boolean includePseudo, boolean includeInherited)` -- the boolean parameters have the opposite meaning
* __Commands with different return types__, usually from `void` to a specific return type
* __Types with additional properties__, e.g. the `TimelineEvent` type has gained the `startTime` and `endTime` properties in the latest version of the Chrome debugger tools.

I can think of a couple of approaches:

1. One version wins (e.g. the latest Chrome version). If another version adds a new command or type which does not conflict, it gets added. If a conflicting change is detected, that command or type is simply not available.
2. Multiple classes for the different versions where conflicts occur. The classes get tagged with an attribute (+ perhaps a `<remarks>` section) which indicate which version they apply to. Types can inherit from other versions of the type if properties have been added; or the properties get tagged with an attribute as well. Possibly runtime validation?
3. One namespace per version of the protocol. That means a lot of duplicated classes, which are not compatible - meaning you cannot simply share your code between, say, v1.0 and v1.1 of the Chrome protocol.

The code which I have so far is attached in this pull request. If you run the ProtocolGenerator, it will output the commands/types/events for which conflicts are detected in a CSV-format. (I've loaded that data in an Excel pivot-table and it helped me analyze some of the differences).

Thoughts?