### PR TITLE
SendAsync: Add the ability to cancel the async task

### DIFF
--- a/source/ChromeDevTools/ChromeSessionExtensions.cs
+++ b/source/ChromeDevTools/ChromeSessionExtensions.cs
@@ -1,0 +1,18 @@
+﻿using System.Threading;
+using System.Threading.Tasks;
+
+namespace MasterDevs.ChromeDevTools
+{
+    public static class ChromeSessionExtensions
+    {
+        public static Task<ICommandResponse> SendAsync<T>(this IChromeSession session, T parameter)
+        {
+            return session.SendAsync<T>(parameter, CancellationToken.None);
+        }
+
+        public static Task<ICommandResponse> SendAsync<T>(this IChromeSession session)
+        {
+            return session.SendAsync<T>(CancellationToken.None);
+        }
+    }
+}

--- a/source/ChromeDevTools/IChromeSession.cs
+++ b/source/ChromeDevTools/IChromeSession.cs
@@ -1,13 +1,14 @@
 ﻿using System;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace MasterDevs.ChromeDevTools
 {
     public interface IChromeSession
     {
-        Task<ICommandResponse> SendAsync<T>(T parameter);
+        Task<ICommandResponse> SendAsync<T>(T parameter, CancellationToken cancellationToken);
 
-        Task<ICommandResponse> SendAsync<T>();
+        Task<ICommandResponse> SendAsync<T>(CancellationToken cancellationToken);
 
         void Subscribe<T>(Action<T> handler) where T : class;
     }

--- a/source/ChromeDevTools/MasterDevs.ChromeDevTools.csproj
+++ b/source/ChromeDevTools/MasterDevs.ChromeDevTools.csproj
@@ -50,6 +50,7 @@
     <Compile Include="ChromeProcessFactory.cs" />
     <Compile Include="ChromeProcess.cs" />
     <Compile Include="ChromeSession.cs" />
+    <Compile Include="ChromeSessionExtensions.cs" />
     <Compile Include="ChromeSessionFactory.cs" />
     <Compile Include="Command.cs" />
     <Compile Include="CommandAttribute.cs" />


### PR DESCRIPTION
Adds a `CancellationToken` parameter to the `ChromeSession.Task<ICommandResponse> SendAsync<T>` and related methods. An extension method was also added which does not require you to specify a `CancellationToken` and passes `CancellationToken.None`, for backward compatibility.

The `ChromeSession` class was also changed to use a `ManualResetEventSlim` instead of `ManualResetEvent` object, because `ManualResetEventSlim` allows for waits to be cancelled.

Hope it helps!