### PR TITLE
Add support for .NET Core

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -63,7 +63,7 @@ nuget:
 before_build:
 - nuget restore source\MasterDevs.ChromeDevTools.sln
 - dotnet restore source\ChromeDevTools\project.json
-- dotnet pack source\ChromeDevTools\project.json
+- dotnet pack source\ChromeDevTools\project.json --version-suffix r%APPVEYOR_BUILD_NUMBER%
 build:
   project: source\MasterDevs.ChromeDevTools.sln
   publish_nuget: true
@@ -71,6 +71,7 @@ build:
   verbosity: minimal
 artifacts:
 - path: '*.nupkg'
+- path: 'source\ChromeDevTools\bin\Debug\*.nupkg'
 deploy:
 - provider: GitHub
   auth_token:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -62,6 +62,8 @@ nuget:
   project_feed: true
 before_build:
 - nuget restore source\MasterDevs.ChromeDevTools.sln
+- dotnet restore source\ChromeDevTools\project.json
+- dotnet pack source\ChromeDevTools\project.json
 build:
   project: source\MasterDevs.ChromeDevTools.sln
   publish_nuget: true

--- a/source/ChromeDevTools/ChromeProcess.cs
+++ b/source/ChromeDevTools/ChromeProcess.cs
@@ -5,6 +5,7 @@ using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Net;
+using System.Net.Http;
 using System.Threading;
 using System.Threading.Tasks;
 
@@ -35,10 +36,10 @@ namespace MasterDevs.ChromeDevTools
         public async Task<string[]> GetSessions()
         {
             var remoteSessionUrls = new List<string>();
-            var webClient = new WebClient();
+            var webClient = new HttpClient();
             var uriBuilder = new UriBuilder(RemoteDebuggingUri);
             uriBuilder.Path = "/json";
-            var remoteSessions = await webClient.DownloadStringTaskAsync(uriBuilder.Uri);
+            var remoteSessions = await webClient.GetStringAsync(uriBuilder.Uri);
             using (var stringReader = new StringReader(remoteSessions))
             using (var jsonReader = new JsonTextReader(stringReader))
             {

--- a/source/ChromeDevTools/ChromeSession.cs
+++ b/source/ChromeDevTools/ChromeSession.cs
@@ -1,4 +1,5 @@
-﻿using MasterDevs.ChromeDevTools.Serialization;
+﻿#if !NETSTANDARD1_5
+using MasterDevs.ChromeDevTools.Serialization;
 using Newtonsoft.Json;
 using System;
 using System.Collections.Concurrent;
@@ -251,3 +252,4 @@ namespace MasterDevs.ChromeDevTools
         }
     }
 }
+#endif

--- a/source/ChromeDevTools/ChromeSessionFactory.cs
+++ b/source/ChromeDevTools/ChromeSessionFactory.cs
@@ -1,4 +1,5 @@
-﻿namespace MasterDevs.ChromeDevTools
+﻿#if !NETSTANDARD1_5
+namespace MasterDevs.ChromeDevTools
 {
     public class ChromeSessionFactory : IChromeSessionFactory
     {
@@ -15,3 +16,4 @@
         }
     }
 }
+#endif

--- a/source/ChromeDevTools/CommandResponse.cs
+++ b/source/ChromeDevTools/CommandResponse.cs
@@ -24,6 +24,15 @@
 
     public class CommandResponse<T> : CommandResponse
     {
+        public CommandResponse()
+        {
+        }
+
+        public CommandResponse(T result)
+        {
+            this.Result = result;
+        }
+
         public T Result
         {
             get;

--- a/source/ChromeDevTools/Extensions/ObjectExtensions.cs
+++ b/source/ChromeDevTools/Extensions/ObjectExtensions.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Linq;
+using System.Reflection;
 
 namespace MasterDevs.ChromeDevTools
 {
@@ -14,18 +15,18 @@ namespace MasterDevs.ChromeDevTools
         public static string GetMethod(this Type type)
         {
             if (null == type) return null;
-            var eventAttribute = type.GetCustomAttributes(typeof(EventAttribute), true)
+            var eventAttribute = type.GetTypeInfo().GetCustomAttributes(typeof(EventAttribute), true)
                 .FirstOrDefault() as EventAttribute;
             if (null != eventAttribute) return eventAttribute.MethodName;
-            var commandAttribute = type.GetCustomAttributes(typeof(CommandAttribute), true)
+            var commandAttribute = type.GetTypeInfo().GetCustomAttributes(typeof(CommandAttribute), true)
                 .FirstOrDefault() as CommandAttribute;
             if (null != commandAttribute) return commandAttribute.MethodName;
-            var commandResponseAttribute = type.GetCustomAttributes(typeof(CommandResponseAttribute), true)
+            var commandResponseAttribute = type.GetTypeInfo().GetCustomAttributes(typeof(CommandResponseAttribute), true)
                 .FirstOrDefault() as CommandResponseAttribute;
             if (null != commandResponseAttribute) return commandResponseAttribute.MethodName;
 
             // maybe it's generic parameter has a method
-            if (type.IsGenericType)
+            if (type.GetTypeInfo().IsGenericType)
             {
                 return type.GenericTypeArguments
                     .FirstOrDefault()

--- a/source/ChromeDevTools/MasterDevs.ChromeDevTools.csproj
+++ b/source/ChromeDevTools/MasterDevs.ChromeDevTools.csproj
@@ -43,6 +43,9 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.Net.Http">
+      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.5\System.Net.Http.dll</HintPath>
+    </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
     <Reference Include="Microsoft.CSharp" />

--- a/source/ChromeDevTools/MasterDevs.ChromeDevTools.project.json
+++ b/source/ChromeDevTools/MasterDevs.ChromeDevTools.project.json
@@ -1,0 +1,8 @@
+{
+  "frameworks": {
+    "net45": {}
+  },
+  "runtimes": {
+    "win": {}
+  }
+}

--- a/source/ChromeDevTools/MethodTypeMap.cs
+++ b/source/ChromeDevTools/MethodTypeMap.cs
@@ -23,11 +23,11 @@ namespace MasterDevs.ChromeDevTools
 
         private void LoadMethodTypeMap(string alias)
         {
-            var assembly = Assembly.GetExecutingAssembly();
+            var assembly = typeof(MethodTypeMap).GetTypeInfo().Assembly;
             var assemblyTypes = assembly.GetTypes();
             foreach (var type in assemblyTypes)
             {
-                if (!type.IsClass) continue;
+                if (!type.GetTypeInfo().IsClass) continue;
 
                 if (!type.Namespace.StartsWith($"MasterDevs.ChromeDevTools.Protocol.{alias}")) continue;
 
@@ -54,7 +54,7 @@ namespace MasterDevs.ChromeDevTools
 
         private string GetMethodName<T>(Type type) where T : IMethodNameAttribute
         {
-            var attribute = type.GetCustomAttributes(typeof(T))
+            var attribute = type.GetTypeInfo().GetCustomAttributes(typeof(T))
                 .FirstOrDefault();
             if (null == attribute) return null;
             var methodNameAttribute = attribute as IMethodNameAttribute;

--- a/source/ChromeDevTools/project.json
+++ b/source/ChromeDevTools/project.json
@@ -1,0 +1,36 @@
+{
+  "version": "1.0.3-*",
+  "description": "Contains the classes and utilities used to interact with the Chrome Developer Tools",
+  "authors": [ "MasterDevs" ],
+  "packOptions": {
+    "projectUrl": "https://github.com/MasterDevs/ChromeDevTools",
+    "licenseUrl": "https://github.com/MasterDevs/ChromeDevTools/blob/master/LICENSE",
+    "iconUrl": "http://masterdevs.com/images/FavIcon_144.png"
+  },
+  "buildOptions": {},
+  "dependencies": {
+    "Newtonsoft.Json": "9.0.1"
+  },
+  "frameworks": {
+    "netstandard15": {
+      "dependencies": {
+        "System.Reflection": "4.1.0",
+        "System.Runtime": "4.1.0",
+        "System.Collections.Concurrent": "4.0.12",
+        "System.IO.FileSystem": "4.0.1",
+        "System.Diagnostics.Process": "4.1.0",
+        "System.Runtime.InteropServices": "4.1.0",
+        "System.Net.Http": "4.1.0",
+        "System.Threading.Thread": "4.0.0"
+      }
+    },
+    "net45": {
+      "dependencies": {
+        "WebSocket4Net": "0.14.1"
+      },
+      "frameworkAssemblies": {
+        "System.Net.Http": "4.0.0.0"
+      }
+    }
+  }
+}

--- a/source/Sample/Program.cs
+++ b/source/Sample/Program.cs
@@ -1,4 +1,4 @@
-﻿using MasterDevs.ChromeDevTools.Protocol.Page;
+﻿using MasterDevs.ChromeDevTools.Protocol.Chrome.Page;
 using System;
 using System.Linq;
 
@@ -31,14 +31,14 @@ namespace MasterDevs.ChromeDevTools.Sample
                 // STEP 4 - Register for events (in this case, "Page" domain events)
                 // send an event to tell chrome to send us all Page events
                 // but we only subscribe to certain events in this session
-                var pageEnableResult = chromeSession.SendAsync<ChromeDevTools.Protocol.Page.EnableCommand>().Result;
+                var pageEnableResult = chromeSession.SendAsync<ChromeDevTools.Protocol.Chrome.Page.EnableCommand>().Result;
                 Console.WriteLine("PageEnable: " + pageEnableResult.Id);
-                chromeSession.Subscribe<Protocol.Page.DomContentEventFiredEvent>(domContentEvent =>
+                chromeSession.Subscribe<Protocol.Chrome.Page.DomContentEventFiredEvent>(domContentEvent =>
                     {
                         Console.WriteLine("DomContentEvent: " + domContentEvent.Timestamp);
                     });
                 // you might never see this, but that's what an event is ... right?
-                chromeSession.Subscribe<Protocol.Page.FrameStartedLoadingEvent>(frameStartedLoadingEvent =>
+                chromeSession.Subscribe<Protocol.Chrome.Page.FrameStartedLoadingEvent>(frameStartedLoadingEvent =>
                     {
                         Console.WriteLine("FrameStartedLoading: " + frameStartedLoadingEvent.FrameId);
                     });


### PR DESCRIPTION
Hi @brewdente 

This PR adds support for compiling and running ChromeDevTools on .NET Core.

There wasn't much that needed to be done; a change from `WebClient` to `HttpClient` and some changes to use the refactored reflection API.

Apart from that, I had to disable the `ChromeSession` and `ChromeSessionFactory` on .NET Core for now, because that uses WebSockets4Net and there isn't a .NET Core version available, yet. I had a look over at their GitHub repository and it seems a .NET Core version is being worked on, so that's a limitation that soon can be lifted.

I've updated the `appveyor.yml` file to also build using the .NET Core toolchain. It creates a single NuGet package targetting .NET 4.5 and .NET Core so I'm guessing that's the one you may want to be publishing to NuGet (would certainly help me!)

Cheers,